### PR TITLE
Page instance permissions

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -99,6 +99,11 @@ DATABASES = {
     }
 }
 
+# Directory for initial database contents
+
+FIXTURE_DIRS = (
+    os.path.join(BASE_DIR, 'cms/fixtures/'),
+)
 
 # Authentication backends
 

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     'drf_yasg',
     'mptt',
     'rest_framework',
+    'rules.apps.AutodiscoverRulesConfig',
 ]
 
 MIDDLEWARE = [
@@ -97,6 +98,14 @@ DATABASES = {
         'PORT': '5432',
     }
 }
+
+
+# Authentication backends
+
+AUTHENTICATION_BACKENDS = (
+    'rules.permissions.ObjectPermissionBackend',
+    'django.contrib.auth.backends.ModelBackend', # this is default
+)
 
 
 # Password validation
@@ -191,6 +200,11 @@ LOGGING = {
         'cms': {
             'handlers': ['console'],
             'level': 'INFO',
+            'propagate': True,
+        },
+        'rules': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
             'propagate': True,
         },
     }

--- a/backend/cms/fixtures/roles.json
+++ b/backend/cms/fixtures/roles.json
@@ -1,0 +1,1 @@
+[{"model": "auth.group", "pk": 1, "fields": {"name": "Verwaltung", "permissions": [51, 3, 4, 2, 7, 9, 10, 12, 14, 13, 11, 15, 17, 18, 16, 19, 20, 21]}}, {"model": "auth.group", "pk": 2, "fields": {"name": "Redakteur", "permissions": [12, 14, 13, 11]}}, {"model": "auth.group", "pk": 3, "fields": {"name": "Terminplaner", "permissions": [3, 4, 2, 19, 20, 21]}}]

--- a/backend/cms/locale/de/LC_MESSAGES/django.po
+++ b/backend/cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-06-05 00:28+0200\n"
+"POT-Creation-Date: 2019-06-12 05:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Timo Ludwig <ludwig@integreat-app.de>\n"
 "Language-Team:\n"
@@ -25,147 +25,189 @@ msgstr "Links nach Rechts"
 msgid "Right to left"
 msgstr "Rechts nach Links"
 
-#: models/page.py:125
+#: models/page.py:150
 msgid "Draft"
 msgstr "Entwurf"
 
-#: models/page.py:126
+#: models/page.py:151
 msgid "Pending Review"
 msgstr "Review ausstehend"
 
-#: models/page.py:127
+#: models/page.py:152
 msgid "Finished Review"
 msgstr "Review abgeschlossen"
 
-#: models/site.py:19 templates/language_tree/tree.html:31
+#: models/site.py:20 templates/language_tree/tree.html:31
+#: templates/users/admin/list.html:28 templates/users/admin/user.html:82
+#: templates/users/region/list.html:28 templates/users/region/user.html:73
 msgid "Active"
 msgstr "Aktiv"
 
-
-#: models/site.py:20
+#: models/site.py:21
 msgid "Hidden"
 msgstr "Versteckt"
 
-#: models/site.py:21
+#: models/site.py:22
 msgid "Archived"
 msgstr "Archiviert"
 
 #: templates/_base.html:11 templates/language_tree/tree.html:15
-#: templates/languages/list.html:9 templates/pages/archive.html:13
+#: templates/languages/list.html:9 templates/media/medialist.html:8
+#: templates/organizations/list.html:9 templates/pages/archive.html:13
 #: templates/pages/tree.html:26 templates/push_notifications/list.html:9
-#: templates/regions/list.html:9 templates/media/medialist.html:9
+#: templates/regions/list.html:9 templates/roles/list.html:9
+#: templates/users/admin/list.html:9 templates/users/region/list.html:9
 msgid "Search"
 msgstr "Suchen"
 
-#: templates/_base.html:28 templates/_base.html:40
+#: templates/_base.html:28 templates/_base.html:43
 msgid "Network Management"
 msgstr "Netzwerkverwaltung"
 
-#: templates/_base.html:82
+#: templates/_base.html:86
 msgid "Help"
 msgstr "Hilfe"
 
-#: templates/_base.html:86
+#: templates/_base.html:90
 msgid "Author Chat"
 msgstr "Autorenchat"
 
-#: templates/_base.html:90
+#: templates/_base.html:94
 msgid "Django Administration"
 msgstr "Django Administration"
 
-#: templates/_base.html:94
+#: templates/_base.html:98
 msgid "Log out"
 msgstr "Abmelden"
 
-#: templates/_base.html:101 templates/registration/login.html:10
+#: templates/_base.html:105 templates/registration/login.html:10
 msgid "Integreat Logo"
 msgstr "Integreat Logo"
 
-#: templates/_base.html:107
+#: templates/_base.html:111
 msgid "My Dashboard"
 msgstr "Mein Dashboard"
 
-#: templates/_base.html:111 templates/regions/region.html:111
+#: templates/_base.html:115
+msgid "Translation Report"
+msgstr "Übersetzungs-Bericht"
+
+#: templates/_base.html:119 templates/analytics/translation_coverage.html:7
+#: templates/regions/region.html:111
 #: templates/statistics/statistics_dashboard.html:7
 msgid "Statistics"
 msgstr "Statistiken"
 
-#: templates/_base.html:119 templates/pages/tree.html:10
+#: templates/_base.html:123
+msgid "Media Library"
+msgstr "Medienbibliothek"
+
+#: templates/_base.html:127 templates/pages/tree.html:10
 msgid "Pages"
 msgstr "Seiten"
 
-#: templates/_base.html:123 templates/regions/region.html:91
+#: templates/_base.html:131 templates/regions/region.html:91
 msgid "Events"
 msgstr "Veranstaltungen"
 
-#: templates/_base.html:127 templates/_base.html:168
-msgid "User"
+#: templates/_base.html:135 templates/_base.html:176
+msgid "Users"
 msgstr "Benutzer"
 
-#: templates/_base.html:131 templates/_base.html:172
+#: templates/_base.html:139 templates/_base.html:188
 msgid "Feedback"
 msgstr "Feedback"
 
-#: templates/_base.html:135 templates/regions/region.html:98
+#: templates/_base.html:143 templates/regions/region.html:98
 msgid "Push Notifications"
 msgstr "Push-Benachrichtigungen"
 
-#: templates/_base.html:139
+#: templates/_base.html:147
 msgid "PDF Export"
 msgstr "PDF Export"
 
-#: templates/_base.html:143
+#: templates/_base.html:151
 msgid "Imprint"
 msgstr "Impressum"
 
-#: templates/_base.html:147 templates/language_tree/tree.html:9
+#: templates/_base.html:155 templates/language_tree/tree.html:9
 msgid "Language tree"
 msgstr "Sprach-Baum"
 
-#: templates/_base.html:151 templates/_base.html:176
+#: templates/_base.html:159 templates/_base.html:192
 #: templates/statistics/statistics_dashboard.html:59
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: templates/_base.html:156
+#: templates/_base.html:164
 msgid "Admin Dashboard"
 msgstr "Admin Dashboard"
 
-#: templates/_base.html:160
+#: templates/_base.html:168 templates/users/admin/user.html:91
 msgid "Regions"
 msgstr "Regionen"
 
-#: templates/_base.html:164
+#: templates/_base.html:172
 msgid "Languages"
 msgstr "Sprachen"
+
+#: templates/_base.html:180 templates/users/admin/user.html:86
+#: templates/users/region/user.html:77
+msgid "Roles"
+msgstr "Rollen"
+
+#: templates/_base.html:184
+msgid "Organizations"
+msgstr "Organisationen"
 
 #: templates/_raw.html:9
 msgid "Integreat Backend"
 msgstr "Integreat CMS"
+
+#: templates/analytics/translation_coverage.html:13
+msgid "Translation Coverage"
+msgstr "Abdeckung der Übersetzungen"
 
 #: templates/general/admin_settings.html:9
 msgid "Admin Settings"
 msgstr "Administrator-Einstellungen"
 
 #: templates/general/confirmation_popups/archive_page.html:4
-#: templates/pages/tree_row.html:44
+#: templates/pages/tree_row.html:63
 msgid "Please confirm that you really want to archive this page"
 msgstr "Bitte bestätigen Sie, dass diese Seite archiviert werden soll."
 
 #: templates/general/confirmation_popups/archive_page.html:6
-#: templates/pages/tree_row.html:46
+#: templates/pages/tree_row.html:65
 msgid "All translations of this page will also be archived."
 msgstr "Es werden auch alle Übersetzungen dieser Seite archiviert."
 
 #: templates/general/confirmation_popups/archive_page.html:8
-#: templates/pages/tree_row.html:50
+#: templates/pages/tree_row.html:69
 msgid "Yes, archive this page now."
 msgstr "Ja, diese Seite jetzt archivieren"
 
 #: templates/general/confirmation_popups/archive_page.html:10
-#: templates/pages/archive.html:53 templates/pages/tree_row.html:52
+#: templates/general/confirmation_popups/delete_region_user.html:12
+#: templates/general/confirmation_popups/delete_user.html:12
+#: templates/pages/archive.html:53 templates/pages/tree_row.html:71
 msgid "Cancel"
 msgstr "Abbrechen"
+
+#: templates/general/confirmation_popups/delete_region_user.html:4
+#: templates/general/confirmation_popups/delete_user.html:4
+msgid "Please confirm that you really want to delete this user"
+msgstr "Bitte bestätigen Sie, dass dieser Benutzer gelöscht werden soll"
+
+#: templates/general/confirmation_popups/delete_region_user.html:6
+#: templates/general/confirmation_popups/delete_user.html:6
+msgid "This cannot be reversed."
+msgstr "Dies kann nicht rückgängig gemacht werden."
+
+#: templates/general/confirmation_popups/delete_region_user.html:9
+#: templates/general/confirmation_popups/delete_user.html:9
+msgid "Yes, delete this user now"
+msgstr "Ja, diesen Benutzer jetzt löschen"
 
 #: templates/general/csrf_failure.html:6
 msgid "CSRF Error"
@@ -192,7 +234,7 @@ msgid "Create language tree node"
 msgstr "Sprach-Knoten hinzufügen"
 
 #: templates/language_tree/tree.html:30
