### PR TITLE
Separate page and translation attributes in page form (fixes #154)

### DIFF
--- a/backend/cms/locale/de/LC_MESSAGES/django.po
+++ b/backend/cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-13 15:37+0200\n"
+"POT-Creation-Date: 2019-10-17 22:22+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Timo Ludwig <ludwig@integreat-app.de>\n"
 "Language-Team:\n"
@@ -359,8 +359,7 @@ msgid "Create language tree node"
 msgstr "Sprach-Knoten hinzufügen"
 
 #: templates/language_tree/tree.html:30
-#: templates/language_tree/tree_node.html:28 templates/pages/page.html:96
-#: templates/pois/poi.html:87
+#: templates/language_tree/tree_node.html:28 templates/pois/poi.html:87
 #: templates/push_notifications/push_notification.html:62
 msgid "Language"
 msgstr "Sprache"
@@ -508,7 +507,7 @@ msgstr "Thumbnail der Organisation"
 msgid "Enter the organization's thumbnail here"
 msgstr "Name der Organisations-Thumbnail hier eingeben"
 
-#: templates/organizations/organization.html:66 templates/pages/page.html:185
+#: templates/organizations/organization.html:66 templates/pages/page.html:170
 #: templates/pois/poi.html:130 templates/regions/region.html:78
 msgid "Set icon"
 msgstr "Icon festlegen"
@@ -517,32 +516,32 @@ msgstr "Icon festlegen"
 msgid "Editors"
 msgstr "Bearbeiter"
 
-#: templates/pages/_page_permission_table.html:31
+#: templates/pages/_page_permission_table.html:30
 msgid "These users can edit this page, but are not allowed to publish it."
 msgstr ""
 "Diese Benutzer können die Seite bearbeiten, aber nicht veröffentlichen."
 
-#: templates/pages/_page_permission_table.html:48
-#: templates/pages/_page_permission_table.html:83
+#: templates/pages/_page_permission_table.html:46
+#: templates/pages/_page_permission_table.html:77
 #: templates/registration/login.html:26 templates/registration/login.html:28
 #: templates/users/admin/list.html:23 templates/users/admin/user.html:36
 #: templates/users/region/list.html:23 templates/users/region/user.html:36
 msgid "Username"
 msgstr "Benutzername"
 
-#: templates/pages/_page_permission_table.html:57
+#: templates/pages/_page_permission_table.html:55
 msgid "Add to editors"
 msgstr "Zu Bearbeitern hinzufügen"
 
-#: templates/pages/_page_permission_table.html:64
+#: templates/pages/_page_permission_table.html:60
 msgid "Publishers"
 msgstr "Veröffentlicher"
 
-#: templates/pages/_page_permission_table.html:66
+#: templates/pages/_page_permission_table.html:61
 msgid "These users can edit and publish this page."
 msgstr "Diese Benutzer können die Seite bearbeiten und veröffentlichen"
 
-#: templates/pages/_page_permission_table.html:92
+#: templates/pages/_page_permission_table.html:86
 msgid "Add to publishers"
 msgstr "Erlaubnis zum Veröffentlichen erteilen"
 
@@ -550,7 +549,7 @@ msgstr "Erlaubnis zum Veröffentlichen erteilen"
 msgid "Archived Pages"
 msgstr "Archivierte Seiten"
 
-#: templates/pages/archive.html:21 templates/pages/page.html:43
+#: templates/pages/archive.html:21 templates/pages/page.html:90
 #: templates/pages/tree.html:57 templates/pois/list.html:32
 #: templates/pois/poi.html:36 templates/push_notifications/list.html:24
 #: templates/push_notifications/push_notification.html:49
@@ -627,57 +626,82 @@ msgstr "Neue Übersetzung erstellen"
 msgid "Create new page"
 msgstr "Neue Seite erstellen"
 
-#: templates/pages/page.html:44 templates/pages/sbs_page.html:30
-#: templates/pois/poi.html:37
-msgid "Insert title here"
-msgstr "Titel hier eingeben"
+#: templates/pages/page.html:69
+msgid "Side by side view"
+msgstr "Übersetzungen nebeneinander anzeigen"
 
-#: templates/pages/page.html:47
-#: templates/push_notifications/push_notification.html:54
-msgid "Content"
-msgstr "Inhalt"
-
-#: templates/pages/page.html:48 templates/pages/sbs_page.html:33
-msgid "Insert content here"
-msgstr "Inhalt hier eingeben"
-
-#: templates/pages/page.html:53 templates/pois/poi.html:70
+#: templates/pages/page.html:77 templates/pois/poi.html:70
 #: templates/regions/region.html:40
 msgid "Permalink"
 msgstr ""
 
-#: templates/pages/page.html:55 templates/pois/poi.html:72
+#: templates/pages/page.html:79 templates/pois/poi.html:72
 #: templates/regions/region.html:42
 msgid " Leave blank to generate unique permalink from title"
 msgstr ""
 " Dieses Feld freilassen, um eine eindeutigen Permalink aus dem Titel zu "
 "generieren"
 
-#: templates/pages/page.html:67
+#: templates/pages/page.html:91 templates/pages/sbs_page.html:30
+#: templates/pois/poi.html:37
+msgid "Insert title here"
+msgstr "Titel hier eingeben"
+
+#: templates/pages/page.html:93
+#: templates/push_notifications/push_notification.html:54
+msgid "Content"
+msgstr "Inhalt"
+
+#: templates/pages/page.html:94 templates/pages/sbs_page.html:33
+msgid "Insert content here"
+msgstr "Inhalt hier eingeben"
+
+#: templates/pages/page.html:98 templates/pois/poi.html:117
+#: templates/regions/list.html:28 templates/regions/region.html:85
+msgid "Status"
+msgstr "Status"
+
+#: templates/pages/page.html:116
+msgid "Settings for all translations"
+msgstr "Einstellungen für alle Übersetzungen"
+
+#: templates/pages/page.html:126
+msgid "Visibility"
+msgstr "Sichtbarkeit"
+
+#: templates/pages/page.html:134
+msgid "Positioning"
+msgstr "Anordnung"
+
+#: templates/pages/page.html:135
+msgid "Relationship"
+msgstr "Verhältnis"
+
+#: templates/pages/page.html:139
+msgid "Page"
+msgstr "Seite"
+
+#: templates/pages/page.html:146
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: templates/pages/page.html:69
+#: templates/pages/page.html:148
 msgid "Search page"
 msgstr "Seite suchen"
 
-#: templates/pages/page.html:72
+#: templates/pages/page.html:151
 msgid "Embed before content"
 msgstr "Vor Inhalt einbinden"
 
-#: templates/pages/page.html:73
+#: templates/pages/page.html:152
 msgid "Embed after content"
 msgstr "Nach Inhalt einbinden"
 
-#: templates/pages/page.html:80
-msgid "Embed page"
-msgstr "Seite einbinden"
-
-#: templates/pages/page.html:85
+#: templates/pages/page.html:159
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: templates/pages/page.html:86
+#: templates/pages/page.html:160
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -685,68 +709,33 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: templates/pages/page.html:97 templates/pois/poi.html:88
-#: templates/push_notifications/push_notification.html:63
-msgid "Current language"
-msgstr "Aktuelle Sprache"
-
-#: templates/pages/page.html:103 templates/pois/poi.html:94
-#: templates/push_notifications/push_notification.html:70
-msgid "Translations"
-msgstr "Übersetzungen"
-
-#: templates/pages/page.html:125
-msgid "Side by Side View"
-msgstr "Übersetzungen nebeneinander anzeigen"
-
-#: templates/pages/page.html:146
-msgid "Positioning"
-msgstr "Anordnung"
-
-#: templates/pages/page.html:147
-msgid "Relationship"
-msgstr "Verhältnis"
-
-#: templates/pages/page.html:151
-msgid "Page"
-msgstr "Seite"
-
-#: templates/pages/page.html:162
-msgid "Visibility"
-msgstr "Sichtbarkeit"
-
-#: templates/pages/page.html:172 templates/pois/poi.html:117
-#: templates/regions/list.html:28 templates/regions/region.html:85
-msgid "Status"
-msgstr "Status"
-
-#: templates/pages/page.html:181 templates/pois/poi.html:126
+#: templates/pages/page.html:166 templates/pois/poi.html:126
 #: templates/regions/region.html:68
 msgid "Icon"
 msgstr "Icon"
 
-#: templates/pages/page.html:191 templates/pages/tree_row.html:48
+#: templates/pages/page.html:176 templates/pages/tree_row.html:48
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: templates/pages/page.html:193
+#: templates/pages/page.html:178
 msgid "Page is archived."
 msgstr "Die Seite wurde archiviert."
 
-#: templates/pages/page.html:196
+#: templates/pages/page.html:181
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: templates/pages/page.html:202 templates/pages/tree_row.html:57
+#: templates/pages/page.html:187 templates/pages/tree_row.html:57
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: templates/pages/page.html:204 templates/pages/tree_row.html:53
+#: templates/pages/page.html:189 templates/pages/tree_row.html:53
 #: views/pages/page.py:215
 msgid "You cannot delete a page which has children."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: templates/pages/page.html:207
+#: templates/pages/page.html:192
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
@@ -881,6 +870,16 @@ msgstr "Geographische Breite"
 #: templates/pois/poi.html:66
 msgid "Insert latitude here"
 msgstr "Geographische Breite hier eingeben"
+
+#: templates/pois/poi.html:88
+#: templates/push_notifications/push_notification.html:63
+msgid "Current language"
+msgstr "Aktuelle Sprache"
+
+#: templates/pois/poi.html:94
+#: templates/push_notifications/push_notification.html:70
+msgid "Translations"
+msgstr "Übersetzungen"
 
 #: templates/push_notifications/list.html:13
 msgid "Create push notification"
@@ -1709,6 +1708,15 @@ msgstr "Linker Nachbar von"
 msgid "Right neighbor of"
 msgstr "Rechter Nachbar von"
 
+#~ msgid "Translation"
+#~ msgstr "Übersetzung"
+
+#~ msgid "Embed page"
+#~ msgstr "Seite einbinden"
+
+#~ msgid "Settings for this language"
+#~ msgstr "Einstellungen für diese Sprache"
+
 #~ msgid "Deleted page"
 #~ msgstr "Gelöschte Seite"
 
@@ -1737,9 +1745,6 @@ msgstr "Rechter Nachbar von"
 
 #~ msgid "Grant permission"
 #~ msgstr "Berechtigung erteilen"
-
-#~ msgid "Edit all translations"
-#~ msgstr "Alle Übersetzungen bearbeiten"
 
 #~ msgid "Publish all translations"
 #~ msgstr "Alle Übersetzungen veröffentlichen"

--- a/backend/cms/models/region.py
+++ b/backend/cms/models/region.py
@@ -56,7 +56,8 @@ class Region(models.Model):
 
     @classmethod
     def get_current_region(cls, request):
-        if not hasattr(request, 'resolver_match'):
+        # if rendered url is edit_region, the region slug originates from the region form.
+        if not hasattr(request, 'resolver_match') or request.resolver_match.url_name == 'edit_region':
             return None
         region_slug = request.resolver_match.kwargs.get('region_slug')
         if not region_slug:

--- a/backend/cms/templates/pages/_page_permission_table.html
+++ b/backend/cms/templates/pages/_page_permission_table.html
@@ -4,30 +4,29 @@
 {% load i18n %}
     {% if permission_message %}
         {% if permission_message.level_tag == 'info' %}
-            <div class="bg-blue-lightest border-l-4 border-blue text-blue-dark px-4 py-3 mb-5" role="alert">
+            <div class="bg-blue-lightest border-l-4 border-blue text-blue-dark px-4 py-3 my-2" role="alert">
                 <p>{{permission_message.message}}</p>
             </div>
         {% endif %}
         {% if permission_message.level_tag == 'success' %}
-            <div class="bg-green-lightest border-l-4 border-green text-green-dark px-4 py-3 mb-5" role="alert">
+            <div class="bg-green-lightest border-l-4 border-green text-green-dark px-4 py-3 my-2" role="alert">
                 <p>{{ permission_message.message }}</p>
             </div>
         {% endif %}
         {% if permission_message.level_tag == 'warning' %}
-            <div class="bg-orange-lightest border-l-4 border-orange text-orange-dark px-4 py-3 mb-5" role="alert">
+            <div class="bg-orange-lightest border-l-4 border-orange text-orange-dark px-4 py-3 my-2" role="alert">
                 <p>{{ permission_message.message }}</p>
             </div>
         {% endif %}
         {% if permission_message.level_tag == 'error' %}
-            <div class="bg-red-lightest border-l-4 border-red text-red-dark px-4 py-3 mb-5" role="alert">
+            <div class="bg-red-lightest border-l-4 border-red text-red-dark px-4 py-3 my-2" role="alert">
                 <p>{{ permission_message.message }}</p>
             </div>
         {% endif %}
     {% endif %}
-<div class="w-fullrounded overflow-hidden shadow-lg mt-6">
-    <div class="px-6 pt-4">
-        <div class="font-bold text-xl mb-2">{% trans 'Editors' %}</div>
+    <div class="pt-4">
         <p class="text-gray-700 text-base">
+	        <span class="font-bold">{% trans 'Editors' %}</span> -
             {% trans 'These users can edit this page, but are not allowed to publish it.' %}
         </p>
     </div>
@@ -42,27 +41,23 @@
         {% empty %}
         {% endfor %}
     </div>
-    <div class="w-full flex flex-wrap mt-2 px-6 pb-4">
-        <div class="w-1/3">
+    <div class="w-full flex flex-wrap mt-2 pb-4">
             <label class="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2" for="grid-first-name">
                 {% trans 'Username' %}
             </label>
-            {% render_field page_form.editors class="appearance-none block w-full bg-grey-lighter text-xl text-grey-darkest border border-grey-lighter rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
-            <div class="pointer-events-none absolute pin-y pin-r flex items-center px-2 text-grey-darkest">
-                <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
-            </div>
-        </div>
-        <div class="w-1/3 mt-6 ml-3">
-            <button type="button" class="bg-blue hover:bg-blue-dark text-white font-bold py-3 px-4 rounded" id="grant-edit-page-permission" data-user-id="{{ user.id }}" data-permission="edit">
+		    <div class="relative my-2 w-full">
+	            {% render_field page_form.editors class="appearance-none block w-full bg-grey-lighter text-xl text-grey-darkest border border-grey-lighter rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
+	            <div class="pointer-events-none absolute pin-y pin-r flex items-center px-2 text-grey-darkest">
+	                <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
+	            </div>
+		    </div>
+            <button type="button" class="bg-blue hover:bg-blue-dark text-white font-bold py-3 px-4 mt-2 rounded w-full" id="grant-edit-page-permission" data-user-id="{{ user.id }}" data-permission="edit">
                 <i data-feather="plus-circle" class="align-middle"></i> {% trans 'Add to editors' %}
             </button>
-        </div>
     </div>
-</div>
-<div class="w-fullrounded overflow-hidden shadow-lg mt-6">
-    <div class="px-6 pt-4">
-        <div class="font-bold text-xl mb-2">{% trans 'Publishers' %}</div>
+    <div class="pt-4">
         <p class="text-gray-700 text-base">
+	        <span class="font-bold">{% trans 'Publishers' %}</span> -
             {% trans 'These users can edit and publish this page.' %}
         </p>
     </div>
@@ -77,20 +72,17 @@
         {% empty %}
         {% endfor %}
     </div>
-    <div class="w-full flex flex-wrap mt-2 px-6 pb-4">
-        <div class="w-1/3">
-            <label class="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2" for="grid-first-name">
-                {% trans 'Username' %}
-            </label>
-            {% render_field page_form.publishers class="appearance-none block w-full bg-grey-lighter text-xl text-grey-darkest border border-grey-lighter rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
-            <div class="pointer-events-none absolute pin-y pin-r flex items-center px-2 text-grey-darkest">
-                <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
-            </div>
-        </div>
-        <div class="w-1/3 mt-6 ml-3">
-            <button type="button" class="bg-blue hover:bg-blue-dark text-white font-bold py-3 px-4 rounded" id="grant-publish-page-permission">
-                <i data-feather="plus-circle" class="align-middle"></i> {% trans 'Add to publishers' %}
-            </button>
-        </div>
+    <div class="w-full flex flex-wrap mt-2 pb-4">
+        <label class="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-4" for="grid-first-name">
+            {% trans 'Username' %}
+        </label>
+	    <div class="relative my-2 w-full">
+	        {% render_field page_form.publishers class="appearance-none block w-full bg-grey-lighter text-xl text-grey-darkest border border-grey-lighter rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
+	        <div class="pointer-events-none absolute pin-y pin-r flex items-center px-2 text-grey-darkest">
+	            <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
+	        </div>
+	    </div>
+        <button type="button" class="bg-blue hover:bg-blue-dark text-white font-bold py-3 px-4 mt-2 rounded w-full" id="grant-publish-page-permission">
+            <i data-feather="plus-circle" class="align-middle"></i> {% trans 'Add to publishers' %}
+        </button>
     </div>
-</div>

--- a/backend/cms/templates/pages/page.html
+++ b/backend/cms/templates/pages/page.html
@@ -7,8 +7,8 @@
 {% load rules %}
 <form method="post">
     {% csrf_token %}
-    <div class="flex flex-wrap mb-4">
-        <div class="w-2/5 flex flex-wrap flex-col justify-center">
+    <div class="flex flex-wrap">
+        <div class="w-4/5 flex flex-wrap flex-col justify-center mb-6">
             <h2 class="heading font-normal">
                 {% if page %}
                     {% if page_translation_form.instance.id %}
@@ -23,127 +23,115 @@
                 {% endif %}
             </h2>
         </div>
-        <div class="w-3/5 flex justify-end">
-            {% has_perm 'cms.edit_page' request.user page as can_edit_page %}
-            {% if can_edit_page %}
-                <input type="submit" name="submit_save" class="{% if public %}bg-blue hover:bg-blue-dark{% else %}bg-grey hover:bg-grey-dark{% endif %} cursor-pointer text-white font-bold py-3 px-4 rounded mr-2" value="{% trans 'Save' %}" />
-            {% endif %}
-            {% has_perm 'cms.publish_page' request.user page as can_publish_page %}
-            {% if not page_translation_form.instance.public and can_publish_page %}
-                <input type="submit" name="submit_publish" class="cursor-pointer bg-blue hover:bg-blue-dark text-white font-bold py-3 px-4 rounded" value="{% trans 'Publish' %}" />
-            {% endif %}
+        <div class="w-1/5 flex justify-end mb-6">
+        {% has_perm 'cms.edit_page' request.user page as can_edit_page %}
+        {% if can_edit_page %}
+            <input type="submit" name="submit_save" class="{% if page_translation_form.instance.public %}bg-blue hover:bg-blue-dark{% else %}bg-grey hover:bg-grey-dark{% endif %} cursor-pointer text-white font-bold py-3 px-4 rounded mr-2" value="{% trans 'Save' %}" />
+        {% endif %}
+        {% has_perm 'cms.publish_page' request.user page as can_publish_page %}
+        {% if not page_translation_form.instance.public and can_publish_page %}
+            <input type="submit" name="submit_publish" class="cursor-pointer bg-blue hover:bg-blue-dark text-white font-bold py-3 px-4 rounded" value="{% trans 'Publish' %}" />
+        {% endif %}
         </div>
-    </div>
-
-    <div class="flex flex-wrap">
-        <div class="w-2/3 pr-2">
+        <div class="w-2/3 flex flex-wrap flex-col pr-2">
             {{page_form.errors}}
             {{page_translation_form.errors}}
-            <div class="w-full p-4 mb-4 rounded border border-solid border-grey-light shadow bg-white">
-                <label class="block mb-2 font-bold">{% trans 'Title' %}</label>
-                {% trans 'Insert title here' as title_placeholder%}
-                {% render_field page_translation_form.title placeholder=title_placeholder class="appearance-none block w-full bg-grey-lighter text-xl text-grey-darkest border border-grey-lighter rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
-                <div class="mt-4">
-                    <label class="block mb-2 font-bold">{% trans 'Content' %}</label>
+            <ul class="flex flex-wrap" style="list-style: none;">
+                {% for other_language in languages %}
+                    <!--li class="mr-1 {% if other_language == language %}bg-blue-dark text-white font-bold{% else %}bg-white hover:bg-blue-dark text-blue-dark hover:text-white border-l border-t border-r border-blue-dark font-semibold{% endif %} inline-block py-2 px-4 rounded-t-lg"-->
+                    <li class="mr-1 {% if other_language == language %}z-10{% endif %} -mb-1">
+                        <div class="bg-white text-blue-dark {% if other_language != language %}hover:bg-blue-dark hover:text-white{% endif %} border-l-2 border-t-2 border-r-2 border-blue-dark font-bold rounded-t-lg">
+                            <div class="border-b-2 border-white">
+                        {% if other_language == language %}
+                            <div class="py-2 px-4">
+                            <i data-feather="{% if other_language in page.languages %}edit-2{% else %}plus{% endif %}"></i>
+                            <span style="vertical-align: super;">
+                                {{ other_language.translated_name }}
+                            </span>
+                            </div>
+                        {% else %}
+                            <a class="inline-block py-2 px-4" style="color: inherit;" href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_code=other_language.code %}">
+                                <i data-feather="{% if other_language in page.languages %}edit-2{% else %}plus{% endif %}"></i>
+                                <span style="vertical-align: super;">
+                                    {{ other_language.translated_name }}
+                                </span>
+                            </a>
+                        {% endif %}
+                            </div>
+                        </div>
+                    </li>
+                {% endfor %}
+                <li class="ml-5">
+                    {% with language.code|add:'__'|add:language.code as sbs_language_code %}
+                    <a class="bg-white text-blue-dark hover:bg-blue-dark hover:text-white font-semibold inline-block py-2 px-4 border-l-2 border-t-2 border-r-2 border-blue-dark rounded-t-lg" href="{% url 'sbs_edit_page' page_id=page.id region_slug=region.slug language_code=sbs_language_code %}">
+                        <i data-feather="columns"></i>
+                        <span style="vertical-align: super;">
+                            {% trans 'Side by side view' %}
+                        </span>
+                    </a>
+                    {% endwith %}
+                </li>
+            </ul>
+            <div class="w-full mb-4 rounded border-2 border-blue-dark bg-white">
+                <div class="w-full p-4">
+                    <label class="block mb-2 font-bold">{% trans 'Permalink' %}</label>
+                    <div class="appearance-none block w-full bg-grey-lighter text-xl text-grey-darkest border border-grey-lighter rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey">
+                        {% trans ' Leave blank to generate unique permalink from title' as slug_placeholder%}
+                        {% spaceless %}
+                            <div style="display: table; white-space: nowrap;">
+                                <span style="display: table-cell;">https://integreat.app/{{ region.slug }}/{{ language.code }}/</span>
+                                {% if page_translation_form.instance.ancestor_path %}
+                                    <span style="display: table-cell;">{{ page_translation_form.instance.ancestor_path }}/</span>
+                                {% endif %}
+                                <span style="display: table-cell; width: 100%;">{% render_field page_translation_form.slug placeholder=slug_placeholder class="w-full rounded" %}</span>
+                            </div>
+                        {% endspaceless %}
+                    </div>
+                    <label class="block mb-2 mt-4 font-bold">{% trans 'Title' %}</label>
+                    {% trans 'Insert title here' as title_placeholder%}
+                    {% render_field page_translation_form.title placeholder=title_placeholder class="appearance-none block w-full bg-grey-lighter text-xl text-grey-darkest border border-grey-lighter rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
+                    <label class="block mb-2 mt-4 font-bold">{% trans 'Content' %}</label>
                     {% trans 'Insert content here' as text_placeholder%}
                     {% render_field page_translation_form.text placeholder=text_placeholder class="bg-grey-lighter w-full p-2 border border-grey-lighter focus:outline-none focus:bg-white focus:border-grey rounded" %}
-                </div>
-            </div>
-            <div class="w-full p-4 mb-4 rounded border border-solid border-grey-light shadow bg-white">
-                <label class="block mb-2 font-bold">{% trans 'Permalink' %}</label>
-            <div class="appearance-none block w-full bg-grey-lighter text-xl text-grey-darkest border border-grey-lighter rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey">
-                {% trans ' Leave blank to generate unique permalink from title' as slug_placeholder%}
-                {% spaceless %}
-                    <div style="display: table; white-space: nowrap;">
-                        <span style="display: table-cell;">https://integreat.app/{{ region.slug }}/{{ language.code }}/</span>
-                        {% if page_translation_form.instance.ancestor_path %}
-                            <span style="display: table-cell;">{{ page_translation_form.instance.ancestor_path }}/</span>
-                        {% endif %}
-                        <span style="display: table-cell; width: 100%;">{% render_field page_translation_form.slug placeholder=slug_placeholder class="w-full rounded" %}</span>
-                    </div>
-                {% endspaceless %}
-            </div></div>
-            <div class="w-full p-4 mb-4 rounded border border-solid border-grey-light shadow bg-white">
-                <h3 class="mb-2">{% trans 'Embed live content' %}</h3>
-                <input type="text" class="appearance-none block w-full bg-grey-lighter text-grey-darker border border-grey-lighter rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey"
-                    placeholder="{% trans 'Search page' %}" />
-                <div class="relative my-2">
-                    <select class="block appearance-none w-full bg-grey-lighter border border-grey-lighter text-grey-darkest py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-grey">
-                        <option>{% trans 'Embed before content' %}</option>
-                        <option>{% trans 'Embed after content' %}</option>
-                    </select>
-                    <div class="pointer-events-none absolute pin-y pin-r flex items-center px-2 text-grey-darkest">
-                        <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
+
+                    <div class="py-2 border-b solid border-grey-lighter mb-2">
+                        <label for="status" class="font-bold">{% trans 'Status' %}</label>
+                        <div class="relative my-2">
+                            {% render_field page_translation_form.status id="status" class="block appearance-none w-full bg-grey-lighter border border-grey-lighter text-grey-darkest py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
+                            <div class="pointer-events-none absolute pin-y pin-r flex items-center px-2 text-grey-darkest">
+                                <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
+                            </div>
+                        </div>
                     </div>
                 </div>
-                <button class="bg-blue hover:bg-blue-dark text-white font-bold py-2 px-4 rounded">
-                    {% trans 'Embed page' %}
-                </button>
             </div>
-            {% if perms.cms.grant_page_permissions %}
-            <div class="w-full p-4 mb-4 rounded border border-solid border-grey-light shadow bg-white">
-                <h3 class="mb-2">{% trans 'Additional permissions for this page' %}</h3>
-                <p class="mb-2">{% trans "This affects only users, who don't have the permission to change arbitrary pages anyway." %}</p>
-                <div id="page_permission_table">
-                        {% include "pages/_page_permission_table.html" %}
-                </div>
-            </div>
-            {% endif %}
         </div>
-        <div class="w-1/3 pl-2">
-            <div class="w-full px-4 py-2 rounded border border-solid border-grey-light shadow bg-white">
-                <div class="py-2 border-b solid border-grey-lighter mb-2">
-                    <span class="block mb-2 font-bold">{% trans 'Language' %}</span>
-                    <label class="text-xs uppercase block">{% trans 'Current language' %}</label>
-                    <div class="relative my-2">
-                        {{ language.translated_name }}
+        <div class="w-1/3 pl-4 flex flex-wrap">
+            <ul class="flex" style="list-style: none;">
+                <li class="z-10" style="margin-bottom: -0.1rem;">
+                    <div class="bg-white text-blue-dark border-l-2 border-t-2 border-r-2 border-blue-dark font-bold rounded-t-lg py-2 px-4">
+                    <div class="border-b-4 border-white">
+                    <i data-feather="flag"></i>
+                    <span style="vertical-align: super;">
+                        {% trans 'Settings for all translations' %}
+                    </span>
                     </div>
-                    {% if page %}
-	                    <div class="entity-lang-list mt-4 mb-2">
-	                        <label class="text-xs uppercase block mb-2">{% trans 'Translations' %}</label>
-	                        <!-- TODO: get available languages from region settings -->
-	                        <table style="width:100%;" border="0" cellspacing="0" cellpadding="0">
-		                        {% for other_language in languages %}
-			                        {% if other_language != language %}
-				                        <tr>
-					                        <td>
-						                        <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_code=other_language.code %}" class="text-black block p-2">
-							                        {{ other_language.translated_name }}
-						                        </a>
-					                        </td>
-					                        <td>
-						                        <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_code=other_language.code %}" class="text-black block p-2 relative">
-							                        <i data-feather="{% if other_language in page.languages %}edit-2{% else %}plus{% endif %}"></i>
-						                        </a>
-					                        </td>
-				                        </tr>
-			                        {% endif %}
-		                        {% endfor %}
-	                        </table>
-	                    </div>
-                        <div class="entity-lang-list mt-4 mb-2">
-                            <label class="text-xs uppercase block mb-2">{% trans 'Side by Side View' %}</label>
-                            <!-- TODO: get available languages from region settings -->
-                            <table style="width:100%;" border="0" cellspacing="0" cellpadding="0">
-                                {% for other_language in languages %}
-                                    {% if other_language != language %}
-                                        {% with language.code|add:'__'|add:other_language.code  as sbs_language_code %}
-                                        <tr>
-                                            <td>
-                                                <a href="{% url 'sbs_edit_page' page_id=page.id region_slug=region.slug language_code=sbs_language_code %}" class="text-black block p-2">
-                                                    {{ other_language.translated_name }}
-                                                </a>
-                                            </td>
-                                        </tr>
-                                        {% endwith %}
-                                    {% endif %}
-                                {% endfor %}
-                            </table>
+                    </div>
+                </li>
+            </ul>
+            <div class="w-full mb-4 rounded border-2 border-solid border-blue-dark shadow bg-white">
+                <div class="w-full p-4">
+                    {% has_perm 'cms.publish_page' request.user page as can_publish_page %}
+                    {% if can_publish_page %}
+                        <label for="public" class="font-bold">{% trans 'Visibility' %}</label>
+                        <div class="relative my-2">
+                            {% render_field page_translation_form.public id="public" class="block appearance-none w-full bg-grey-lighter border border-grey-lighter text-grey-darkest py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
+                            <div class="pointer-events-none absolute pin-y pin-r flex items-center px-2 text-grey-darkest">
+                                <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
+                            </div>
                         </div>
                     {% endif %}
-                </div>
-                <div class="py-2 border-b solid border-grey-lighter mb-2">
-                    <span class="font-bold mb-2 block">{% trans 'Positioning' %}</span>
+                    <span class="font-bold mb-2 mt-4 block">{% trans 'Positioning' %}</span>
                     <label for="position" class="text-xs uppercase block mt-4">{% trans 'Relationship' %}</label>
                     <div class="relative my-2">
                         {% render_field page_form.position placeholder="0" id="position" class="appearance-none block w-full bg-grey-lighter text-grey-darker border border-grey-lighter rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
@@ -155,72 +143,71 @@
                             <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
                         </div>
                     </div>
-                </div>
-                {% has_perm 'cms.publish_page' request.user page as can_publish_page %}
-                {% if can_publish_page %}
-                <div class="py-2 border-b solid border-grey-lighter mb-2">
-                    <label for="public" class="font-bold">{% trans 'Visibility' %}</label>
-                    <div class="relative my-2">
-                        {% render_field page_translation_form.public id="public" class="block appearance-none w-full bg-grey-lighter border border-grey-lighter text-grey-darkest py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
+                    <span class="font-bold mb-2 mt-4">{% trans 'Embed live content' %}</span>
+                    <input type="text" class="appearance-none block w-full bg-grey-lighter text-grey-darker border border-grey-lighter rounded mb-2 mt-4 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey"
+                           placeholder="{% trans 'Search page' %}" />
+                    <div class="relative my-2 pb-2">
+                        <select class="block appearance-none w-full bg-grey-lighter border border-grey-lighter text-grey-darkest py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-grey">
+                            <option>{% trans 'Embed before content' %}</option>
+                            <option>{% trans 'Embed after content' %}</option>
+                        </select>
                         <div class="pointer-events-none absolute pin-y pin-r flex items-center px-2 text-grey-darkest">
                             <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
                         </div>
                     </div>
-                </div>
-                {% endif %}
-                <div class="py-2 border-b solid border-grey-lighter mb-2">
-                    <label for="status" class="font-bold">{% trans 'Status' %}</label>
-                    <div class="relative my-2">
-                        {% render_field page_translation_form.status id="status" class="block appearance-none w-full bg-grey-lighter border border-grey-lighter text-grey-darkest py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
-                        <div class="pointer-events-none absolute pin-y pin-r flex items-center px-2 text-grey-darkest">
-                            <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
+                    {% if perms.cms.grant_page_permissions %}
+                        <span class="block font-bold mb-2">{% trans 'Additional permissions for this page' %}</span>
+                        <p class="italic">{% trans "This affects only users, who don't have the permission to change arbitrary pages anyway." %}</p>
+                        <div id="page_permission_table">
+                            {% include "pages/_page_permission_table.html" %}
                         </div>
+                    {% endif %}
+                    <div class="pt-2 pb-4">
+                        <span class="block font-bold mb-4">{% trans 'Icon' %}</span>
+                        {% render_field page_form.icon id="icon" class="image-field" %}
+                        <label for="icon" class="font-bold bg-blue hover:bg-blue-dark focus:bg-blue-dark text-white font-bold py-3 pl-10 pr-4 rounded cursor-pointer relative">
+                            <i data-feather="upload"></i>
+                            <span class="standard_text">{% trans 'Set icon' %}</span>
+                            <span class="filename"></span>
+                        </label>
                     </div>
+                    {% if page %}
+                        <div class="pt-2 pb-4">
+                            <span class="block font-bold mb-4">{% trans 'Archive page' %}</span>
+                            {% if page.archived %}
+                                {% trans 'Page is archived.' %}
+                            {% else %}
+                                <button class="bg-blue hover:bg-blue-dark text-white font-bold py-2 px-4 rounded" onclick="confirmation_popup(event, '#confirm_archive_page_{{ page.id }}')">
+                                    {% trans 'Archive this page' %}
+                                </button>
+                            {% endif %}
+                        </div>
+                        {% if user.is_superuser or user.is_staff %}
+                            <div class="pt-2 pb-4">
+                                <span class="block font-bold mb-4">{% trans 'Delete page' %}</span>
+                                {% if page.children.all %}
+                                    {% trans 'You cannot delete a page which has children.' %}
+                                {% else %}
+                                    <button class="bg-red hover:bg-red-dark text-white font-bold py-2 px-4 rounded" onclick="confirmation_popup(event, '#confirm_delete_page_{{ page.id }}')">
+                                        {% trans 'Delete this page' %}
+                                    </button>
+                                {% endif %}
+                            </div>
+                        {% endif %}
+                    {% endif %}
                 </div>
-                <div class="pt-2 pb-4">
-                    <span class="block font-bold mb-4">{% trans 'Icon' %}</span>
-                    {% render_field page_form.icon id="icon" class="image-field" %}
-                    <label for="icon" class="font-bold my-2 bg-blue hover:bg-blue-dark focus:bg-blue-dark text-white font-bold py-2 pl-10 pr-4 rounded cursor-pointer relative">
-                        <i data-feather="upload"></i>
-                        <span class="standard_text">{% trans 'Set icon' %}</span>
-                        <span class="filename"></span>
-                    </label>
                 </div>
-	            {% if page %}
-	                <div class="pt-2 pb-4">
-	                    <span class="block font-bold mb-4">{% trans 'Archive page' %}</span>
-	                    {% if page.archived %}
-	                        {% trans 'Page is archived.' %}
-	                    {% else %}
-	                        <button class="bg-blue hover:bg-blue-dark text-white font-bold py-2 px-4 rounded" onclick="confirmation_popup(event, '#confirm_archive_page_{{ page.id }}')">
-	                            {% trans 'Archive this page' %}
-	                        </button>
-	                    {% endif %}
-	                </div>
-		            {% if user.is_superuser or user.is_staff %}
-				        <div class="pt-2 pb-4">
-			                <span class="block font-bold mb-4">{% trans 'Delete page' %}</span>
-					        {% if page.children.all %}
-						        {% trans 'You cannot delete a page which has children.' %}
-					        {% else %}
-				                <button class="bg-red hover:bg-red-dark text-white font-bold py-2 px-4 rounded" onclick="confirmation_popup(event, '#confirm_delete_page_{{ page.id }}')">
-					                {% trans 'Delete this page' %}
-				                </button>
-					        {% endif %}
-		                </div>
-		            {% endif %}
-	            {% endif %}
             </div>
         </div>
     </div>
 </form>
 {% if page %}
-	{% include "./confirmation_popups/archive_page.html" with page=page %}
-	{% if user.is_superuser or user.is_staff %}
-		{% if not page.children.all %}
-			{% include "./confirmation_popups/delete_page.html" with page=page %}
-		{% endif %}
-	{% endif %}
+    {% include "./confirmation_popups/archive_page.html" with page=page %}
+    {% if user.is_superuser or user.is_staff %}
+        {% if not page.children.all %}
+            {% include "./confirmation_popups/delete_page.html" with page=page %}
+        {% endif %}
+    {% endif %}
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
I redesigned the page form to point out which attributes belong to a translation and which ones belong to the entire page. I used a tab view for every language.
This is a completely new design approach which differs from the other pages, so if you have ideas how to implement the requirement more similar to the other forms or have other suggestions regarding the positioning or color choices, feel free to reach out to me.

![Screenshot_2019-10-17 Integreat CMS](https://user-images.githubusercontent.com/16021269/67045270-3f0b3700-f12e-11e9-94da-824612ab8336.png)
