### PR TITLE
Remove double entries from translation file

### DIFF
--- a/backend/cms/locale/de/LC_MESSAGES/django.po
+++ b/backend/cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-17 22:22+0200\n"
+"POT-Creation-Date: 2019-10-23 10:27+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Timo Ludwig <ludwig@integreat-app.de>\n"
 "Language-Team:\n"
@@ -361,7 +361,7 @@ msgid "Create language tree node"
 msgstr "Sprach-Knoten hinzufügen"
 
 #: templates/language_tree/tree.html:30
-#: templates/language_tree/tree_node.html:28 templates/pois/poi.html:87
+#: templates/language_tree/tree_node.html:28 templates/pois/poi.html:90
 #: templates/push_notifications/push_notification.html:62
 msgid "Language"
 msgstr "Sprache"
@@ -518,7 +518,7 @@ msgid "Enter the organization's thumbnail here"
 msgstr "Name der Organisations-Thumbnail hier eingeben"
 
 #: templates/organizations/organization.html:66 templates/pages/page.html:170
-#: templates/pois/poi.html:130 templates/regions/region.html:78
+#: templates/pois/poi.html:133 templates/regions/region.html:78
 msgid "Set icon"
 msgstr "Icon festlegen"
 
@@ -565,9 +565,6 @@ msgstr "Archivierte Seiten"
 #: templates/push_notifications/push_notification.html:49
 msgid "Title"
 msgstr "Titel"
-
-msgid "Short description"
-msgstr "Kurzbeschreibung"
 
 #: templates/pages/archive.html:33
 msgid "Restore page"
@@ -643,12 +640,12 @@ msgstr "Neue Seite erstellen"
 msgid "Side by side view"
 msgstr "Übersetzungen nebeneinander anzeigen"
 
-#: templates/pages/page.html:77 templates/pois/poi.html:70
+#: templates/pages/page.html:77 templates/pois/poi.html:73
 #: templates/regions/region.html:40
 msgid "Permalink"
 msgstr ""
 
-#: templates/pages/page.html:79 templates/pois/poi.html:72
+#: templates/pages/page.html:79 templates/pois/poi.html:75
 #: templates/regions/region.html:42
 msgid " Leave blank to generate unique permalink from title"
 msgstr ""
@@ -660,9 +657,6 @@ msgstr ""
 msgid "Insert title here"
 msgstr "Titel hier eingeben"
 
-msgid "Insert short description here"
-msgstr "Kurzbeschreibung hier eingeben"
-
 #: templates/pages/page.html:93
 #: templates/push_notifications/push_notification.html:54
 msgid "Content"
@@ -672,8 +666,8 @@ msgstr "Inhalt"
 msgid "Insert content here"
 msgstr "Inhalt hier eingeben"
 
-#: templates/pages/page.html:98 templates/pois/poi.html:117
-#: templates/regions/list.html:28 templates/regions/region.html:85
+#: templates/pages/page.html:98 templates/pois/poi.html:120
+#: templates/regions/list.html:33 templates/regions/region.html:85
 msgid "Status"
 msgstr "Status"
 
@@ -725,42 +719,7 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: templates/pages/page.html:97 templates/pois/poi.html:88
-#: templates/push_notifications/push_notification.html:63
-msgid "Current language"
-msgstr "Aktuelle Sprache"
-
-#: templates/pages/page.html:103 templates/pois/poi.html:94
-#: templates/push_notifications/push_notification.html:70
-msgid "Translations"
-msgstr "Übersetzungen"
-
-#: templates/pages/page.html:125
-msgid "Side by Side View"
-msgstr "Übersetzungen nebeneinander anzeigen"
-
-#: templates/pages/page.html:146
-msgid "Positioning"
-msgstr "Anordnung"
-
-#: templates/pages/page.html:147
-msgid "Relationship"
-msgstr "Verhältnis"
-
-#: templates/pages/page.html:151
-msgid "Page"
-msgstr "Seite"
-
-#: templates/pages/page.html:162
-msgid "Visibility"
-msgstr "Sichtbarkeit"
-
-#: templates/pages/page.html:172 templates/pois/poi.html:117
-#: templates/regions/list.html:33 templates/regions/region.html:85
-msgid "Status"
-msgstr "Status"
-
-#: templates/pages/page.html:166 templates/pois/poi.html:126
+#: templates/pages/page.html:166 templates/pois/poi.html:129
 #: templates/regions/region.html:68
 msgid "Icon"
 msgstr "Icon"