-#: templates/language_tree/tree_node.html:28 templates/pages/page.html:64
+#: templates/language_tree/tree_node.html:28 templates/pages/page.html:96
 #: templates/push_notifications/push_notification.html:62
 msgid "Language"
 msgstr "Sprache"
@@ -210,9 +252,12 @@ msgid "Add language"
 msgstr "Sprache hinzufügen"
 
 #: templates/language_tree/tree_node.html:19
-#: templates/languages/language.html:19 templates/pages/page.html:25
+#: templates/languages/language.html:19
+#: templates/organizations/organization.html:21 templates/pages/page.html:29
+#: templates/pages/sbs_page.html:38
 #: templates/push_notifications/push_notification.html:26
-#: templates/regions/region.html:21
+#: templates/regions/region.html:21 templates/roles/role.html:21
+#: templates/users/admin/user.html:21 templates/users/region/user.html:21
 msgid "Save"
 msgstr "Speichern"
 
@@ -233,13 +278,15 @@ msgstr "Sprache %(form.name.initial)s bearbeiten"
 msgid "Create new language"
 msgstr "Neue Sprache erstellen"
 
-#: templates/languages/language.html:20 templates/pages/page.html:27
+#: templates/languages/language.html:20
+#: templates/organizations/organization.html:22 templates/pages/page.html:33
 #: templates/regions/region.html:22
 msgid "Publish"
 msgstr "Veröffentlichen"
 
 #: templates/languages/language.html:28 templates/languages/list.html:23
-#: templates/regions/list.html:23 template/media/medialist.html:23
+#: templates/media/medialist.html:22 templates/organizations/list.html:23
+#: templates/regions/list.html:23 templates/roles/list.html:23
 msgid "Name"
 msgstr "Name"
 
@@ -267,11 +314,13 @@ msgstr "Schreibrichtung auswählen"
 msgid "Create language"
 msgstr "Sprache hinzufügen"
 
-#: templates/languages/list.html:26 templates/regions/list.html:26
+#: templates/languages/list.html:26 templates/pages/tree.html:69
+#: templates/regions/list.html:26
 msgid "Created"
 msgstr "Erstellt"
 
-#: templates/languages/list.html:27 templates/regions/list.html:27
+#: templates/languages/list.html:27 templates/pages/tree.html:68
+#: templates/regions/list.html:27
 msgid "Last updated"
 msgstr "Zuletzt aktualisiert"
 
@@ -279,29 +328,138 @@ msgstr "Zuletzt aktualisiert"
 msgid "No languages available yet."
 msgstr "Noch keine Sprachen vorhanden."
 
+#: templates/media/mediaedit.html:12
+msgid "Submit"
+msgstr "Absenden"
+
+#: templates/media/mediaedit.html:15
+msgid "Return"
+msgstr "Zurück"
+
+#: templates/media/medialist.html:12
+msgid "Upload File"
+msgstr "Datei hochladen"
+
+#: templates/media/medialist.html:23
+msgid "Date"
+msgstr "Datum"
+
+#: templates/media/medialist.html:24 templates/pages/archive.html:22
+msgid "Operations"
+msgstr "Optionenen"
+
+#: templates/organizations/list.html:13
+msgid "Create organization"
+msgstr "Organisation erstellen"
+
+#: templates/organizations/list.html:24
+msgid "Slug"
+msgstr "URL-Parameter"
+
+#: templates/organizations/list.html:25
+msgid "Thumbnail"
+msgstr "Vorschaubild"
+
+#: templates/organizations/list.html:34
+msgid "No organizations available yet."
+msgstr "Noch keine Organisationen vorhanden."
+
+#: templates/organizations/organization.html:13
+#, python-format
+msgid "Edit organization \"%(organization_name)s\""
+msgstr "Organisation \"%(organization_name)s\" bearbeiten"
+
+#: templates/organizations/organization.html:16
+msgid "Create new organization"
+msgstr "Neue Organisation erstellen"
+
+#: templates/organizations/organization.html:31
+#: templates/regions/region.html:31 templates/users/admin/user.html:31
+#: templates/users/region/user.html:31
+msgid "General Settings"
+msgstr "Allgemeine Einstellungen"
+
+#: templates/organizations/organization.html:36
+msgid "Organizationname"
+msgstr "Organisationsname"
+
+#: templates/organizations/organization.html:37
+msgid "Enter the organization's name here"
+msgstr "Name der Organisation hier eingeben"
+
+#: templates/organizations/organization.html:40
+msgid "Slug of the organization"
+msgstr "Slug der Organisation"
+
+#: templates/organizations/organization.html:41
+msgid "Enter the organization's slug here"
+msgstr "URL-Parameter der Organisation hier eingeben"
+
+#: templates/organizations/organization.html:44
+msgid "Thumbnail of the organization"
+msgstr "Thumbnail der Organisation"
+
+#: templates/organizations/organization.html:45
+msgid "Enter the organization's thumbnail here"
+msgstr "Name der Organisations-Thumbnail hier eingeben"
+
+#: templates/organizations/organization.html:54
+#: templates/regions/region.html:87 templates/users/admin/user.html:67
+#: templates/users/region/user.html:67
+msgid "Extended Settings"
+msgstr "Erweiterte Einstellungen"
+
+#: templates/organizations/organization.html:66 templates/pages/page.html:185
+#: templates/regions/region.html:67
+msgid "Set icon"
+msgstr "Icon festlegen"
+
+#: templates/pages/_page_permission_table.html:29
+msgid "Editors"
+msgstr "Bearbeiter"
+
+#: templates/pages/_page_permission_table.html:31
+msgid "These users can edit this page, but are not allowed to publish it."
+msgstr ""
+"Diese Benutzer können die Seite bearbeiten, aber nicht veröffentlichen."
+
+#: templates/pages/_page_permission_table.html:48
+#: templates/pages/_page_permission_table.html:83
+#: templates/registration/login.html:26 templates/registration/login.html:28
+#: templates/users/admin/list.html:23 templates/users/admin/user.html:36
+#: templates/users/region/list.html:23 templates/users/region/user.html:36
+msgid "Username"
+msgstr "Benutzername"
+
+#: templates/pages/_page_permission_table.html:57
+msgid "Add to editors"
+msgstr "Zu Bearbeitern hinzufügen"
+
+#: templates/pages/_page_permission_table.html:64
+msgid "Publishers"
+msgstr "Veröffentlicher"
+
+#: templates/pages/_page_permission_table.html:66
+msgid "These users can edit and publish this page."
+msgstr "Diese Benutzer können die Seite bearbeiten und veröffentlichen"
+
+#: templates/pages/_page_permission_table.html:92
+msgid "Add to publishers"
+msgstr "Erlaubnis zum Veröffentlichen erteilen"
+
 #: templates/pages/archive.html:8
-#, fuzzy
-#| msgid "Archived pages"
 msgid "Archived Pages"
 msgstr "Archivierte Seiten"
 
-#: templates/pages/archive.html:21 templates/pages/tree.html:43
-#: templates/push_notifications/list.html:24
+#: templates/pages/archive.html:21 templates/pages/page.html:43
+#: templates/pages/tree.html:57 templates/push_notifications/list.html:24
 #: templates/push_notifications/push_notification.html:49
 msgid "Title"
 msgstr "Titel"
 
-#: templates/pages/archive.html:22 teamplate/media/medialist.html:25
-#, fuzzy
-#| msgid "Options"
-msgid "Operations"
-msgstr "Optionen"
-
 #: templates/pages/archive.html:33
-#, fuzzy
-#| msgid "Related page"
 msgid "Restore page"
-msgstr "Verwandte Seite"
+msgstr "Seite wiederherstellen"
 
 #: templates/pages/archive.html:38
 msgid "Restore"
@@ -319,137 +477,178 @@ msgstr "Alle Übersetzungen dieser Seite werden wiederhergestellt."
 msgid "Yes, restore this page now."
 msgstr "Ja, die Seite wiederherstellen."
 
-#: templates/pages/archive.html:65 templates/pages/tree.html:68
+#: templates/pages/archive.html:65 templates/pages/tree.html:85
 msgid "No pages available yet."
 msgstr "Noch keine Seiten vorhanden."
 
-#: templates/pages/page.html:14
+#: templates/pages/page.html:16
 #, python-format
 msgid "Edit page \"%(page_title)s\""
 msgstr "Seite \"%(page_title)s\" bearbeiten"
 
-#: templates/pages/page.html:17
+#: templates/pages/page.html:19
 msgid "Create new translation"
 msgstr "Neue Übersetzung erstellen"
 
-#: templates/pages/page.html:20
+#: templates/pages/page.html:22
 msgid "Create new page"
 msgstr "Neue Seite erstellen"
 
-#: templates/pages/page.html:36
+#: templates/pages/page.html:44 templates/pages/sbs_page.html:30
 msgid "Insert title here"
 msgstr "Titel hier eingeben"
 
-#: templates/pages/page.html:39
+#: templates/pages/page.html:47
+#: templates/push_notifications/push_notification.html:54
+msgid "Content"
+msgstr "Inhalt"
+
+#: templates/pages/page.html:48 templates/pages/sbs_page.html:33
 msgid "Insert content here"
 msgstr "Inhalt hier eingeben"
 
-#: templates/pages/page.html:44
+#: templates/pages/page.html:53
+msgid "Permalink"
+msgstr ""
+
+#: templates/pages/page.html:55
+msgid " Leave blank to generate unique permalink from title"
+msgstr ""
+" Dieses Feld freilassen, um eine eindeutigen Permalink aus dem Titel zu "
+"generieren"
+
+#: templates/pages/page.html:67
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: templates/pages/page.html:46
+#: templates/pages/page.html:69
 msgid "Search page"
 msgstr "Seite suchen"
 
-#: templates/pages/page.html:49
+#: templates/pages/page.html:72
 msgid "Embed before content"
 msgstr "Vor Inhalt einbinden"
 
-#: templates/pages/page.html:50
+#: templates/pages/page.html:73
 msgid "Embed after content"
 msgstr "Nach Inhalt einbinden"
 
-#: templates/pages/page.html:57
+#: templates/pages/page.html:80
 msgid "Embed page"
 msgstr "Seite einbinden"
 
