### PR TITLE
Enable deletion of pages (Resolves #11)

### DIFF
--- a/backend/cms/locale/de/LC_MESSAGES/django.po
+++ b/backend/cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-12 01:33+0200\n"
+"POT-Creation-Date: 2019-10-13 15:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Timo Ludwig <ludwig@integreat-app.de>\n"
 "Language-Team:\n"
@@ -37,15 +37,15 @@ msgstr "Links nach Rechts"
 msgid "Right to left"
 msgstr "Rechts nach Links"
 
-#: models/page.py:157
+#: models/page.py:156
 msgid "Draft"
 msgstr "Entwurf"
 
-#: models/page.py:158
+#: models/page.py:157
 msgid "Pending Review"
 msgstr "Review ausstehend"
 
-#: models/page.py:159
+#: models/page.py:158
 msgid "Finished Review"
 msgstr "Review abgeschlossen"
 
@@ -456,7 +456,7 @@ msgstr "Datum"
 
 #: templates/media/medialist.html:24 templates/pages/archive.html:22
 msgid "Operations"
-msgstr "Optionenen"
+msgstr "Optionen"
 
 #: templates/organizations/list.html:13
 msgid "Create organization"
@@ -578,8 +578,9 @@ msgid "Yes, restore this page now."
 msgstr "Ja, die Seite wiederherstellen."
 
 #: templates/pages/archive.html:53
-#: templates/pages/confirmation_popups/archive_page.html:10
-#: templates/pages/tree_row.html:71 templates/regions/region.html:184
+#: templates/pages/confirmation_popups/archive_page.html:13
+#: templates/pages/confirmation_popups/delete_page.html:13
+#: templates/regions/region.html:184
 #: templates/users/confirmation_popups/delete_region_user.html:12
 #: templates/users/confirmation_popups/delete_user.html:12
 msgid "Cancel"
@@ -589,20 +590,29 @@ msgstr "Abbrechen"
 msgid "No pages available yet."
 msgstr "Noch keine Seiten vorhanden."
 
-#: templates/pages/confirmation_popups/archive_page.html:4
-#: templates/pages/tree_row.html:63
+#: templates/pages/confirmation_popups/archive_page.html:5
 msgid "Please confirm that you really want to archive this page"
 msgstr "Bitte bestätigen Sie, dass diese Seite archiviert werden soll."
 
-#: templates/pages/confirmation_popups/archive_page.html:6
-#: templates/pages/tree_row.html:65
+#: templates/pages/confirmation_popups/archive_page.html:7
 msgid "All translations of this page will also be archived."
 msgstr "Es werden auch alle Übersetzungen dieser Seite archiviert."
 
-#: templates/pages/confirmation_popups/archive_page.html:8
-#: templates/pages/tree_row.html:69
+#: templates/pages/confirmation_popups/archive_page.html:11
 msgid "Yes, archive this page now."
 msgstr "Ja, diese Seite jetzt archivieren"
+
+#: templates/pages/confirmation_popups/delete_page.html:5
+msgid "Please confirm that you really want to delete this page"
+msgstr "Bitte bestätigen Sie, dass diese Seite gelöscht werden soll"
+
+#: templates/pages/confirmation_popups/delete_page.html:7
+msgid "All translations of this page will also be deleted."
+msgstr "Alle Übersetzungen dieser Seite werden gelöscht."
+
+#: templates/pages/confirmation_popups/delete_page.html:11
+msgid "Yes, delete this page now."
+msgstr "Ja, die Seite jetzt löschen."
 
 #: templates/pages/page.html:16
 #, python-format
@@ -715,23 +725,37 @@ msgstr "Status"
 msgid "Icon"
 msgstr "Icon"
 
-#: templates/pages/page.html:190 templates/pages/tree_row.html:51
+#: templates/pages/page.html:191 templates/pages/tree_row.html:48
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: templates/pages/page.html:192
+#: templates/pages/page.html:193
 msgid "Page is archived."
 msgstr "Die Seite wurde archiviert."
 
-#: templates/pages/page.html:195
+#: templates/pages/page.html:196
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
+
+#: templates/pages/page.html:202 templates/pages/tree_row.html:57
+msgid "Delete page"
+msgstr "Seite löschen"
+
+#: templates/pages/page.html:204 templates/pages/tree_row.html:53
+#: views/pages/page.py:215
+msgid "You cannot delete a page which has children."
+msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
+
+#: templates/pages/page.html:207
+msgid "Delete this page"
+msgstr "Diese Seite löschen"
 
 #: templates/pages/sbs_page.html:11
 #, python-format
 msgid ""
 "Translate \"%(page_title)s\" from %(source_language)s to %(target_language)s"
 msgstr ""
+"Übersetze \"%(page_title)s\" von %(source_language)s nach %(target_language)s"
 
 #: templates/pages/sbs_page.html:40
 msgid "Go Back to Page Editor"
@@ -769,11 +793,7 @@ msgstr "Seite ansehen"
 msgid "Edit page"
 msgstr "Seite bearbeiten"
 
-#: templates/pages/tree_row.html:47
-msgid "Delete page"
-msgstr "Gelöschte Seite"
-
-#: templates/pages/tree_row.html:56
+#: templates/pages/tree_row.html:63
 msgid "Download page"
 msgstr "Seite herunterladen"
 
@@ -1377,7 +1397,7 @@ msgstr "Extra-Vorlage wurde erfolgreich erstellt."
 
 #: views/extra_templates/extra_templates.py:74
 #: views/language_tree/language_tree_node.py:70
-#: views/organizations/organizations.py:72 views/pages/page.py:142
+#: views/organizations/organizations.py:72 views/pages/page.py:139
 #: views/pages/sbs_page.py:109 views/pois/poi.py:122
 #: views/push_notifications/push_notifications.py:171
 #: views/regions/regions.py:78 views/roles/roles.py:71
@@ -1433,60 +1453,64 @@ msgstr "Organisation wurde erfolgreich erstellt."
 msgid "Organization saved successfully"
 msgstr "Organisation wurde erfolgreich gespeichert."
 
-#: views/pages/page.py:117 views/pages/page.py:166
-msgid "Page was successfully archived."
-msgstr "Seite wurde erfolgreich archiviert."
-
-#: views/pages/page.py:120
+#: views/pages/page.py:117
 msgid "Page was successfully created and published."
 msgstr "Seite wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/pages/page.py:122
+#: views/pages/page.py:119
 msgid "Page was successfully created."
 msgstr "Seite wurde erfolgreich erstellt."
 
-#: views/pages/page.py:125
+#: views/pages/page.py:122
 msgid "Translation was successfully created and published."
 msgstr "Übersetzung wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/pages/page.py:127 views/pages/sbs_page.py:103
+#: views/pages/page.py:124 views/pages/sbs_page.py:103
 msgid "Translation was successfully created."
 msgstr "Übersetzung wurde erfolgreich erstellt."
 
-#: views/pages/page.py:130
+#: views/pages/page.py:127
 msgid "Translation was successfully published."
 msgstr "Übersetzung wurde erfolgreich veröffentlich."
 
-#: views/pages/page.py:132 views/pages/sbs_page.py:105
+#: views/pages/page.py:129 views/pages/sbs_page.py:105
 msgid "Translation was successfully saved."
 msgstr "Übersetzung wurde erfolgreich gespeichert."
 
-#: views/pages/page.py:134 views/pages/sbs_page.py:107 views/pois/poi.py:114
+#: views/pages/page.py:131 views/pages/sbs_page.py:107 views/pois/poi.py:114
 #: views/regions/regions.py:89 views/users/region_users.py:113
 #: views/users/users.py:89
 msgid "No changes detected."
 msgstr "Keine Änderungen vorgenommen."
 
-#: views/pages/page.py:185
+#: views/pages/page.py:163
+msgid "Page was successfully archived."
+msgstr "Seite wurde erfolgreich archiviert."
+
+#: views/pages/page.py:182
 msgid "Page was successfully restored."
 msgstr "Seite wurde erfolgreich wiederhergestellt."
 
-#: views/pages/page.py:301 views/pages/page.py:316
+#: views/pages/page.py:218
+msgid "Page was successfully deleted."
+msgstr "Seite wurde erfolgreich gelöscht."
+
+#: views/pages/page.py:316 views/pages/page.py:331
 #, python-brace-format
 msgid "Information: The user {user} has this permission already."
 msgstr "Information: Der Nutzer {user} hat diese Berechtigung bereits"
 
-#: views/pages/page.py:309
+#: views/pages/page.py:324
 #, python-brace-format
 msgid "Success: The user {user} can now edit this page."
 msgstr "Erfolg: Der Nutzer {user} kann nun diese Seite bearbeiten"
 
-#: views/pages/page.py:324
+#: views/pages/page.py:339
 #, python-brace-format
 msgid "Success: The user {user} can now publish this page."
 msgstr "Erfolg: Der Nutzer {user} kann dieses Seite nurn veröffentlichen"
 
-#: views/pages/page.py:391
+#: views/pages/page.py:406
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the editors of this page, "
@@ -1496,12 +1520,12 @@ msgstr ""
 "bearbeiten wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin veröffentlichen"
 
-#: views/pages/page.py:397
+#: views/pages/page.py:412
 #, python-brace-format
 msgid "Success: The user {user} cannot edit this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr bearbeiten"
 
-#: views/pages/page.py:408
+#: views/pages/page.py:423
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the publishers of this "
@@ -1511,7 +1535,7 @@ msgstr ""
 "veröffentlichen wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin veröffentlichen"
 
-#: views/pages/page.py:414
+#: views/pages/page.py:429
 #, python-brace-format
 msgid "Success: The user {user} cannot publish this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr veröffentlichen"
@@ -1684,6 +1708,9 @@ msgstr "Linker Nachbar von"
 #: views/utils/tree_utils.py:8
 msgid "Right neighbor of"
 msgstr "Rechter Nachbar von"
+
+#~ msgid "Deleted page"
+#~ msgstr "Gelöschte Seite"
 
 #~ msgid "Edit language \"%(form.instance.translated_name)s\""
 #~ msgstr "Sprache \"%(form.instance.translated_name)s\" bearbeiten"

--- a/backend/cms/templates/pages/confirmation_popups/archive_page.html
+++ b/backend/cms/templates/pages/confirmation_popups/archive_page.html
@@ -1,13 +1,18 @@
 {% load i18n %}
-<div id="confirm_archive_page" class="confirmation-popup flex-col justify-center max-w-sm fixed pin-t pin-b pin-r pin-l hidden">
+<!-- confirmation popup for archiving page with id {{ page.id }}-->
+<div id="confirm_archive_page_{{ page.id }}" class="confirmation-popup flex-col justify-center max-w-sm fixed pin-t pin-b pin-r pin-l hidden">
 	<div class="content bg-grey-light w-full p-4 shadow-md rounded">
 		<h2>{% trans 'Please confirm that you really want to archive this page' %}</h2>
 		<p class="mt-4 mb-6">
-            {% trans 'All translations of this page will also be archived.' %}
+			{% trans 'All translations of this page will also be archived.' %}
 		</p>
-		<input type="submit" name="submit_archive" class="cursor-pointer bg-blue hover:bg-blue-dark text-white font-bold py-3 px-4 rounded" value="{% trans 'Yes, archive this page now.' %}" />
-		<button class="cursor-pointer bg-red hover:bg-red-dark text-white font-bold py-3 px-4 rounded" onclick="close_confirmation_popup(event)">
-			{% trans 'Cancel' %}
-		</button>
+		<form method="post" action="{% url 'archive_page' page_id=page.id region_slug=region.slug language_code=language.code %}">
+			{% csrf_token %}
+			<input type="submit" class="inline-block cursor-pointer bg-blue hover:bg-blue-dark text-white font-bold py-3 px-4 rounded" value="{% trans 'Yes, archive this page now.' %}" />
+			<button class="cursor-pointer bg-red hover:bg-red-dark text-white font-bold py-3 px-4 rounded" onclick="close_confirmation_popup(event)">
+				{% trans 'Cancel' %}
+			</button>
+		</form>
 	</div>
 </div>
+<!------------------------>

--- a/backend/cms/templates/pages/confirmation_popups/delete_page.html
+++ b/backend/cms/templates/pages/confirmation_popups/delete_page.html
@@ -1,0 +1,18 @@
+{% load i18n %}
+<!-- confirmation popup for deleting page with id {{ page.id }}-->
+<div id="confirm_delete_page_{{ page.id }}" class="confirmation-popup flex-col justify-center max-w-sm fixed pin-t pin-b pin-r pin-l hidden">
+	<div class="content bg-grey-light w-full p-4 shadow-md rounded">
+		<h2>{% trans 'Please confirm that you really want to delete this page' %}</h2>
+		<p class="mt-4 mb-6">
+			{% trans 'All translations of this page will also be deleted.' %}
+		</p>
+		<form method="post" action="{% url 'delete_page' page_id=page.id region_slug=region.slug language_code=language.code %}">
+			{% csrf_token %}
+			<input type="submit" class="inline-block cursor-pointer bg-red hover:bg-red-dark text-white font-bold py-3 px-4 rounded" value="{% trans 'Yes, delete this page now.' %}" />
+			<button class="cursor-pointer bg-blue hover:bg-blue-dark text-white font-bold py-3 px-4 rounded" onclick="close_confirmation_popup(event)">
+				{% trans 'Cancel' %}
+			</button>
+		</form>
+	</div>
+</div>
+<!------------------------>

--- a/backend/cms/templates/pages/page.html
+++ b/backend/cms/templates/pages/page.html
@@ -186,22 +186,42 @@
                         <span class="filename"></span>
                     </label>
                 </div>
-                <div class="pt-2 pb-4">
-                    <span class="block font-bold mb-4">{% trans 'Archive page' %}</span>
-                    {% if page.archived %}
-                        {% trans 'Page is archived.' %}
-                    {% else %}
-                        <button class="bg-blue hover:bg-blue-dark text-white font-bold py-2 px-4 rounded" onclick="confirmation_popup(event, '#confirm_archive_page')">
-                            {% trans 'Archive this page' %}
-                        </button>
-                    {% endif %}
-
-                    {% include "./confirmation_popups/archive_page.html" %}
-                </div>
+	            {% if page %}
+	                <div class="pt-2 pb-4">
+	                    <span class="block font-bold mb-4">{% trans 'Archive page' %}</span>
+	                    {% if page.archived %}
+	                        {% trans 'Page is archived.' %}
+	                    {% else %}
+	                        <button class="bg-blue hover:bg-blue-dark text-white font-bold py-2 px-4 rounded" onclick="confirmation_popup(event, '#confirm_archive_page_{{ page.id }}')">
+	                            {% trans 'Archive this page' %}
+	                        </button>
+	                    {% endif %}
+	                </div>
+		            {% if user.is_superuser or user.is_staff %}
+				        <div class="pt-2 pb-4">
+			                <span class="block font-bold mb-4">{% trans 'Delete page' %}</span>
+					        {% if page.children.all %}
+						        {% trans 'You cannot delete a page which has children.' %}
+					        {% else %}
+				                <button class="bg-red hover:bg-red-dark text-white font-bold py-2 px-4 rounded" onclick="confirmation_popup(event, '#confirm_delete_page_{{ page.id }}')">
+					                {% trans 'Delete this page' %}
+				                </button>
+					        {% endif %}
+		                </div>
+		            {% endif %}
+	            {% endif %}
             </div>
         </div>
     </div>
 </form>
+{% if page %}
+	{% include "./confirmation_popups/archive_page.html" with page=page %}
+	{% if user.is_superuser or user.is_staff %}
+		{% if not page.children.all %}
+			{% include "./confirmation_popups/delete_page.html" with page=page %}
+		{% endif %}
+	{% endif %}
+{% endif %}
 {% endblock %}
 
 {% block javascript %}

--- a/backend/cms/templates/pages/tree_row.html
+++ b/backend/cms/templates/pages/tree_row.html
@@ -44,35 +44,30 @@
         <a href="{% url 'edit_page' page_id=node.id region_slug=region.slug language_code=language.code %}" title="{% trans 'Edit page' %}" class="py-3" style="padding-left:4px;padding-right:4px;">
             <i data-feather="edit" class="text-grey-darkest"></i>
         </a>
-        <a href="{% url 'delete_page' page_id=node.id region_slug=region.slug language_code=language.code %}" title="{% trans 'Delete page' %}" class="py-3" style="padding-left:4px;padding-right:4px;">
-            <i data-feather="trash-2" class="text-grey-darkest"></i>
-        </a>
 
-        <button title="{% trans 'Archive page' %}" class="py-3" style="padding-left:4px;" onclick="confirmation_popup(event, '#confirm_archive_page{{ node.id }}')">
-            <i data-feather="archive" class="text-grey-darkest"></i>
-        </button>
-
+	    <button title="{% trans 'Archive page' %}" class="py-3" style="padding-left:4px;" onclick="confirmation_popup(event, '#confirm_archive_page_{{ node.id }}')">
+		    <i data-feather="archive" class="text-grey-darkest"></i>
+	    </button>
+	    {% if user.is_superuser or user.is_staff %}
+	        {% if node.children.all %}
+		        <button title="{% trans 'You cannot delete a page which has children.' %}" class="py-3" style="padding-left:4px;">
+			        <i data-feather="trash-2" class="text-grey"></i>
+		        </button>
+	        {% else %}
+		        <button title="{% trans 'Delete page' %}" class="py-3" style="padding-left:4px;" onclick="confirmation_popup(event, '#confirm_delete_page_{{ node.id }}')">
+			        <i data-feather="trash-2" class="text-grey-darkest"></i>
+		        </button>
+	        {% endif %}
+		{% endif %}
         <a href="{% url 'download_page' page_id=node.id region_slug=region.slug language_code=language.code %}"
            title="{% trans 'Download page' %}" class="py-3" style="padding-left:4px;padding-right:4px;">
              <i data-feather="download" class="text-grey-darkest"></i>
         </a>
-
-        <!-- confirmation popup -->
-        <div id="confirm_archive_page{{ node.id }}" class="confirmation-popup flex-col justify-center max-w-sm fixed pin-t pin-b pin-r pin-l hidden">
-            <div class="content bg-grey-light w-full p-4 shadow-md rounded">
-                <h2>{% trans 'Please confirm that you really want to archive this page' %}</h2>
-                <p class="mt-4 mb-6">
-                    {% trans 'All translations of this page will also be archived.' %}
-                </p>
-                <form method="post" action="{% url 'archive_page' page_id=node.id region_slug=region.slug language_code=language.code %}">
-                    {% csrf_token %}
-                    <input type="submit" class="inline-block cursor-pointer bg-blue hover:bg-blue-dark text-white font-bold py-3 px-4 rounded" value="{% trans 'Yes, archive this page now.' %}" />
-                    <button class="cursor-pointer bg-red hover:bg-red-dark text-white font-bold py-3 px-4 rounded" onclick="close_confirmation_popup(event)">
-                        {% trans 'Cancel' %}
-                    </button>
-                </form>
-            </div>
-        </div>
-        <!------------------------>
     </td>
 </tr>
+{% include "./confirmation_popups/archive_page.html" with page=node %}
+{% if user.is_superuser or user.is_staff %}
+	{% if not node.children.all %}
+		{% include "./confirmation_popups/delete_page.html" with page=node %}
+	{% endif %}
+{% endif %}

--- a/backend/cms/urls.py
+++ b/backend/cms/urls.py
@@ -201,7 +201,7 @@ urlpatterns = [
                     ),
                     url(
                         r'^delete$',
-                        pages.PageView.as_view(),
+                        pages.delete_page,
                         name='delete_page'
                     ),
                     url(

--- a/backend/cms/views/pages/__init__.py
+++ b/backend/cms/views/pages/__init__.py
@@ -2,6 +2,15 @@
 Python standard Init-File
 """
 from .pages import PageTreeView
-from .page import PageView, archive_page, restore_page, view_page, download_page_xliff, upload_page, grant_page_permission_ajax, revoke_page_permission_ajax
+from .page import (
+    PageView,
+    archive_page,
+    restore_page,
+    view_page, delete_page,
+    download_page_xliff,
+    upload_page,
+    grant_page_permission_ajax,
+    revoke_page_permission_ajax
+)
 from .archive import ArchivedPagesView
 from .sbs_page import SBSPageView

--- a/backend/cms/views/pages/page.py
+++ b/backend/cms/views/pages/page.py
@@ -23,7 +23,7 @@ from django.views.static import serve
 from .page_form import PageForm, PageTranslationForm
 from ...models import Page, PageTranslation, Region, Language
 from ...page_xliff_converter import PageXliffHelper, XLIFFS_DIR
-from ...decorators import region_permission_required
+from ...decorators import region_permission_required, staff_required
 
 
 logger = logging.getLogger(__name__)
@@ -112,10 +112,7 @@ class PageView(PermissionRequiredMixin, TemplateView):
 
             if page_form.has_changed() or page_translation_form.has_changed():
                 published = page_translation.public and 'public' in page_translation_form.changed_data
-                if page_form.data.get('submit_archive'):
-                    # archive button has been submitted
-                    messages.success(request, _('Page was successfully archived.'))
-                elif not page_instance:
+                if not page_instance:
                     if published:
                         messages.success(request, _('Page was successfully created and published.'))
                     else:
@@ -206,6 +203,24 @@ def view_page(request, page_id, region_slug, language_code):
             "page_translation": page_translation
         }
     )
+
+
+@login_required
+@staff_required
+def delete_page(request, page_id, region_slug, language_code):
+
+    page = Page.objects.get(id=page_id)
+
+    if page.children.exists():
+        messages.error(request, _('You cannot delete a page which has children.'))
+    else:
+        page.delete()
+        messages.success(request, _('Page was successfully deleted.'))
+
+    return redirect('pages', **{
+        'region_slug': region_slug,
+        'language_code': language_code,
+    })
 
 
 @login_required

--- a/backend/cms/views/pages/page_form.py
+++ b/backend/cms/views/pages/page_form.py
@@ -224,7 +224,8 @@ class PageTranslationForm(forms.ModelForm):
         return page_translation
 
     def clean_slug(self):
-        existing_version = PageTranslation.objects.filter(language=self.language, page=self.instance.page)
-        if existing_version:
-            return existing_version.first().slug
+        if self.instance.id:
+            existing_version = PageTranslation.objects.filter(language=self.language, page=self.instance.page)
+            if existing_version:
+                return existing_version.first().slug
         return generate_unique_slug(self, 'page')


### PR DESCRIPTION
- Enables the deletion of pages for superusers and staff members for debugging and administrative tasks (region admins can only archive a page)
- Repairs the broken archive page functionality