@@ -841,19 +800,19 @@ msgstr "Seite herunterladen"
 msgid "Create POI"
 msgstr "POI erstellen"
 
-#: templates/pois/list.html:42 templates/pois/poi.html:46
+#: templates/pois/list.html:42 templates/pois/poi.html:49
 msgid "Address"
 msgstr "Adresse"
 
-#: templates/pois/list.html:43 templates/pois/poi.html:50
+#: templates/pois/list.html:43 templates/pois/poi.html:53
 msgid "Postal Code"
 msgstr "Postleitzahl"
 
-#: templates/pois/list.html:44 templates/pois/poi.html:53
+#: templates/pois/list.html:44 templates/pois/poi.html:56
 msgid "City"
 msgstr "Stadt"
 
-#: templates/pois/list.html:45 templates/pois/poi.html:56
+#: templates/pois/list.html:45 templates/pois/poi.html:59
 msgid "Country"
 msgstr "Land"
 
@@ -874,53 +833,71 @@ msgstr "Neue POI Übersetzung erstellen"
 msgid "Create new point of interest"
 msgstr "Neuen POI erstellen"
 
+#: templates/pois/poi.html:39
+msgid "Short description"
+msgstr "Kurzbeschreibung"
+
 #: templates/pois/poi.html:40
+msgid "Insert short description here"
+msgstr "Kurzbeschreibung hier eingeben"
+
+#: templates/pois/poi.html:43
 msgid "Description"
 msgstr "Beschreibung"
 
-#: templates/pois/poi.html:41
+#: templates/pois/poi.html:44
 msgid "Insert description here"
 msgstr "Beschreibung hier eingeben"
 
-#: templates/pois/poi.html:47
+#: templates/pois/poi.html:50
 msgid "Street"
 msgstr "Straße"
 
-#: templates/pois/poi.html:48
+#: templates/pois/poi.html:51
 msgid "Insert street here"
 msgstr "Straße hier eingeben"
 
-#: templates/pois/poi.html:51
+#: templates/pois/poi.html:54
 msgid "Insert postal code here"
 msgstr "Postleitzahl hier eingeben"
 
-#: templates/pois/poi.html:54
+#: templates/pois/poi.html:57
 msgid "Insert city here"
 msgstr "Stadt hier eingeben"
 
-#: templates/pois/poi.html:57
+#: templates/pois/poi.html:60
 msgid "Insert country here"
 msgstr "Land hier eingeben"
 
-#: templates/pois/poi.html:61
+#: templates/pois/poi.html:64
 msgid "Position"
 msgstr "Position"
 
-#: templates/pois/poi.html:62 templates/regions/region.html:63
+#: templates/pois/poi.html:65 templates/regions/region.html:63
 msgid "Longitude"
 msgstr "Geographische Länge"
 
-#: templates/pois/poi.html:63
+#: templates/pois/poi.html:66
 msgid "Insert longitude here"
 msgstr "Geographische Länge hier eingeben"
 
-#: templates/pois/poi.html:65 templates/regions/region.html:60
+#: templates/pois/poi.html:68 templates/regions/region.html:60
 msgid "Latitude"
 msgstr "Geographische Breite"
 
-#: templates/pois/poi.html:66
+#: templates/pois/poi.html:69
 msgid "Insert latitude here"
 msgstr "Geographische Breite hier eingeben"
+
+#: templates/pois/poi.html:91
+#: templates/push_notifications/push_notification.html:63
+msgid "Current language"
+msgstr "Aktuelle Sprache"
+
+#: templates/pois/poi.html:97
+#: templates/push_notifications/push_notification.html:70
+msgid "Translations"
+msgstr "Übersetzungen"
 
 #: templates/push_notifications/list.html:13
 msgid "Create push notification"
@@ -1760,6 +1737,9 @@ msgstr "Linker Nachbar von"
 #: views/utils/tree_utils.py:8
 msgid "Right neighbor of"
 msgstr "Rechter Nachbar von"
+
+#~ msgid "Side by Side View"
+#~ msgstr "Übersetzungen nebeneinander anzeigen"
 
 #~ msgid "Translation"
 #~ msgstr "Übersetzung"


### PR DESCRIPTION
Apparently, the merge of the last PR didn't work as expected and resulted in double entries in the translation .po file.
This PR fixes all conflicts in that file.