-#: templates/pages/page.html:65
+#: templates/pages/page.html:85
+msgid "Additional permissions for this page"
+msgstr "Zusätzliche Berechtigungen für diese Seite"
+
+#: templates/pages/page.html:86
+msgid ""
+"This affects only users, who don't have the permission to change arbitrary "
+"pages anyway."
+msgstr ""
+"Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
+"beliebige Seiten zu ändern."
+
+#: templates/pages/page.html:97
 #: templates/push_notifications/push_notification.html:63
 msgid "Current language"
 msgstr "Aktuelle Sprache"
 
-#: templates/pages/page.html:71
+#: templates/pages/page.html:103
 #: templates/push_notifications/push_notification.html:70
 msgid "Translations"
 msgstr "Übersetzungen"
 
-#: templates/pages/page.html:95
+#: templates/pages/page.html:125
+msgid "Side by Side View"
+msgstr "Übersetzungen nebeneinander anzeigen"
+
+#: templates/pages/page.html:146
 msgid "Positioning"
 msgstr "Anordnung"
 
-#: templates/pages/page.html:96
+#: templates/pages/page.html:147
 msgid "Relationship"
 msgstr "Verhältnis"
 
-#: templates/pages/page.html:100
+#: templates/pages/page.html:151
 msgid "Page"
 msgstr "Seite"
 
-#: templates/pages/page.html:109
+#: templates/pages/page.html:162
 msgid "Visibility"
 msgstr "Sichtbarkeit"
 
-#: templates/pages/page.html:118 templates/regions/list.html:28
+#: templates/pages/page.html:172 templates/regions/list.html:28
 #: templates/regions/region.html:74
 msgid "Status"
 msgstr "Status"
 
-#: templates/pages/page.html:127 templates/regions/region.html:57
+#: templates/pages/page.html:181 templates/regions/region.html:57
 msgid "Icon"
 msgstr "Icon"
 
-#: templates/pages/page.html:131 templates/regions/region.html:67
-msgid "Set icon"
-msgstr "Icon festlegen"
-
-#: templates/pages/page.html:136 templates/pages/tree_row.html:37
+#: templates/pages/page.html:190 templates/pages/tree_row.html:51
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: templates/pages/page.html:138
+#: templates/pages/page.html:192
 msgid "Page is archived."
 msgstr "Die Seite wurde archiviert."
 
-#: templates/pages/page.html:141
-#, fuzzy
-#| msgid "Archived pages"
+#: templates/pages/page.html:195
 msgid "Archive this page"
-msgstr "Archivierte Seiten"
+msgstr "Diese Seite archivieren"
+
+#: templates/pages/sbs_page.html:11
+#, python-format
+msgid ""
+"Translate \"%(page_title)s\" from %(source_language)s to %(target_language)s"
+msgstr ""
+
+#: templates/pages/sbs_page.html:40
+msgid "Go Back to Page Editor"
+msgstr "Zurück zum Seiten-Editor"
 
 #: templates/pages/tree.html:15
 msgid "Archived pages"
 msgstr "Archivierte Seiten"
 
-#: templates/pages/tree.html:31
-msgid "Create page"
-msgstr "Seite erstellen"
-
-#: models/site.py:19 templates/language_tree/tree.html:37
+#: templates/pages/tree.html:37
 msgid "Upload"
 msgstr "Hochladen"
 
-#: templates/pages/tree.html:53
+#: templates/pages/tree.html:44
+msgid "Create page"
+msgstr "Seite erstellen"
+
+#: templates/pages/tree.html:56
+msgid "ID"
+msgstr ""
+
+#: templates/pages/tree.html:67
+msgid "Creator"
+msgstr "Ersteller"
+
+#: templates/pages/tree.html:70
 msgid "Options"
 msgstr "Optionen"
 
-#: templates/pages/tree_row.html:27
-#, fuzzy
-#| msgid "Embed page"
+#: templates/pages/tree_row.html:41
 msgid "View page"
-msgstr "Seite einbinden"
+msgstr "Seite ansehen"
 
-#: templates/pages/tree_row.html:30
-#, fuzzy
-#| msgid "Embed page"
+#: templates/pages/tree_row.html:44
 msgid "Edit page"
-msgstr "Seite einbinden"
+msgstr "Seite bearbeiten"
 
-#: templates/pages/tree_row.html:33
-#, fuzzy
-#| msgid "Related page"
+#: templates/pages/tree_row.html:47
 msgid "Delete page"
-msgstr "Verwandte Seite"
+msgstr "Gelöschte Seite"
+
+#: templates/pages/tree_row.html:56
+msgid "Download page"
+msgstr "Seite herunterladen"
 
 #: templates/push_notifications/list.html:13
 msgid "Create push notification"
@@ -491,8 +690,8 @@ msgid ""
 "This push notification has already been sent on the "
 "%(push_notification_sent_date)s."
 msgstr ""
-"Diese Push-Benachrichtigung wurde bereits am "
-"%(push_notification_sent_date)s gesendet."
+"Diese Push-Benachrichtigung wurde bereits am %(push_notification_sent_date)s "
+"gesendet."
 
 #: templates/push_notifications/push_notification.html:44
 msgid "This affects all translations of this notification."
@@ -503,20 +702,14 @@ msgid "Insert channel name here"
 msgstr "Kanal-Name hier eingeben"
 
 #: templates/push_notifications/push_notification.html:50
-#, fuzzy, python-format
-#| msgid "Insert title here"
+#, python-format
 msgid "Insert title in %(language)s here"
-msgstr "Titel hier eingeben"
-
-#: templates/push_notifications/push_notification.html:54
-msgid "Content"
-msgstr "Inhalt"
+msgstr "Titel auf %(language)s hier eingeben"
 
 #: templates/push_notifications/push_notification.html:55
-#, fuzzy, python-format
-#| msgid "Insert content here"
+#, python-format
 msgid "Insert content in %(language)s here"
-msgstr "Inhalt hier eingeben"
+msgstr "Inhalt auf %(language)s hier eingeben"
 
 #: templates/regions/list.html:13
 msgid "Create region"
@@ -542,10 +735,6 @@ msgstr "Region \"%(region_name)s\" bearbeiten"
 #: templates/regions/region.html:16
 msgid "Create new region"
 msgstr "Neue Region erstellen"
-
-#: templates/regions/region.html:31
-msgid "General Settings"
-msgstr "Allgemeine Einstellungen"
 
 #: templates/regions/region.html:36
 msgid "Name of the region"
@@ -591,10 +780,6 @@ msgstr "Geographische Länge"
 msgid "Enter longitude here"
 msgstr "Geographische Länge hier eingeben"
 
-#: templates/regions/region.html:87
-msgid "Extended Settings"
-msgstr "Erweiterte Einstellungen"
-
 #: templates/regions/region.html:93
 msgid "Activate events"
 msgstr "Veranstaltungen aktivieren"
@@ -639,10 +824,6 @@ msgstr "Der Benutzername oder das Passwort ist falsch."
 #: templates/registration/password_reset_form.html:16
 msgid "Please try again."
 msgstr "Bitte versuchen Sie es erneut."
-
-#: templates/registration/login.html:26 templates/registration/login.html:28
-msgid "Username"
-msgstr "Benutzername"
 
 #: templates/registration/login.html:33 templates/registration/login.html:35
 #: templates/registration/password_reset_confirm.html:22
@@ -721,6 +902,7 @@ msgid "Reset password"
 msgstr "Passwort zurücksetzen"
 
 #: templates/registration/password_reset_form.html:14
+#: views/languages/languages.py:72
 msgid "An error has occurred."
 msgstr "Es ist ein Fehler aufgetreten."
 
@@ -732,6 +914,35 @@ msgstr "Womöglich ist diese E-Mail Adresse nicht im System vorhanden."
 #: templates/registration/password_reset_form.html:33
 msgid "E-mail address"
 msgstr "E-Mail Adresse"
+
+#: templates/roles/list.html:13
+msgid "Create role"
+msgstr "Rolle erstellen"
+
+#: templates/roles/list.html:32
+msgid "No roles available yet."
+msgstr "Noch keine Rollen vorhanden."
+
+#: templates/roles/role.html:13
+#, python-format
+msgid "Edit role \"%(role_name)s\""
+msgstr "Rolle \"%(role_name)s\" bearbeiten"
+
+#: templates/roles/role.html:16
+msgid "Create new role"
+msgstr "Neue Rolle erstellen"
+
+#: templates/roles/role.html:30
+msgid "Name of the Role"
+msgstr "Name der Rolle"
+
+#: templates/roles/role.html:33
+msgid "Enter the role's name here"
+msgstr "Name der Rolle hier eingeben"
+
+#: templates/roles/role.html:41
+msgid "Permissions of the role"
+msgstr "Berechtigungen der Rolle"
 
 #: templates/statistics/statistics_dashboard.html:13
 msgid "Page views"
@@ -772,41 +983,127 @@ msgstr "bitte auswählen"
 
 #: templates/statistics/statistics_dashboard.html:87
 msgid "Image/PNG"
-msgstr "Bild/PNG"
+msgstr ""
 
 #: templates/statistics/statistics_dashboard.html:88
 msgid "Table Document/CSV"
 msgstr "Tabellendokument/CSV"
 
