### PR TITLE
Change pages tree view class to table-auto

### DIFF
--- a/backend/cms/templates/pages/tree.html
+++ b/backend/cms/templates/pages/tree.html
@@ -49,14 +49,14 @@
 </div>
 
 <div class="table-listing">
-    <table class="w-full mt-4 rounded border border-solid border-grey-light shadow bg-white table-fixed">
+    <table class="w-full mt-4 rounded border border-solid border-grey-light shadow bg-white table-auto">
         <thead>
             <tr class="border-b border-solid border-grey-light">
-                <th class="text-sm text-left uppercase py-3 pl-2 pr-4" style="width: 100px;"></th>
-                <th class="text-sm text-left uppercase py-3" style="width: 50px;">{% trans 'ID' %}</th>
+                <th class="text-sm text-left uppercase py-3 pl-2 pr-4"></th>
+                <th class="text-sm text-left uppercase py-3 pl-4">{% trans 'ID' %}</th>
                 <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title' %}</th>
-                <th class="text-sm text-left uppercase py-3 px-2" style="width: 200px;">
-                    <div class="lang-grid flags" style="white-space: nowrap;">
+                <th class="text-sm text-left uppercase py-3 px-2">
+                    <div class="lang-grid flags whitespace-no-wrap">
 	                    {% for lang in languages %}
 		                    <a href="{% url 'pages' region_slug=region.slug language_code=lang.code %}">
 			                    <img src="{% static '' %}images/flags/{{ lang.code }}.png" title="{{ lang.name }}" />
@@ -64,10 +64,10 @@
 	                    {% endfor %}
                     </div>
                 </th>
-                <th class="text-sm text-left uppercase py-3" style="width: 250px;">{% trans 'Creator' %}</th>
-                <th class="text-sm text-left uppercase py-3" style="width: 200px;">{% trans 'Last updated' %}</th>
-                <th class="text-sm text-left uppercase py-3" style="width: 200px;">{% trans 'Created' %}</th>
-                <th class="text-sm text-left uppercase py-3 pl-2 pr-4" style="width: 200px;">{% trans 'Options' %}</th>
+                <th class="text-sm text-left uppercase py-3">{% trans 'Creator' %}</th>
+                <th class="text-sm text-left uppercase py-3">{% trans 'Last updated' %}</th>
+                <th class="text-sm text-left uppercase py-3">{% trans 'Created' %}</th>
+                <th class="text-sm text-left uppercase py-3 pl-2 pr-4">{% trans 'Options' %}</th>
             </tr>
         </thead>
         <tbody>

--- a/backend/cms/templates/pages/tree_row.html
+++ b/backend/cms/templates/pages/tree_row.html
@@ -6,7 +6,7 @@
             <i data-feather="move" class="text-grey-darkest"></i>
         </span>
     </td>
-    <td>
+    <td class="pl-4">
         {{ node.id }}
     </td>
     <td>
@@ -14,7 +14,7 @@
             {{ node|page_translation_title:language }}
         </a>
     </td>
-    <td>
+    <td class="whitespace-no-wrap">
         <div class="block py-3 px-2 text-grey-darkest">
             <div class="lang-grid">
 	            {% for other_language in languages %}
@@ -34,7 +34,7 @@
     <td>
         {{ node|page_translation_created_date:language }}
     </td>
-    <td class="pl-2 pr-4" width="180">
+    <td class="pl-2 pr-4">
         <!-- TODO: add link to view page in web app -->
         <a href="{% url 'view_page' page_id=node.id region_slug=region.slug language_code=language.code %}"
            target="_blank"


### PR DESCRIPTION
I realized that the table for pages in UI is having edit buttons overlap with title

## Before
<img width="1161" alt="Screen Shot 2019-10-14 at 12 46 05 AM" src="https://user-images.githubusercontent.com/5971942/66718967-66a38c00-ee1c-11e9-994c-00ff54033db1.png">


## After
<img width="1136" alt="Screen Shot 2019-10-14 at 12 42 49 AM" src="https://user-images.githubusercontent.com/5971942/66718963-5d1a2400-ee1c-11e9-8108-28f1063eacf5.png">