### PR TITLE
Implement API for feedback about a single page

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import include, url
 
+from .v3.feedback import feedback
 from .v3.languages import languages
 from .v3.sites import sites, livesites, hiddenites, pushnew
 from .v3.push_notifications import sent_push_notifications
@@ -12,5 +13,6 @@ urlpatterns = [
     url(r'(?P<site_slug>[-\w]+)/', include([
         url(r'languages$', languages),
         url(r'(?P<lan_code>[-\w]+)/sent_push_notifications/$', sent_push_notifications),
+        url(r'(?P<languages>[-\w]+)/feedback/$', feedback),
     ])),
 ]

--- a/backend/api/v3/feedback.py
+++ b/backend/api/v3/feedback.py
@@ -3,8 +3,6 @@ from django.http import HttpResponse
 
 from cms.models import Page, PageFeedback, PageTranslation
 
-from django.views.decorators.csrf import csrf_exempt
-
 
 class FeedbackData:
     def __init__(self, page_id, permalink, comment, emotion):
@@ -36,7 +34,6 @@ class FeedbackData:
     def __is_either_exist(self, one, two):
         return one or two
 
-@csrf_exempt
 def feedback(req, site_slug, languages):
     if req.method != 'POST':
         return HttpResponse(f'Invalid request method.', status=405)

--- a/backend/api/v3/feedback.py
+++ b/backend/api/v3/feedback.py
@@ -1,0 +1,65 @@
+import json
+from django.http import HttpResponse
+
+from cms.models import Page, PageFeedback, PageTranslation
+
+from django.views.decorators.csrf import csrf_exempt
+
+
+class FeedbackData:
+    def __init__(self, page_id, permalink, comment, emotion):
+        self.page_id = page_id
+        self.permalink = permalink
+        self.comment = comment
+        self.emotion = emotion
+
+    def from_dict(dict):
+        return FeedbackData(
+            dict.get('id', None),
+            dict.get('permalink', None),
+            dict.get('comment', None),
+            dict.get('emotion', None)
+        )
+
+    def has_id(self):
+        return self.__is_either_exist(self.page_id, self.permalink)
+
+    def has_content(self):
+        return self.__is_either_exist(self.comment, self.emotion)
+
+    def get_comment(self):
+        return self.comment if self.comment else ''
+
+    def get_emotion(self):
+        return self.emotion if self.emotion else "NA"
+
+    def __is_either_exist(self, one, two):
+        return one or two
+
+@csrf_exempt
+def feedback(req, site_slug, languages):
+    if req.method != 'POST':
+        return HttpResponse(f'Invalid request method.', status=405)
+
+    data = json.loads(req.body)
+    feedback_data = FeedbackData.from_dict(data)
+
+    if not feedback_data.has_id():
+        return HttpResponse(f'No page found for site "{site_slug}" with permalink "{feedback_data.permalink}".',
+                            content_type='text/plain', status=404)
+
+    if not feedback_data.has_content():
+        return HttpResponse("Please enter a valid rating/comment.", content_type='text/plain', status=400)
+
+    page = Page.objects.get(id=feedback_data.page_id)
+    if not page:
+        page_translation = PageTranslation.objects.get(permalink=feedback_data.permalink)
+        page = page_translation.page
+
+    try:
+        page_feedback = PageFeedback(page=page, emotion=feedback_data.get_emotion(),
+                                     comment=feedback_data.get_comment())
+        page_feedback.save()
+        return HttpResponse(status=200)
+    except ValueError:
+        return HttpResponse("Bad request.", content_type='text/plain', status=400)

--- a/backend/cms/models/feedback.py
+++ b/backend/cms/models/feedback.py
@@ -8,7 +8,8 @@ from cms.models.event import Event
 class Feedback(models.Model):
     EMOTION = (
         ("Pos", "Positive"),
-        ("Neg", "Negative")
+        ("Neg", "Negative"),
+        ("NA", "Not Available"),
     )
     emotion = models.CharField(max_length=3, choices=EMOTION)
     comment = models.CharField(max_length=1000)


### PR DESCRIPTION
There is some discrepancy between the API documentation and the current Feedback model. In the documentation, the field "Rating" is used, but in the database model, the field "Emotion" is used. Since the documentation is probably easier to change, I have used "Emotion" in the implementation here instead.

This code may be extended in future so that the api implementation for feedback for extras/events can also be built upon the same functions/class.