-#: views/general/general.py:5
+#: templates/users/admin/list.html:13 templates/users/region/list.html:13
+msgid "Create user"
+msgstr "Benutzer erstellen"
+
+#: templates/users/admin/list.html:24 templates/users/region/list.html:24
+msgid "First Name"
+msgstr "Vorname"
+
+#: templates/users/admin/list.html:25 templates/users/region/list.html:25
+msgid "Last Name"
+msgstr "Nachname"
+
+#: templates/users/admin/list.html:26 templates/users/region/list.html:26
+msgid "E-mail-address"
+msgstr "E-Mail Adresse"
+
+#: templates/users/admin/list.html:27 templates/users/admin/user.html:96
+#: templates/users/region/list.html:27 templates/users/region/user.html:82
+msgid "Organization"
+msgstr "Organisation"
+
+#: templates/users/admin/list.html:29 templates/users/admin/user.html:77
+msgid "Staff"
+msgstr "Mitarbeiter"
+
+#: templates/users/admin/list.html:30 templates/users/admin/user.html:72
+msgid "Superuser"
+msgstr "Super-Administrator"
+
+#: templates/users/admin/list.html:39 templates/users/region/list.html:37
+msgid "No users available yet."
+msgstr "Noch keine Benutzer vorhanden."
+
+#: templates/users/admin/user.html:13 templates/users/region/user.html:13
+#, python-format
+msgid "Edit user \"%(user_name)s\""
+msgstr "Benutzer \"%(user_name)s\" bearbeiten"
+
+#: templates/users/admin/user.html:16 templates/users/region/user.html:16
+msgid "Create new user"
+msgstr "Neuen Benutzer erstellen"
+
+#: templates/users/admin/user.html:37 templates/users/region/user.html:37
+msgid "Enter the username here"
+msgstr "Name des Benutzers hier eingeben"
+
+#: templates/users/admin/user.html:40 templates/users/region/user.html:40
+msgid "First name of the user"
+msgstr "Vorname des Benutzers"
+
+#: templates/users/admin/user.html:41 templates/users/region/user.html:41
+msgid "Enter the user's first name here"
+msgstr "Vorname des Benutzers hier eingeben"
+
+#: templates/users/admin/user.html:44 templates/users/region/user.html:44
+msgid "Last name of the user"
+msgstr "Nachname des Benutzers"
+
+#: templates/users/admin/user.html:45 templates/users/region/user.html:45
+msgid "Enter the user's last name here"
+msgstr "Nachname des Benutzers hier eingeben"
+
+#: templates/users/admin/user.html:48 templates/users/region/user.html:48
+msgid "E-mail-address of the user"
+msgstr "E-Mail-Adresse des Benutzers"
+
+#: templates/users/admin/user.html:49 templates/users/region/user.html:49
+msgid "Enter the user's e-mail-address here"
+msgstr "E-Mail-Adresse des Benutzers hier eingeben"
+
+#: templates/users/admin/user.html:52 templates/users/region/user.html:52
+msgid "Password of the user"
+msgstr "Passwort des Benutzers"
+
+#: templates/users/admin/user.html:58 templates/users/region/user.html:58
+msgid "Leave empty to keep unchanged"
+msgstr "Feld leer lassen, um das Passwort nicht zu ändern"
+
+#: templates/users/admin/user.html:58 templates/users/region/user.html:58
+msgid "Enter the user's password here"
+msgstr "Passwort des Benutzers hier eingeben"
+
+#: templates/users/admin/user.html:108 templates/users/region/user.html:94
+msgid "Delete this user"
+msgstr "Diesen Benutzer löschen"
+
+#: views/general/error_handler.py:5
 msgid "Bad request"
 msgstr "Inkorrekte Anfrage"
 
-#: views/general/general.py:6
+#: views/general/error_handler.py:6
 msgid "There was an error in your request."
 msgstr "Die Anfrage war fehlerhaft aufgebaut."
 
-#: views/general/general.py:13
+#: views/general/error_handler.py:13
 msgid "Forbidden"
 msgstr "Zugriff verweigert"
 
-#: views/general/general.py:14
+#: views/general/error_handler.py:14
 msgid "You don't have the permission to access this page."
 msgstr "Sie haben nicht die nötige Berechtigung, um diese Seite aufzurufen."
 
-#: views/general/general.py:21
+#: views/general/error_handler.py:21
 msgid "Page not found"
 msgstr "Seite nicht gefunden"
 
-#: views/general/general.py:22
+#: views/general/error_handler.py:22
 msgid "The page you requested could not be found."
 msgstr "Die von Ihnen angeforderte Seite konnte leider nicht gefunden werden."
 
-#: views/general/general.py:29
+#: views/general/error_handler.py:29
 msgid "Internal Server Error"
 msgstr "Interner Server-Fehler"
 
-#: views/general/general.py:30
+#: views/general/error_handler.py:30
 msgid "An unexpected error has occurred."
 msgstr "Es ist ein unerwarteter Fehler aufgetreten."
 
@@ -826,17 +1123,20 @@ msgstr "Linker Nachbar von"
 msgid "Right neighbor of"
 msgstr "Rechter Nachbar von"
 
-#: views/language_tree/language_tree_node.py:54
+#: views/language_tree/language_tree_node.py:61
 msgid "Language tree node was saved successfully."
 msgstr "Sprach-Baum wurde erfolgreich gespeichert."
 
-#: views/language_tree/language_tree_node.py:57
+#: views/language_tree/language_tree_node.py:64
 msgid "Language tree node was created successfully."
 msgstr "Sprach-Baum wurde erfolgreich erstellt."
 
-#: views/language_tree/language_tree_node.py:64 views/pages/page.py:104
-#: views/push_notifications/push_notifications.py:147
-#: views/regions/regions.py:70
+#: views/language_tree/language_tree_node.py:71
+#: views/organizations/organizations.py:72 views/pages/page.py:140
+#: views/pages/sbs_page.py:109
+#: views/push_notifications/push_notifications.py:170
+#: views/regions/regions.py:82 views/roles/roles.py:71
+#: views/users/region_users.py:113 views/users/users.py:92
 msgid "Errors have occurred."
 msgstr "Es sind Fehler aufgetreten."
 
@@ -856,100 +1156,140 @@ msgstr ""
 "Diese Quell-Sprache gehört zu einer anderen Region. Bitte geben Sie eine "
 "Quell-Sprache dieser Region ein."
 
-#: views/languages/languages.py:54
+#: views/languages/languages.py:66
 msgid "Language saved successfully."
 msgstr "Sprache wurde erfolgreich gespeichert."
 
-#: views/languages/languages.py:57
+#: views/languages/languages.py:69
 msgid "Language created successfully"
 msgstr "Sprache wurde erfolgreich erstellt."
 
-#: views/languages/languages.py:60
-msgid "Es sind Fehler aufgetreten."
-msgstr ""
+#: views/organizations/organizations.py:62
+msgid "Organization created successfully"
+msgstr "Organisation wurde erfolgreich erstellt."
 
-#: views/pages/page.py:75
-#, fuzzy
-#| msgid "Page was saved successfully."
-msgid "Page was successfully published."
-msgstr "Seite wurde erfolgreich gespeichert."
+#: views/organizations/organizations.py:65
+msgid "Organization saved successfully"
+msgstr "Organisation wurde erfolgreich gespeichert."
 
-#: views/pages/page.py:78
-#, fuzzy
-#| msgid "Page was created and published successfully."
+#: views/pages/page.py:115 views/pages/page.py:164
+msgid "Page was successfully archived."
+msgstr "Seite wurde erfolgreich archiviert."
+
+#: views/pages/page.py:118
 msgid "Page was successfully created and published."
 msgstr "Seite wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/pages/page.py:87 views/pages/page.py:99
-#, fuzzy
-#| msgid "Page was saved successfully."
-msgid "Page was successfully saved."
-msgstr "Seite wurde erfolgreich gespeichert."
-
-#: views/pages/page.py:90 views/pages/page.py:102
-#, fuzzy
-#| msgid "Page was saved successfully."
+#: views/pages/page.py:120
 msgid "Page was successfully created."
-msgstr "Seite wurde erfolgreich gespeichert."
+msgstr "Seite wurde erfolgreich erstellt."
 
-#: views/pages/page.py:121
-#, fuzzy
-#| msgid "Page was saved successfully."
-msgid "Page was successfully archived."
-msgstr "Seite wurde erfolgreich gespeichert."
+#: views/pages/page.py:123
+msgid "Translation was successfully created and published."
+msgstr "Übersetzung wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/pages/page.py:135
-#, fuzzy
-#| msgid "Page was saved successfully."
+#: views/pages/page.py:125 views/pages/sbs_page.py:103
+msgid "Translation was successfully created."
+msgstr "Übersetzung wurde erfolgreich erstellt."
+
+#: views/pages/page.py:128
+msgid "Translation was successfully published."
+msgstr "Übersetzung wurde erfolgreich veröffentlich."
+
+#: views/pages/page.py:130 views/pages/sbs_page.py:105
+msgid "Translation was successfully saved."
+msgstr "Übersetzung wurde erfolgreich gespeichert."
+
+#: views/pages/page.py:132 views/pages/sbs_page.py:107
+#: views/users/region_users.py:110 views/users/users.py:89
+msgid "No changes detected."
+msgstr "Keine Änderungen vorgenommen."
+
+#: views/pages/page.py:183
 msgid "Page was successfully restored."
-msgstr "Seite wurde erfolgreich gespeichert."
+msgstr "Seite wurde erfolgreich wiederhergestellt."
 
-#: views/pages/page_form.py:26
+#: views/pages/page.py:290 views/pages/page.py:305
+#, python-brace-format
+msgid "Information: The user {user} has this permission already."
+msgstr ""
+
+#: views/pages/page.py:298
+#, python-brace-format
+msgid "Success: The user {user} can now edit this page."
+msgstr ""
+
+#: views/pages/page.py:313
+#, python-brace-format
+msgid "Success: The user {user} can now publish this page."
+msgstr ""
+
+#: views/pages/page.py:374
+#, python-brace-format
+msgid ""
+"Information: The user {user} has been removed from the editors of this page, "
+"but has the implicit permission to edit this page anyway."
+msgstr ""
+
+#: views/pages/page.py:380
+#, python-brace-format
+msgid "Success: The user {user} cannot edit this page anymore."
+msgstr ""
+
+#: views/pages/page.py:391
+#, python-brace-format
+msgid ""
+"Information: The user {user} has been removed from the publishers of this "
+"page, but has the implicit permission to publish this page anyway."
+msgstr ""
+
+#: views/pages/page.py:397
+#, python-brace-format
+msgid "Success: The user {user} cannot publish this page anymore."
+msgstr ""
+
+#: views/pages/page_form.py:146
 msgid "Public"
 msgstr "Öffentlich"
 
-#: views/pages/page_form.py:27
+#: views/pages/page_form.py:147
 msgid "Private"
 msgstr "Privat"
 
-#: views/pages/pages.py:33
+#: views/pages/pages.py:39
 msgid "Please create at least one language node before creating pages."
 msgstr ""
 "Bitte erstellen Sie mindestens einen Sprach-Knoten, bevor Sie Seiten "
 "verwalten."
 
