### PR TITLE
Add global alerts and custom error pages

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -134,4 +134,5 @@ LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/login'
 
 # Miscellaneous
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend' 
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+CSRF_FAILURE_VIEW = 'cms.views.general.csrf_failure'

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -1,8 +1,14 @@
-from django.conf.urls import include, url
+from django.conf.urls import include, url, handler400, handler403, handler404, handler500
 from django.contrib import admin
+
 
 urlpatterns = [
     url(r'^', include('cms.urls')),
     url(r'^api/', include('api.urls')),
     url(r'^admin/', admin.site.urls),
 ]
+
+handler400 = 'cms.views.general.handler400'
+handler403 = 'cms.views.general.handler403'
+handler404 = 'cms.views.general.handler404'
+handler500 = 'cms.views.general.handler500'

--- a/backend/cms/templates/_base.html
+++ b/backend/cms/templates/_base.html
@@ -137,6 +137,7 @@
 </nav>
 <main class="relative">
     <div class="p-6">
+        {% include "messages.html" %}   
         {% block content %}{% endblock content %}
     </div>
 </main>

--- a/backend/cms/templates/csrf_failure.html
+++ b/backend/cms/templates/csrf_failure.html
@@ -1,0 +1,15 @@
+{% extends "_raw.html" %}
+
+{% block raw_content %}
+<div id="no-session" class="px-4 py-10">
+    <div class="w-full max-w-xs mx-auto">
+        <h1 class="mb-4">CSRF Fehler</h1>
+        <p class="mb-4">
+            Bitte versuchen Sie die Seite neu zu laden.
+        </p>
+        <p>
+            <a href="/" class="text-grey-darker">Zur Startseite</a>
+        </p>
+    </div>
+</div>
+{% endblock %}

--- a/backend/cms/templates/dashboard.html
+++ b/backend/cms/templates/dashboard.html
@@ -1,1 +1,5 @@
 {% extends "_base.html" %}
+
+{% block content %}
+
+{% endblock %}

--- a/backend/cms/templates/http_error.html
+++ b/backend/cms/templates/http_error.html
@@ -1,0 +1,16 @@
+{% extends "_raw.html" %}
+
+{% block raw_content %}
+<div id="no-session" class="px-4 py-10">
+    <div class="w-full max-w-xs mx-auto">
+        <h3 class="mb-2">Error {{code}}</h3>
+        <h1 class="mb-4">{{title}}</h1>
+        <p class="mb-4">
+            {{message}}
+        </p>
+        <p>
+            <a href="/" class="text-grey-darker">Zur Startseite</a>
+        </p>
+    </div>
+</div>
+{% endblock %}

--- a/backend/cms/templates/messages.html
+++ b/backend/cms/templates/messages.html
@@ -1,0 +1,26 @@
+{% if messages %}
+<div class="mb-8">
+    {% for msg in messages %}
+        {% if msg.level_tag == 'info' %}
+        <div class="bg-blue-lightest border-l-4 border-blue text-blue-dark px-4 py-3 mb-5" role="alert">
+                <p>{{msg.message}}</p>
+            </div>
+        {% endif %}
+        {% if msg.level_tag == 'success' %}
+            <div class="bg-green-lightest border-l-4 border-green text-green-dark px-4 py-3 mb-5" role="alert">
+                <p>{{msg.message}}</p>
+            </div>
+        {% endif %}
+        {% if msg.level_tag == 'warning' %}
+            <div class="bg-orange-lightest border-l-4 border-orange text-orange-dark px-4 py-3 mb-5" role="alert">
+                <p>{{msg.message}}</p>
+            </div>
+        {% endif %}
+        {% if msg.level_tag == 'error' %}
+            <div class="bg-red-lightest border-l-4 border-red text-red-dark px-4 py-3 mb-5" role="alert">
+                <p>{{msg.message}}</p>
+            </div>
+        {% endif %}
+    {% endfor %}
+</div>
+{% endif %}

--- a/backend/cms/templates/registration/login.html
+++ b/backend/cms/templates/registration/login.html
@@ -17,21 +17,10 @@
                     <p>Der Benutzername oder das Passwort ist falsch. Bitte versuchen Sie es erneut.</p>
                 </div>
                 {% endif %}
-                {% if messages %}
-                    {% for msg in messages %}
-                        {% if msg.level_tag == 'info' %}
-                            <div class="bg-blue-lightest border-l-4 border-blue text-blue-dark px-4 py-3 mb-5" role="alert">
-                                <p>{{msg.message}}</p>
-                            </div>
-                        {% endif %}
-                        {% if msg.level_tag == 'success' %}
-                            <div class="bg-green-lightest border-l-4 border-green text-green-dark px-4 py-3 mb-5" role="alert">
-                                <p>{{msg.message}}</p>
-                            </div>
-                        {% endif %}
-                    {% endfor %}
-                {% endif %}
-                <div class="mb-4">
+                <div class="mb-3">
+                    {% include "messages.html" %}
+                </div>
+                <div class="-mt-3 mb-4">
                     <label class="block text-grey-darker text-sm font-bold mb-2" for="username">
                         Benutzername
                     </label>

--- a/backend/cms/templates/registration/password_reset_confirm.html
+++ b/backend/cms/templates/registration/password_reset_confirm.html
@@ -1,7 +1,6 @@
 {% extends "_raw.html" %}
 
 {% block raw_content %}
-{% load static %}
 <div id="no-session" class="flex flex-wrap flex-col justify-center px-3 py-10">
     <div class="mx-auto w-full max-w-xs">
         <div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">

--- a/backend/cms/templates/registration/password_reset_form.html
+++ b/backend/cms/templates/registration/password_reset_form.html
@@ -1,7 +1,6 @@
 {% extends "_raw.html" %}
 
 {% block raw_content %}
-{% load static %}
 <div id="no-session" class="flex flex-wrap flex-col justify-center px-3 py-10">
     <div class="mx-auto w-full max-w-xs">
         <div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">

--- a/backend/cms/views/general.py
+++ b/backend/cms/views/general.py
@@ -1,7 +1,34 @@
-from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
+from django.shortcuts import render
 
 
 @login_required
 def index(request):
     return render(request, 'dashboard.html')
+
+def handler400(request):
+    ctx = {'code': 400, 'title': 'Bad request', 'message': 'Die Anfrage war fehlerhaft aufgebaut.'}
+    response = render(request, 'http_error.html', ctx)
+    response.status_code = 400
+    return response
+
+def handler403(request):
+    ctx = {'code': 403, 'title': 'Forbidden', 'message': 'In der Anfrage wurde nicht die notwendige Berechtigung übermittelt.'}
+    response = render(request, 'http_error.html', ctx)
+    response.status_code = 403
+    return response
+
+def handler404(request):
+    ctx = {'code': 404, 'title': 'Seite nicht gefunden', 'message': 'Die von Ihnen angeforderte Seite konnte leider nicht gefunden werden.'}
+    response = render(request, 'http_error.html', ctx)
+    response.status_code = 404
+    return response
+
+def handler500(request):
+    ctx = {'code': 500, 'title': 'Internal Server Error', 'message': 'Es ist ein unerwarteter Fehler aufgetreten.'}
+    response = render(request, 'http_error.html', ctx)
+    response.status_code = 500
+    return response
+
+def csrf_failure(request):
+    return render(request, 'csrf_failure.html')


### PR DESCRIPTION
[Django messages](https://docs.djangoproject.com/en/1.11/ref/contrib/messages/) can now be used on all pages that extend the _base template. The normal error pages for HTTP status codes and csrf errors are replaced.