-#: views/push_notifications/push_notifications.py:37
-#, fuzzy
-#| msgid "Please create at least one language node before creating pages."
+#: views/push_notifications/push_notifications.py:44
 msgid ""
 "Please create at least one language node before creating push notifications."
 msgstr ""
-"Bitte erstellen Sie mindestens einen Sprach-Knoten, bevor Sie Seiten "
-"verwalten."
+"Bitte erstellen Sie mindestens einen Sprach-Knoten, bevor Sie Push-"
+"Benachrichtigungen verwalten."
 
-#: views/push_notifications/push_notifications.py:97
-#, fuzzy
-#| msgid "Region saved successfully."
+#: views/push_notifications/push_notifications.py:116
 msgid "Push notification saved successfully."
-msgstr "Region wurde erfolgreich gespeichert."
+msgstr "Push-Benachrichtigung wurde erfolgreich gespeichert."
 
-#: views/push_notifications/push_notifications.py:100
-#, fuzzy
-#| msgid "Region created successfully"
+#: views/push_notifications/push_notifications.py:119
 msgid "Push notification created successfully."
-msgstr "Region wurde erfolgreich erstellt."
+msgstr "Push-Benachrichtigung wurde erfolgreich erstellt."
 
-#: views/push_notifications/push_notifications.py:144
-#, fuzzy
-#| msgid "Page was saved successfully."
+#: views/push_notifications/push_notifications.py:165
 msgid "Push notification was successfully sent."
-msgstr "Seite wurde erfolgreich gespeichert."
+msgstr "Push-Benachrichtigung wurde erfolgreich gespeichert."
 
-#: views/regions/regions.py:64
+#: views/push_notifications/push_notifications.py:167
+msgid "Error occurred sending the push notification"
+msgstr "Push-Benachrichtigung konnte nicht gesendet werden"
+
+#: views/regions/regions.py:76
 msgid "Region saved successfully."
 msgstr "Region wurde erfolgreich gespeichert."
 
-#: views/regions/regions.py:67
+#: views/regions/regions.py:79
 msgid "Region created successfully"
 msgstr "Region wurde erfolgreich erstellt."
 
@@ -977,25 +1317,52 @@ msgstr "Ihr Passwort wurde erfolgreich geändert."
 msgid "You can now log in with your new password."
 msgstr "Sie können sich jetzt mit dem neuen Passwort einloggen."
 
-#: templates/_base.html:115
-msgid "Media Library"
-msgstr "Medienbibliothek"
+#: views/roles/roles.py:62
+msgid "Role saved successfully"
+msgstr "Rolle wurde erfolgreich gespeichert."
 
-#: templates/media/medialist.html:13
-msgid "Upload File"
-msgstr "Datei hochladen"
+#: views/roles/roles.py:65
+msgid "Role created successfully"
+msgstr "Rolle wurde erfolgreich erstellt."
 
-#: templates/media/medialist.html:24
-msgid "Date"
-msgstr "Datum"
+#: views/users/region_users.py:102 views/users/users.py:82
+msgid "User was successfully saved."
+msgstr "Benutzer wurde erfolgreich gespeichert."
 
-#: templates/media/mediaupload.html:12
-msgid "Submit"
-msgstr "einreichen"
+#: views/users/region_users.py:104 views/users/users.py:84
+msgid "User was successfully created."
+msgstr "Benutzer wurde erfolgreich erstellt."
 
-#: templates/media/mediaupload.html:15
-msgid "Return"
-msgstr "Rückkehr"
+#: views/users/region_users.py:130 views/users/users.py:107
+msgid "User was successfully deleted."
+msgstr "Benutzer wurde erfolgreich gelöscht."
+
+#~ msgid "User"
+#~ msgstr "Benutzer"
+
+#~ msgid "Permissions"
+#~ msgstr "Berechtigungen"
+
+#~ msgid "Grant permission"
+#~ msgstr "Berechtigung erteilen"
+
+#~ msgid "Edit all translations"
+#~ msgstr "Alle Übersetzungen bearbeiten"
+
+#~ msgid "Publish all translations"
+#~ msgstr "Alle Übersetzungen veröffentlichen"
+
+#~ msgid "Edit this translation"
+#~ msgstr "Diese Übersetzung bearbeiten"
+
+#~ msgid "Publish this translation"
+#~ msgstr "Diese Übersetzung veröffentlichen"
+
+#~ msgid "User saved successfully."
+#~ msgstr "Benutzer wurde erfolgreich gespeichert."
+
+#~ msgid "User created successfully."
+#~ msgstr "Benutzer wurde erfolgreich erstellt."
 
 #~ msgid "History"
 #~ msgstr "Historie"
@@ -1023,9 +1390,6 @@ msgstr "Rückkehr"
 
 #~ msgid "Turkish"
 #~ msgstr "Türkisch"
-
-#~ msgid "German"
-#~ msgstr "Deutsch"
 
 #~ msgid "Parent page"
 #~ msgstr "Übergeordnete Seite"

--- a/backend/cms/models/configuration.py
+++ b/backend/cms/models/configuration.py
@@ -2,7 +2,14 @@ from django.db import models
 
 
 class Configuration(models.Model):
+
     key = models.CharField(max_length=100, unique=True, blank=False)
     value = models.CharField(max_length=1000, blank=False)
     created_date = models.DateTimeField(auto_now_add=True)
     last_updated = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        default_permissions = ()
+        permissions = (
+            ('manage_configuration', 'Can manage configuration'),
+        )

--- a/backend/cms/models/event.py
+++ b/backend/cms/models/event.py
@@ -157,6 +157,14 @@ class Event(models.Model):
             return [x for x in occurrences if start <= x <= end or start <= x + event_span <= end]
         return [event_start] if start <= event_start <= end or start <= event_end <= end else []
 
+    class Meta:
+        default_permissions = ()
+        permissions = (
+            ('view_events', 'Can view events'),
+            ('edit_events', 'Can edit events'),
+            ('publish_events', 'Can publish events'),
+        )
+
 
 class EventTranslation(models.Model):
     """
@@ -179,3 +187,6 @@ class EventTranslation(models.Model):
     created_date = models.DateTimeField(default=timezone.now)
     last_updated = models.DateTimeField(auto_now=True)
     creator = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, on_delete=models.SET_NULL)
+
+    class Meta:
+        default_permissions = ()

--- a/backend/cms/models/extra.py
+++ b/backend/cms/models/extra.py
@@ -25,3 +25,9 @@ class Extra(models.Model):
 
     def post_data(self):
         return self.template.post_data
+
+    class Meta:
+        default_permissions = ()
+        permissions = (
+            ('manage_extras', 'Can manage extras'),
+        )

--- a/backend/cms/models/extra_template.py
+++ b/backend/cms/models/extra_template.py
@@ -26,3 +26,9 @@ class ExtraTemplate(models.Model):
         Returns: String
         """
         return self.name
+
+    class Meta:
+        default_permissions = ()
+        permissions = (
+            ('manage_extra_templates', 'Can manage extra templates'),
+        )

--- a/backend/cms/models/feedback.py
+++ b/backend/cms/models/feedback.py
@@ -18,26 +18,56 @@ class Feedback(models.Model):
     created_date = models.DateTimeField(auto_now_add=True)
     last_updated = models.DateTimeField(auto_now=True)
 
+    class Meta:
+        default_permissions = ()
+        permissions = (
+            ('view_feedback', 'Can view feedback'),
+        )
+
 
 class SiteFeedback(Feedback):
+
     site = models.ForeignKey(Site)
+
+    class Meta:
+        default_permissions = ()
 
 
 class PageFeedback(Feedback):
+
     page = models.ForeignKey(Page)
+
+    class Meta:
+        default_permissions = ()
 
 
 class TechnicalFeedback(Feedback):
+
     page = models.ForeignKey(Page)
+
+    class Meta:
+        default_permissions = ()
 
 
 class ExtraFeedback(Feedback):
+
     extra = models.ForeignKey(Extra)
+
+    class Meta:
+        default_permissions = ()
 
 
 class EventFeedback(Feedback):
+
     event = models.ForeignKey(Event)
+
+    class Meta:
+        default_permissions = ()
 
 
 class SearchResultFeedback(Feedback):
+
     searchQuery = models.CharField(max_length=1000)
+
+    class Meta:
+        default_permissions = ()

--- a/backend/cms/models/language.py
+++ b/backend/cms/models/language.py
@@ -40,6 +40,11 @@ class Language(models.Model):
         """
         return self.name
 
+    class Meta:
+        default_permissions = ()
+        permissions = (
+            ('manage_languages', 'Can manage languages'),
+        )
 
 class LanguageTreeNode(MPTTModel):
     """Class defining a LanguageTree database object.
@@ -77,6 +82,10 @@ class LanguageTreeNode(MPTTModel):
 
     class Meta:
         unique_together = (('language', 'site', ), )
+        default_permissions = ()
+        permissions = (
+            ('manage_language_tree', 'Can manage language tree'),
+        )
 
     def __str__(self):
         """Function that provides a string representation of this object

--- a/backend/cms/models/media_models.py
+++ b/backend/cms/models/media_models.py
@@ -3,6 +3,7 @@ from django import forms
 
 
 class Document(models.Model):
+
     description = models.CharField(max_length=255, blank=True)
     document = models.FileField(upload_to='')
     uploaded_at = models.DateTimeField(auto_now_add=True)
@@ -14,8 +15,12 @@ class Document(models.Model):
         self.document.delete()
         super().delete(*args, **kwargs)
 
+    class Meta:
+        default_permissions = ()
+
 
 class DocumentForm(forms.ModelForm):
+
     class Meta:
         model = Document
         fields = ('description', 'document', )

--- a/backend/cms/models/organization.py
+++ b/backend/cms/models/organization.py
@@ -13,3 +13,9 @@ class Organization(models.Model):
 
     def __str__(self):
         return self.name
+
+    class Meta:
+        default_permissions = ()
+        permissions = (
+            ('manage_organizations', 'Can manage organizations'),
+        )

--- a/backend/cms/models/page.py
+++ b/backend/cms/models/page.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
+
 from mptt.models import MPTTModel, TreeForeignKey
 
 from .language import Language
@@ -131,6 +132,7 @@ class Page(MPTTModel):
             ('view_pages', 'Can view pages'),
             ('edit_pages', 'Can edit pages'),
             ('publish_pages', 'Can publish pages'),
+            ('grant_page_permissions', 'Can grant page permissions'),
         )
 
 

--- a/backend/cms/models/poi.py
+++ b/backend/cms/models/poi.py
@@ -42,6 +42,12 @@ class POI(models.Model):
 
         return pois
 
+    class Meta:
+        default_permissions = ()
+        permissions = (
+            ('manage_pois', 'Can manage points of interest'),
+        )
+
 
 class POITranslation(models.Model):
     """Translation of an Point of Interest
@@ -67,3 +73,6 @@ class POITranslation(models.Model):
     created_date = models.DateTimeField(default=timezone.now)
     last_updated = models.DateTimeField(auto_now=True)
     creator = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, on_delete=models.SET_NULL)
+
+    class Meta:
+        default_permissions = ()

--- a/backend/cms/models/postal_code_in_get_parameter_extra.py
+++ b/backend/cms/models/postal_code_in_get_parameter_extra.py
@@ -5,3 +5,6 @@ class PostalCodeInGetParameterExtra(Extra):
 
     def url(self):
         return self.template.url + self.site.postal_code
+
+    class Meta:
+        default_permissions = ()

--- a/backend/cms/models/postal_code_in_post_parameter_extra.py
+++ b/backend/cms/models/postal_code_in_post_parameter_extra.py
@@ -7,3 +7,6 @@ class PostalCodeInPostParameterExtra(Extra):
         post = self.template.post_data
         post.update({'search-plz': self.site.postal_code})
         return post
+
+    class Meta:
+        default_permissions = ()

--- a/backend/cms/models/push_notification.py
+++ b/backend/cms/models/push_notification.py
@@ -25,6 +25,14 @@ class PushNotification(models.Model):
             return self.translations.first().title
         return ""
 
+    class Meta:
+        default_permissions = ()
+        permissions = (
+            ('view_push_notifications', 'Can view push notification'),
+            ('edit_push_notifications', 'Can edit push notification'),
+            ('send_push_notifications', 'Can send push notification'),
+        )
+
 
 class PushNotificationTranslation(models.Model):
     """Class representing the Translation of a Push Notification
@@ -41,3 +49,6 @@ class PushNotificationTranslation(models.Model):
 
     def __str__(self):
         return self.title
+
+    class Meta:
+        default_permissions = ()

--- a/backend/cms/models/user_profile.py
+++ b/backend/cms/models/user_profile.py
@@ -18,5 +18,5 @@ class UserProfile(models.Model):
     def __str__(self):
         return self.user.username
 
-    class Meta():
+    class Meta:
         default_permissions = ()

--- a/backend/cms/rules.py
+++ b/backend/cms/rules.py
@@ -1,0 +1,30 @@
+from rules import add_rule, add_perm, predicate
+
+
+# Predicates
+
+@predicate
+def is_page_editor(user, page):
+    if not page:
+        return False
+    return user in page.editors.all()
+
+@predicate
+def is_page_publisher(user, page):
+    if not page:
+        return False
+    return user in page.publishers.all()
+
+@predicate
+def can_edit_all_pages(user, page):
+    return user.has_perm('edit_pages')
+
+@predicate
+def can_publish_all_pages(user, page):
+    return user.has_perm('publish_pages')
+
+
+# Permissions
+
+add_perm('cms.edit_page', can_edit_all_pages | is_page_editor | can_publish_all_pages | is_page_publisher)
+add_perm('cms.publish_page', can_publish_all_pages | is_page_publisher)

--- a/backend/cms/templates/_base.html
+++ b/backend/cms/templates/_base.html
@@ -80,7 +80,7 @@
 	        {% endif %}
             <i data-feather="chevron-down" class="absolute pin-t pin-r"></i>
         </span>
-        <div id="user-menu" class="absolute shadow rounded-b">
+        <div id="user-menu" class="absolute shadow rounded-b" style="left: -120px;">
             <a href="/" class="relative block pl-10 pr-4 py-3 text-grey-darkest hover:bg-grey">
                 <i data-feather="help-circle" class="absolute"></i>
 	            {% trans 'Help' %}

--- a/backend/cms/templates/_raw.html
+++ b/backend/cms/templates/_raw.html
@@ -22,5 +22,6 @@
     <script>
         feather.replace()
     </script>
+    {% block javascript %}{% endblock %}
 </body>
 </html>

--- a/backend/cms/templates/pages/_page_permission_table.html
+++ b/backend/cms/templates/pages/_page_permission_table.html
@@ -1,0 +1,96 @@
+{% load page_filters %}
+{% load widget_tweaks %}
+{% load static %}
+{% load i18n %}
+    {% if permission_message %}
+        {% if permission_message.level_tag == 'info' %}
+            <div class="bg-blue-lightest border-l-4 border-blue text-blue-dark px-4 py-3 mb-5" role="alert">
+                <p>{{permission_message.message}}</p>
+            </div>
+        {% endif %}
+        {% if permission_message.level_tag == 'success' %}
+            <div class="bg-green-lightest border-l-4 border-green text-green-dark px-4 py-3 mb-5" role="alert">
+                <p>{{ permission_message.message }}</p>
+            </div>
+        {% endif %}
+        {% if permission_message.level_tag == 'warning' %}
+            <div class="bg-orange-lightest border-l-4 border-orange text-orange-dark px-4 py-3 mb-5" role="alert">
+                <p>{{ permission_message.message }}</p>
+            </div>
+        {% endif %}
+        {% if permission_message.level_tag == 'error' %}
+            <div class="bg-red-lightest border-l-4 border-red text-red-dark px-4 py-3 mb-5" role="alert">
+                <p>{{ permission_message.message }}</p>
+            </div>
+        {% endif %}
+    {% endif %}
+<div class="w-fullrounded overflow-hidden shadow-lg mt-6">
+    <div class="px-6 pt-4">
+        <div class="font-bold text-xl mb-2">{% trans 'Editors' %}</div>
+        <p class="text-gray-700 text-base">
+            {% trans 'These users can edit this page, but are not allowed to publish it.' %}
+        </p>
+    </div>
+    <div class="px-2 py-2">
+        {% for user in page.editors.all %}
+            <span class="inline-block rounded-full py-2 px-4 mx-2 my-1 bg-blue text-white text-xl">
+                {{ user.username }}
+                <a class="revoke-page-permission" data-user-id="{{ user.id }}" data-permission="edit">
+                    <i data-feather="x-circle" class="cursor-pointer ml-1 mb-0 align-middle"></i>
+                </a>
+            </span>
+        {% empty %}
+        {% endfor %}
+    </div>
+    <div class="w-full flex flex-wrap mt-2 px-6 pb-4">
+        <div class="w-1/3">
+            <label class="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2" for="grid-first-name">
+                {% trans 'Username' %}
+            </label>
+            {% render_field page_form.editors class="appearance-none block w-full bg-grey-lighter text-xl text-grey-darkest border border-grey-lighter rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
+            <div class="pointer-events-none absolute pin-y pin-r flex items-center px-2 text-grey-darkest">
+                <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
+            </div>
+        </div>
+        <div class="w-1/3 mt-6 ml-3">
+            <button type="button" class="bg-blue hover:bg-blue-dark text-white font-bold py-3 px-4 rounded" id="grant-edit-page-permission" data-user-id="{{ user.id }}" data-permission="edit">
+                <i data-feather="plus-circle" class="align-middle"></i> {% trans 'Add to editors' %}
+            </button>
+        </div>
+    </div>
+</div>
+<div class="w-fullrounded overflow-hidden shadow-lg mt-6">
+    <div class="px-6 pt-4">
+        <div class="font-bold text-xl mb-2">{% trans 'Publishers' %}</div>
+        <p class="text-gray-700 text-base">
+            {% trans 'These users can edit and publish this page.' %}
+        </p>
+    </div>
+    <div class="px-2 py-2">
+        {% for user in page.publishers.all %}
+            <span class="inline-block rounded-full py-2 px-4 mx-2 my-1 bg-blue text-white text-xl">
+                {{ user.username }}
+                <a class="revoke-page-permission" data-user-id="{{ user.id }}" data-permission="publish">
+                    <i data-feather="x-circle" class="cursor-pointer ml-1 mb-0 align-middle"></i>
+                </a>
+            </span>
+        {% empty %}
+        {% endfor %}
+    </div>
+    <div class="w-full flex flex-wrap mt-2 px-6 pb-4">
+        <div class="w-1/3">
+            <label class="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2" for="grid-first-name">
+                {% trans 'Username' %}
+            </label>
+            {% render_field page_form.publishers class="appearance-none block w-full bg-grey-lighter text-xl text-grey-darkest border border-grey-lighter rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
+            <div class="pointer-events-none absolute pin-y pin-r flex items-center px-2 text-grey-darkest">
+                <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
+            </div>
+        </div>
+        <div class="w-1/3 mt-6 ml-3">
+            <button type="button" class="bg-blue hover:bg-blue-dark text-white font-bold py-3 px-4 rounded" id="grant-publish-page-permission">
+                <i data-feather="plus-circle" class="align-middle"></i> {% trans 'Add to publishers' %}
+            </button>
+        </div>
+    </div>
+</div>

--- a/backend/cms/templates/pages/page.html
+++ b/backend/cms/templates/pages/page.html
@@ -3,6 +3,8 @@
 {% block content %}
 {% load static %}
 {% load widget_tweaks %}
+{% load page_filters %}
+{% load rules %}
 <form method="post">
     {% csrf_token %}
     <div class="flex flex-wrap mb-4">
@@ -17,13 +19,17 @@
                         {% trans 'Create new translation' %}
                     {% endif %}
                 {% else %}
-	                {% trans 'Create new page' %}
+                    {% trans 'Create new page' %}
                 {% endif %}
             </h2>
         </div>
         <div class="w-3/5 flex justify-end">
-            <input type="submit" name="submit_save" class="{% if public %}bg-blue hover:bg-blue-dark{% else %}bg-grey hover:bg-grey-dark{% endif %} cursor-pointer text-white font-bold py-3 px-4 rounded mr-2" value="{% trans 'Save' %}" />
-            {% if not page_translation_form.instance.public %}
+            {% has_perm 'cms.edit_page' request.user page as can_edit_page %}
+            {% if can_edit_page %}
+                <input type="submit" name="submit_save" class="{% if public %}bg-blue hover:bg-blue-dark{% else %}bg-grey hover:bg-grey-dark{% endif %} cursor-pointer text-white font-bold py-3 px-4 rounded mr-2" value="{% trans 'Save' %}" />
+            {% endif %}
+            {% has_perm 'cms.publish_page' request.user page as can_publish_page %}
+            {% if not page_translation_form.instance.public and can_publish_page %}
                 <input type="submit" name="submit_publish" class="cursor-pointer bg-blue hover:bg-blue-dark text-white font-bold py-3 px-4 rounded" value="{% trans 'Publish' %}" />
             {% endif %}
         </div>
@@ -71,9 +77,18 @@
                     </div>
                 </div>
                 <button class="bg-blue hover:bg-blue-dark text-white font-bold py-2 px-4 rounded">
-	                {% trans 'Embed page' %}
+                    {% trans 'Embed page' %}
                 </button>
             </div>
+            {% if perms.cms.grant_page_permissions %}
+            <div class="w-full p-4 mb-4 rounded border border-solid border-grey-light shadow bg-white">
+                <h3 class="mb-2">{% trans 'Additional permissions for this page' %}</h3>
+                <p class="mb-2">{% trans "This affects only users, who don't have the permission to change arbitrary pages anyway." %}</p>
+                <div id="page_permission_table">
+                        {% include "pages/_page_permission_table.html" %}
+                </div>
+            </div>
+            {% endif %}
         </div>
         <div class="w-1/3 pl-2">
             <div class="w-full px-4 py-2 rounded border border-solid border-grey-light shadow bg-white">
@@ -81,7 +96,7 @@
                     <span class="block mb-2 font-bold">{% trans 'Language' %}</span>
                     <label class="text-xs uppercase block">{% trans 'Current language' %}</label>
                     <div class="relative my-2">
-	                    {{ language.name }}
+                        {{ language.name }}
                     </div>
                     {% if page %}
 	                    <div class="entity-lang-list mt-4 mb-2">
@@ -107,24 +122,24 @@
 	                        </table>
 	                    </div>
                         <div class="entity-lang-list mt-4 mb-2">
-	                        <label class="text-xs uppercase block mb-2">{% trans 'Side by Side View' %}</label>
-	                        <!-- TODO: get available languages from site settings -->
-	                        <table style="width:100%;" border="0" cellspacing="0" cellpadding="0">
-		                        {% for other_language in languages %}
-			                        {% if other_language != language %}
+                            <label class="text-xs uppercase block mb-2">{% trans 'Side by Side View' %}</label>
+                            <!-- TODO: get available languages from site settings -->
+                            <table style="width:100%;" border="0" cellspacing="0" cellpadding="0">
+                                {% for other_language in languages %}
+                                    {% if other_language != language %}
                                         {% with language.code|add:'__'|add:other_language.code  as sbs_language_code %}
-				                        <tr>
-					                        <td>
-						                        <a href="{% url 'sbs_edit_page' page_id=page.id site_slug=site.slug language_code=sbs_language_code %}" class="text-black block p-2">
-							                        {{ other_language.name }}
-						                        </a>
-					                        </td>
-				                        </tr>
+                                        <tr>
+                                            <td>
+                                                <a href="{% url 'sbs_edit_page' page_id=page.id site_slug=site.slug language_code=sbs_language_code %}" class="text-black block p-2">
+                                                    {{ other_language.name }}
+                                                </a>
+                                            </td>
+                                        </tr>
                                         {% endwith %}
-			                        {% endif %}
-		                        {% endfor %}
-	                        </table>
-	                    </div>
+                                    {% endif %}
+                                {% endfor %}
+                            </table>
+                        </div>
                     {% endif %}
                 </div>
                 <div class="py-2 border-b solid border-grey-lighter mb-2">
@@ -141,6 +156,8 @@
                         </div>
                     </div>
                 </div>
+                {% has_perm 'cms.publish_page' request.user page as can_publish_page %}
+                {% if can_publish_page %}
                 <div class="py-2 border-b solid border-grey-lighter mb-2">
                     <label for="public" class="font-bold">{% trans 'Visibility' %}</label>
                     <div class="relative my-2">
@@ -150,6 +167,7 @@
                         </div>
                     </div>
                 </div>
+                {% endif %}
                 <div class="py-2 border-b solid border-grey-lighter mb-2">
                     <label for="status" class="font-bold">{% trans 'Status' %}</label>
                     <div class="relative my-2">
@@ -184,4 +202,78 @@
         </div>
     </div>
 </form>
+{% endblock %}
+
+{% block javascript %}
+    <script>
+        // event handler for granting edit page permissions
+        u("#grant-edit-page-permission").handle('click', grant_edit_page_permission);
+        // wrapper function for granting edit page permissions
+        async function grant_edit_page_permission(e) {
+            update_page_permission(
+                "{% url 'grant_page_permission_ajax' %}",
+                "{{ page.id }}",
+                u("#id_editors").first().value,
+                'edit'
+            );
+        }
+        // event handler for granting publish page permissions
+        u("#grant-publish-page-permission").handle('click', grant_publish_page_permission);
+        // wrapper function for granting publish page permissions
+        async function grant_publish_page_permission(e) {
+            update_page_permission(
+                "{% url 'grant_page_permission_ajax' %}",
+                "{{ page.id }}",
+                u("#id_publishers").first().value,
+                'publish'
+            );
+        }
+        // event handler for revoking page permissions
+        u('.revoke-page-permission').each(function(node, i)  {
+            u(this).handle('click', revoke_page_permission);
+        });
+        // wrapper function for revoking page permissions
+        async function revoke_page_permission(e) {
+            update_page_permission(
+                "{% url 'revoke_page_permission_ajax' %}",
+                "{{ page.id }}",
+                u(this).data('user-id'),
+                u(this).data('permission')
+            );
+        }
+        // ajax call for updating the page permissions
+        async function update_page_permission(url, page_id, user_id, permission) {
+            const data = await fetch(url, {
+                method: 'POST',
+                headers:  {
+                    'X-CSRFToken': u('[name=csrfmiddlewaretoken]').first().value
+                },
+                body: JSON.stringify({
+                    "page_id": page_id,
+                    "user_id": user_id,
+                    "permission": permission
+                })
+            }).then(res => {
+                if (res.status != 200) {
+                    // return empty result if status is not ok
+                    return '';
+                } else {
+                    // return response text otherwise
+                    return res.text();
+                }
+            });
+            if (data) {
+                // insert response into table
+                u("#page_permission_table").html(data);
+                // set new event listeners
+                u('.revoke-page-permission').each(function(node, i)  {
+                    u(this).handle('click', revoke_page_permission);
+                });
+                u("#grant-edit-page-permission").handle('click', grant_edit_page_permission);
+                u("#grant-publish-page-permission").handle('click', grant_publish_page_permission);
+                feather.replace();
+            }
+
+        }
+    </script>
 {% endblock %}

--- a/backend/cms/templates/users/admin/list.html
+++ b/backend/cms/templates/users/admin/list.html
@@ -20,7 +20,7 @@
     <table class="w-full mt-4 rounded border border-solid border-grey-light shadow bg-white">
         <thead>
             <tr class="border-b border-solid border-grey-light">
-                <th class="text-sm text-left uppercase py-3 pl-4 pr-2">{% trans 'Userame' %}</th>
+                <th class="text-sm text-left uppercase py-3 pl-4 pr-2">{% trans 'Username' %}</th>
                 <th class="text-sm text-left uppercase py-3 px-2">{% trans 'First Name' %}</th>
                 <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Last Name' %}</th>
                 <th class="text-sm text-left uppercase py-3 px-2">{% trans 'E-mail-address' %}</th>

--- a/backend/cms/urls.py
+++ b/backend/cms/urls.py
@@ -119,6 +119,19 @@ urlpatterns = [
         ),
     ])),
 
+    url(r'^ajax/', include([
+        url(
+            r'^grant_page_permission$',
+            pages.grant_page_permission_ajax,
+            name='grant_page_permission_ajax'
+        ),
+        url(
+            r'^revoke_page_permission$',
+            pages.revoke_page_permission_ajax,
+            name='revoke_page_permission_ajax'
+        ),
+    ])),
+
     url(r'^(?P<site_slug>[-\w]+)/', include([
         url(r'^$', general.DashboardView.as_view(), name='dashboard'),
         url(r'^translation_coverage/', analytics.TranslationCoverageView.as_view(), name='translation_coverage'),

--- a/backend/cms/views/general/redirect.py
+++ b/backend/cms/views/general/redirect.py
@@ -10,7 +10,7 @@ from django.shortcuts import redirect
 
 @method_decorator(login_required, name='dispatch')
 class RedirectView(TemplateView):
-    """View class representing the Dashboard
+    """View class representing redirection to correct dashboard
 
     Args:
         TemplateView : View inherits from the django TemplateView class

--- a/backend/cms/views/language_tree/language_tree.py
+++ b/backend/cms/views/language_tree/language_tree.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 from django.shortcuts import render
@@ -9,7 +10,10 @@ from ...decorators import region_permission_required
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(region_permission_required, name='dispatch')
-class LanguageTreeView(TemplateView):
+class LanguageTreeView(PermissionRequiredMixin, TemplateView):
+    permission_required = 'cms.manage_language_tree'
+    raise_exception = True
+
     template_name = 'language_tree/tree.html'
     base_context = {'current_menu_item': 'language_tree'}
 

--- a/backend/cms/views/language_tree/language_tree_node.py
+++ b/backend/cms/views/language_tree/language_tree_node.py
@@ -6,6 +6,7 @@ Returns:
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.utils.translation import ugettext as _
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
@@ -18,7 +19,10 @@ from ...decorators import region_permission_required
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(region_permission_required, name='dispatch')
-class LanguageTreeNodeView(TemplateView):
+class LanguageTreeNodeView(PermissionRequiredMixin, TemplateView):
+    permission_required = 'cms.manage_language_tree'
+    raise_exception = True
+
     template_name = 'language_tree/tree_node.html'
     base_context = {'current_menu_item': 'language_tree'}
 

--- a/backend/cms/views/languages/languages.py
+++ b/backend/cms/views/languages/languages.py
@@ -69,7 +69,7 @@ class LanguageView(PermissionRequiredMixin, TemplateView):
                 messages.success(request, _('Language created successfully'))
             # TODO: improve messages
         else:
-            messages.error(request, _('Es sind Fehler aufgetreten.'))
+            messages.error(request, _('An error has occurred.'))
 
         return render(request, self.template_name, {
             'form': form, **self.base_context})

--- a/backend/cms/views/languages/languages.py
+++ b/backend/cms/views/languages/languages.py
@@ -1,5 +1,6 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
@@ -12,7 +13,10 @@ from ...decorators import staff_required
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(staff_required, name='dispatch')
-class LanguageListView(TemplateView):
+class LanguageListView(PermissionRequiredMixin, TemplateView):
+    permission_required = 'cms.manage_languages'
+    raise_exception = True
+
     template_name = 'languages/list.html'
     base_context = {'current_menu_item': 'languages'}
 
@@ -31,7 +35,10 @@ class LanguageListView(TemplateView):
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(staff_required, name='dispatch')
-class LanguageView(TemplateView):
+class LanguageView(PermissionRequiredMixin, TemplateView):
+    permission_required = 'cms.manage_languages'
+    raise_exception = True
+
     template_name = 'languages/language.html'
     base_context = {'current_menu_item': 'languages'}
     language_code = None

--- a/backend/cms/views/organizations/organizations.py
+++ b/backend/cms/views/organizations/organizations.py
@@ -1,5 +1,6 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
@@ -12,7 +13,10 @@ from ...decorators import staff_required
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(staff_required, name='dispatch')
-class OrganizationListView(TemplateView):
+class OrganizationListView(PermissionRequiredMixin, TemplateView):
+    permission_required = 'cms.manage_organizations'
+    raise_exception = True
+
     template_name = 'organizations/list.html'
     base_context = {'current_menu_item': 'organizations'}
 
@@ -31,7 +35,10 @@ class OrganizationListView(TemplateView):
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(staff_required, name='dispatch')
-class OrganizationView(TemplateView):
+class OrganizationView(PermissionRequiredMixin, TemplateView):
+    permission_required = 'cms.manage_organizations'
+    raise_exception = True
+
     template_name = 'organizations/organization.html'
     base_context = {'current_menu_item': 'organizations'}
 

--- a/backend/cms/views/pages/__init__.py
+++ b/backend/cms/views/pages/__init__.py
@@ -2,6 +2,6 @@
 Python standard Init-File
 """
 from .pages import PageTreeView
-from .page import PageView, archive_page, restore_page, view_page, download_page_xliff, upload_page
+from .page import PageView, archive_page, restore_page, view_page, download_page_xliff, upload_page, grant_page_permission_ajax, revoke_page_permission_ajax
 from .archive import ArchivedPagesView
 from .sbs_page import SBSPageView

--- a/backend/cms/views/pages/pages.py
+++ b/backend/cms/views/pages/pages.py
@@ -1,5 +1,6 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
@@ -11,7 +12,10 @@ from ...decorators import region_permission_required
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(region_permission_required, name='dispatch')
-class PageTreeView(TemplateView):
+class PageTreeView(PermissionRequiredMixin, TemplateView):
+    permission_required = 'cms.view_pages'
+    raise_exception = True
+
     template_name = 'pages/tree.html'
     base_context = {'current_menu_item': 'pages'}
 

--- a/backend/cms/views/push_notifications/push_notifications.py
+++ b/backend/cms/views/push_notifications/push_notifications.py
@@ -1,5 +1,7 @@
+from django.core.exceptions import PermissionDenied
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
@@ -16,7 +18,10 @@ from ...decorators import region_permission_required
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(region_permission_required, name='dispatch')
-class PushNotificationListView(TemplateView):
+class PushNotificationListView(PermissionRequiredMixin, TemplateView):
+    permission_required = 'cms.view_push_notifications'
+    raise_exception = True
+
     template_name = 'push_notifications/list.html'
     base_context = {'current_menu_item': 'push_notifications'}
 
@@ -56,7 +61,9 @@ class PushNotificationListView(TemplateView):
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(region_permission_required, name='dispatch')
-class PushNotificationView(TemplateView):
+class PushNotificationView(PermissionRequiredMixin, TemplateView):
+    permission_required = 'cms.view_push_notifications'
+    raise_exception = True
 
     template_name = 'push_notifications/push_notification.html'
     base_context = {'current_menu_item': 'push_notifications'}
@@ -91,6 +98,14 @@ class PushNotificationView(TemplateView):
         })
 
     def post(self, request, *args, **kwargs):
+
+        if not request.user.has_perm('cms.edit_push_notifications'):
+            raise PermissionDenied
+
+        if 'submit_send' in request.POST:
+            if not request.user.has_perm('cms.send_push_notifications'):
+                raise PermissionDenied
+
         site = Site.objects.get(slug=kwargs.get('site_slug'))
         language = Language.objects.get(code=kwargs.get('language_code'))
 

--- a/backend/cms/views/regions/regions.py
+++ b/backend/cms/views/regions/regions.py
@@ -1,5 +1,6 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
@@ -12,7 +13,10 @@ from ...decorators import staff_required
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(staff_required, name='dispatch')
-class RegionListView(TemplateView):
+class RegionListView(PermissionRequiredMixin, TemplateView):
+    permission_required = 'cms.manage_regions'
+    raise_exception = True
+
     template_name = 'regions/list.html'
     base_context = {'current_menu_item': 'regions'}
 
@@ -31,7 +35,10 @@ class RegionListView(TemplateView):
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(staff_required, name='dispatch')
-class RegionView(TemplateView):
+class RegionView(PermissionRequiredMixin, TemplateView):
+    permission_required = 'cms.manage_regions'
+    raise_exception = True
+
     template_name = 'regions/region.html'
     base_context = {'current_menu_item': 'regions'}
     region_slug = None

--- a/backend/cms/views/roles/roles.py
+++ b/backend/cms/views/roles/roles.py
@@ -1,5 +1,6 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.auth.models import Group as Role
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
@@ -12,7 +13,10 @@ from ...decorators import staff_required
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(staff_required, name='dispatch')
-class RoleListView(TemplateView):
+class RoleListView(PermissionRequiredMixin, TemplateView):
+    permission_required = 'auth.change_group'
+    raise_exception = True
+
     template_name = 'roles/list.html'
     base_context = {'current_menu_item': 'roles'}
 
@@ -31,7 +35,10 @@ class RoleListView(TemplateView):
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(staff_required, name='dispatch')
-class RoleView(TemplateView):
+class RoleView(PermissionRequiredMixin, TemplateView):
+    permission_required = 'auth.change_group'
+    raise_exception = True
+
     template_name = 'roles/role.html'
     base_context = {'current_menu_item': 'roles'}
 

--- a/backend/cms/views/users/region_users.py
+++ b/backend/cms/views/users/region_users.py
@@ -1,6 +1,7 @@
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
@@ -14,7 +15,9 @@ from ...decorators import region_permission_required
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(region_permission_required, name='dispatch')
-class RegionUserListView(TemplateView):
+class RegionUserListView(PermissionRequiredMixin, TemplateView):
+    permission_required = 'cms.change_user'
+    raise_exception = True
 
     template_name = 'users/region/list.html'
     base_context = {'current_menu_item': 'region_users'}
@@ -41,7 +44,9 @@ class RegionUserListView(TemplateView):
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(region_permission_required, name='dispatch')
-class RegionUserView(TemplateView):
+class RegionUserView(PermissionRequiredMixin, TemplateView):
+    permission_required = 'cms.change_user'
+    raise_exception = True
 
     template_name = 'users/region/user.html'
     base_context = {'current_menu_item': 'region_users'}

--- a/backend/cms/views/users/users.py
+++ b/backend/cms/views/users/users.py
@@ -1,6 +1,7 @@
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
@@ -13,7 +14,9 @@ from ...decorators import staff_required
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(staff_required, name='dispatch')
-class UserListView(TemplateView):
+class UserListView(PermissionRequiredMixin, TemplateView):
+    permission_required = 'cms.change_user'
+    raise_exception = True
 
     template_name = 'users/admin/list.html'
     base_context = {'current_menu_item': 'users'}
@@ -33,7 +36,9 @@ class UserListView(TemplateView):
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(staff_required, name='dispatch')
-class UserView(TemplateView):
+class UserView(PermissionRequiredMixin, TemplateView):
+    permission_required = 'cms.change_user'
+    raise_exception = True
 
     template_name = 'users/admin/user.html'
     base_context = {'current_menu_item': 'users'}

--- a/dev-tools/migrate.sh
+++ b/dev-tools/migrate.sh
@@ -2,4 +2,4 @@
 
 docker exec -it $(docker-compose ps -q django) bash -ic "integreat-cms makemigrations cms"
 docker exec -it $(docker-compose ps -q django) bash -ic "integreat-cms migrate"
-
+docker exec -it $(docker-compose ps -q django) bash -ic "integreat-cms loaddata backend/cms/fixtures/roles.json"

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "pycparser==2.19",
         "python-dateutil==2.7.5",
         "pytz==2018.3",
+        "rules==2.0.1",
         "pyxdg==0.26",
         "SecretStorage==2.3.1",
         "six==1.11.0",


### PR DESCRIPTION
### Add rule-based permissions for page instances (fixes #55)
- Add rules package to enable function-based permissions
- Add instance-specific permission rules for pages
- Add rule based permission checks for pages
- Add AJAX-based UI to manage instance-based permission for pages
### Add role fixtures
- Add possibility to populate the database with fixed values
- Add fixture file for user roles
- Apply fixtures on database migrations
#### This is a follow-up PR on #150 (which should be merged before), so the real diff which should be reviewed here is:
https://github.com/Integreat/cms-django/compare/feature/access-control...feature/page-instance-permissions