### PR TITLE
Enhance page view and form

### DIFF
--- a/backend/cms/locale/de/LC_MESSAGES/django.po
+++ b/backend/cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-23 13:57+0200\n"
+"POT-Creation-Date: 2019-10-28 12:14+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Timo Ludwig <ludwig@integreat-app.de>\n"
 "Language-Team:\n"
@@ -65,7 +65,7 @@ msgstr "Archiviert"
 
 #: templates/_base.html:11 templates/extras/list.html:15
 #: templates/language_tree/tree.html:15 templates/media/medialist.html:8
-#: templates/pages/archive.html:13 templates/pages/tree.html:26
+#: templates/pages/archive.html:13 templates/pages/tree.html:27
 #: templates/pois/list.html:15 templates/push_notifications/list.html:9
 #: templates/regions/list.html:14 templates/users/admin/list.html:14
 #: templates/users/region/list.html:9
@@ -114,7 +114,7 @@ msgstr "Statistiken"
 msgid "Media Library"
 msgstr "Medienbibliothek"
 
-#: templates/_base.html:129 templates/pages/tree.html:10
+#: templates/_base.html:129 templates/pages/tree.html:11
 #: templates/regions/region.html:174
 msgid "Pages"
 msgstr "Seiten"
@@ -224,7 +224,7 @@ msgstr "Neue Extra-Vorlage erstellen"
 #: templates/extra_templates/extra_template.html:22
 #: templates/language_tree/tree_node.html:19
 #: templates/languages/language.html:21
-#: templates/organizations/organization.html:21 templates/pages/page.html:29
+#: templates/organizations/organization.html:21 templates/pages/page.html:37
 #: templates/pages/sbs_page.html:38 templates/pois/poi.html:27
 #: templates/push_notifications/push_notification.html:26
 #: templates/regions/region.html:21 templates/roles/role.html:21
@@ -319,12 +319,12 @@ msgid "URL"
 msgstr "URL"
 
 #: templates/extra_templates/list.html:27 templates/languages/list.html:30
-#: templates/pages/tree.html:68 templates/regions/list.html:32
+#: templates/pages/tree.html:74 templates/regions/list.html:32
 msgid "Last updated"
 msgstr "Zuletzt aktualisiert"
 
 #: templates/extra_templates/list.html:28 templates/languages/list.html:29
-#: templates/pages/tree.html:69 templates/regions/list.html:31
+#: templates/regions/list.html:31
 msgid "Created"
 msgstr "Erstellt"
 
@@ -488,7 +488,7 @@ msgstr "Organisation \"%(organization_name)s\" bearbeiten"
 msgid "Create new organization"
 msgstr "Neue Organisation erstellen"
 
-#: templates/organizations/organization.html:22 templates/pages/page.html:33
+#: templates/organizations/organization.html:22 templates/pages/page.html:41
 #: templates/regions/region.html:22
 msgid "Publish"
 msgstr "Veröffentlichen"
@@ -517,7 +517,7 @@ msgstr "Thumbnail der Organisation"
 msgid "Enter the organization's thumbnail here"
 msgstr "Name der Organisations-Thumbnail hier eingeben"
 
-#: templates/organizations/organization.html:66 templates/pages/page.html:170
+#: templates/organizations/organization.html:66 templates/pages/page.html:178
 #: templates/pois/poi.html:133 templates/regions/region.html:78
 msgid "Set icon"
 msgstr "Icon festlegen"
@@ -559,9 +559,9 @@ msgstr "Erlaubnis zum Veröffentlichen erteilen"
 msgid "Archived Pages"
 msgstr "Archivierte Seiten"
 
-#: templates/pages/archive.html:21 templates/pages/page.html:90
-#: templates/pages/tree.html:57 templates/pois/list.html:32
-#: templates/pois/poi.html:36 templates/push_notifications/list.html:24
+#: templates/pages/archive.html:21 templates/pages/page.html:98
+#: templates/pois/list.html:32 templates/pois/poi.html:36
+#: templates/push_notifications/list.html:24
 #: templates/push_notifications/push_notification.html:49
 msgid "Title"
 msgstr "Titel"
@@ -595,7 +595,7 @@ msgstr "Ja, die Seite wiederherstellen."
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: templates/pages/archive.html:65 templates/pages/tree.html:85
+#: templates/pages/archive.html:65 templates/pages/tree.html:91
 msgid "No pages available yet."
 msgstr "Noch keine Seiten vorhanden."
 
@@ -628,90 +628,95 @@ msgstr "Ja, die Seite jetzt löschen."
 msgid "Edit page \"%(page_title)s\""
 msgstr "Seite \"%(page_title)s\" bearbeiten"
 
-#: templates/pages/page.html:19 templates/pages/tree_row.html:38
+#: templates/pages/page.html:23 templates/pages/tree.html:59
+#: templates/pages/tree.html:63
+msgid "Title in"
+msgstr "Titel auf"
+
+#: templates/pages/page.html:27 templates/pages/tree_row.html:59
 msgid "Create new translation"
 msgstr "Neue Übersetzung erstellen"
 
-#: templates/pages/page.html:22
+#: templates/pages/page.html:30
 msgid "Create new page"
 msgstr "Neue Seite erstellen"
 
-#: templates/pages/page.html:69
+#: templates/pages/page.html:77
 msgid "Side by side view"
 msgstr "Übersetzungen nebeneinander anzeigen"
 
-#: templates/pages/page.html:77 templates/pois/poi.html:73
+#: templates/pages/page.html:85 templates/pois/poi.html:73
 #: templates/regions/region.html:40
 msgid "Permalink"
 msgstr ""
 
-#: templates/pages/page.html:79 templates/pois/poi.html:75
+#: templates/pages/page.html:87 templates/pois/poi.html:75
 #: templates/regions/region.html:42
 msgid " Leave blank to generate unique permalink from title"
 msgstr ""
 " Dieses Feld freilassen, um eine eindeutigen Permalink aus dem Titel zu "
 "generieren"
 
-#: templates/pages/page.html:91 templates/pages/sbs_page.html:30
+#: templates/pages/page.html:99 templates/pages/sbs_page.html:30
 #: templates/pois/poi.html:37
 msgid "Insert title here"
 msgstr "Titel hier eingeben"
 
-#: templates/pages/page.html:93
+#: templates/pages/page.html:101
 #: templates/push_notifications/push_notification.html:54
 msgid "Content"
 msgstr "Inhalt"
 
-#: templates/pages/page.html:94 templates/pages/sbs_page.html:33
+#: templates/pages/page.html:102 templates/pages/sbs_page.html:33
 msgid "Insert content here"
 msgstr "Inhalt hier eingeben"
 
-#: templates/pages/page.html:98 templates/pois/poi.html:120
+#: templates/pages/page.html:106 templates/pois/poi.html:120
 #: templates/regions/list.html:33 templates/regions/region.html:85
 msgid "Status"
 msgstr "Status"
 
-#: templates/pages/page.html:116
+#: templates/pages/page.html:124
 msgid "Settings for all translations"
 msgstr "Einstellungen für alle Übersetzungen"
 
-#: templates/pages/page.html:126
+#: templates/pages/page.html:134
 msgid "Visibility"
 msgstr "Sichtbarkeit"
 
-#: templates/pages/page.html:134
+#: templates/pages/page.html:142
 msgid "Positioning"
 msgstr "Anordnung"
 
-#: templates/pages/page.html:135
+#: templates/pages/page.html:143
 msgid "Relationship"
 msgstr "Verhältnis"
 
-#: templates/pages/page.html:139
+#: templates/pages/page.html:147
 msgid "Page"
 msgstr "Seite"
 
-#: templates/pages/page.html:146
+#: templates/pages/page.html:154
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: templates/pages/page.html:148
+#: templates/pages/page.html:156
 msgid "Search page"
 msgstr "Seite suchen"
 
-#: templates/pages/page.html:151
+#: templates/pages/page.html:159
 msgid "Embed before content"
 msgstr "Vor Inhalt einbinden"
 
-#: templates/pages/page.html:152
+#: templates/pages/page.html:160
 msgid "Embed after content"
 msgstr "Nach Inhalt einbinden"
 
-#: templates/pages/page.html:159
+#: templates/pages/page.html:167
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: templates/pages/page.html:160
+#: templates/pages/page.html:168
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -719,33 +724,33 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: templates/pages/page.html:166 templates/pois/poi.html:129
+#: templates/pages/page.html:174 templates/pois/poi.html:129
 #: templates/regions/region.html:68
 msgid "Icon"
 msgstr "Icon"
 
-#: templates/pages/page.html:176 templates/pages/tree_row.html:67
+#: templates/pages/page.html:184 templates/pages/tree_row.html:82
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: templates/pages/page.html:178
+#: templates/pages/page.html:186
 msgid "Page is archived."
 msgstr "Die Seite wurde archiviert."
 
-#: templates/pages/page.html:181
+#: templates/pages/page.html:189
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: templates/pages/page.html:187 templates/pages/tree_row.html:76
+#: templates/pages/page.html:195 templates/pages/tree_row.html:91
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: templates/pages/page.html:189 templates/pages/tree_row.html:72
+#: templates/pages/page.html:197 templates/pages/tree_row.html:87
 #: views/pages/page.py:215
 msgid "You cannot delete a page which has children."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: templates/pages/page.html:192
+#: templates/pages/page.html:200
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
@@ -760,51 +765,55 @@ msgstr ""
 msgid "Go Back to Page Editor"
 msgstr "Zurück zum Seiten-Editor"
 
-#: templates/pages/tree.html:15
+#: templates/pages/tree.html:16
 msgid "Archived pages"
 msgstr "Archivierte Seiten"
 
-#: templates/pages/tree.html:37
+#: templates/pages/tree.html:38
 msgid "Upload"
 msgstr "Hochladen"
 
-#: templates/pages/tree.html:44
+#: templates/pages/tree.html:45
 msgid "Create page"
 msgstr "Seite erstellen"
 
-#: templates/pages/tree.html:56 templates/pois/list.html:31
+#: templates/pages/tree.html:57 templates/pois/list.html:31
 msgid "ID"
 msgstr ""
 
-#: templates/pages/tree.html:67
-msgid "Creator"
-msgstr "Ersteller"
+#: templates/pages/tree.html:58
+msgid "Version"
+msgstr "Version"
 
-#: templates/pages/tree.html:70
+#: templates/pages/tree.html:75
 msgid "Options"
 msgstr "Optionen"
 
-#: templates/pages/tree_row.html:25
+#: templates/pages/tree_row.html:20 templates/pages/tree_row.html:33
+msgid "Translation not available"
+msgstr "Übersetzung nicht verfügbar"
+
+#: templates/pages/tree_row.html:46
 msgid "Currently in translation"
 msgstr "Wird momentan übersetzt"
 
-#: templates/pages/tree_row.html:29
+#: templates/pages/tree_row.html:50
 msgid "Translation outdated"
 msgstr "Übersetzung is veraltet"
 
-#: templates/pages/tree_row.html:33
+#: templates/pages/tree_row.html:54
 msgid "Edit translation"
 msgstr "Diese Übersetzung bearbeiten"
 
-#: templates/pages/tree_row.html:60
+#: templates/pages/tree_row.html:75
 msgid "View page"
 msgstr "Seite ansehen"
 
-#: templates/pages/tree_row.html:63
+#: templates/pages/tree_row.html:78
 msgid "Edit page"
 msgstr "Seite bearbeiten"
 
-#: templates/pages/tree_row.html:82
+#: templates/pages/tree_row.html:97
 msgid "Download page"
 msgstr "Seite herunterladen"
 
@@ -1750,6 +1759,9 @@ msgstr "Linker Nachbar von"
 msgid "Right neighbor of"
 msgstr "Rechter Nachbar von"
 
+#~ msgid "Creator"
+#~ msgstr "Ersteller"
+
 #~ msgid "Side by Side View"
 #~ msgstr "Übersetzungen nebeneinander anzeigen"
 
@@ -1783,9 +1795,6 @@ msgstr "Rechter Nachbar von"
 
 #~ msgid "User"
 #~ msgstr "Benutzer"
-
-#~ msgid "Permissions"
-#~ msgstr "Berechtigungen"
 
 #~ msgid "Grant permission"
 #~ msgstr "Berechtigung erteilen"

--- a/backend/cms/locale/de/LC_MESSAGES/django.po
+++ b/backend/cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-28 12:14+0100\n"
+"POT-Creation-Date: 2019-10-28 17:48+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Timo Ludwig <ludwig@integreat-app.de>\n"
 "Language-Team:\n"
@@ -65,7 +65,7 @@ msgstr "Archiviert"
 
 #: templates/_base.html:11 templates/extras/list.html:15
 #: templates/language_tree/tree.html:15 templates/media/medialist.html:8
-#: templates/pages/archive.html:13 templates/pages/tree.html:27
+#: templates/pages/archive.html:13 templates/pages/tree.html:28
 #: templates/pois/list.html:15 templates/push_notifications/list.html:9
 #: templates/regions/list.html:14 templates/users/admin/list.html:14
 #: templates/users/region/list.html:9
@@ -114,7 +114,7 @@ msgstr "Statistiken"
 msgid "Media Library"
 msgstr "Medienbibliothek"
 
-#: templates/_base.html:129 templates/pages/tree.html:11
+#: templates/_base.html:129 templates/pages/tree.html:12
 #: templates/regions/region.html:174
 msgid "Pages"
 msgstr "Seiten"
@@ -319,7 +319,7 @@ msgid "URL"
 msgstr "URL"
 
 #: templates/extra_templates/list.html:27 templates/languages/list.html:30
-#: templates/pages/tree.html:74 templates/regions/list.html:32
+#: templates/pages/tree.html:82 templates/regions/list.html:32
 msgid "Last updated"
 msgstr "Zuletzt aktualisiert"
 
@@ -517,7 +517,7 @@ msgstr "Thumbnail der Organisation"
 msgid "Enter the organization's thumbnail here"
 msgstr "Name der Organisations-Thumbnail hier eingeben"
 
-#: templates/organizations/organization.html:66 templates/pages/page.html:178
+#: templates/organizations/organization.html:66 templates/pages/page.html:179
 #: templates/pois/poi.html:133 templates/regions/region.html:78
 msgid "Set icon"
 msgstr "Icon festlegen"
@@ -559,7 +559,7 @@ msgstr "Erlaubnis zum Veröffentlichen erteilen"
 msgid "Archived Pages"
 msgstr "Archivierte Seiten"
 
-#: templates/pages/archive.html:21 templates/pages/page.html:98
+#: templates/pages/archive.html:21 templates/pages/page.html:99
 #: templates/pois/list.html:32 templates/pois/poi.html:36
 #: templates/push_notifications/list.html:24
 #: templates/push_notifications/push_notification.html:49
@@ -595,7 +595,7 @@ msgstr "Ja, die Seite wiederherstellen."
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: templates/pages/archive.html:65 templates/pages/tree.html:91
+#: templates/pages/archive.html:65 templates/pages/tree.html:99
 msgid "No pages available yet."
 msgstr "Noch keine Seiten vorhanden."
 
@@ -628,8 +628,8 @@ msgstr "Ja, die Seite jetzt löschen."
 msgid "Edit page \"%(page_title)s\""
 msgstr "Seite \"%(page_title)s\" bearbeiten"
 
-#: templates/pages/page.html:23 templates/pages/tree.html:59
-#: templates/pages/tree.html:63
+#: templates/pages/page.html:23 templates/pages/tree.html:67
+#: templates/pages/tree.html:71
 msgid "Title in"
 msgstr "Titel auf"
 
@@ -645,78 +645,78 @@ msgstr "Neue Seite erstellen"
 msgid "Side by side view"
 msgstr "Übersetzungen nebeneinander anzeigen"
 
-#: templates/pages/page.html:85 templates/pois/poi.html:73
+#: templates/pages/page.html:86 templates/pois/poi.html:73
 #: templates/regions/region.html:40
 msgid "Permalink"
 msgstr ""
 
-#: templates/pages/page.html:87 templates/pois/poi.html:75
+#: templates/pages/page.html:88 templates/pois/poi.html:75
 #: templates/regions/region.html:42
 msgid " Leave blank to generate unique permalink from title"
 msgstr ""
 " Dieses Feld freilassen, um eine eindeutigen Permalink aus dem Titel zu "
 "generieren"
 
-#: templates/pages/page.html:99 templates/pages/sbs_page.html:30
+#: templates/pages/page.html:100 templates/pages/sbs_page.html:30
 #: templates/pois/poi.html:37
 msgid "Insert title here"
 msgstr "Titel hier eingeben"
 
-#: templates/pages/page.html:101
+#: templates/pages/page.html:102
 #: templates/push_notifications/push_notification.html:54
 msgid "Content"
 msgstr "Inhalt"
 
-#: templates/pages/page.html:102 templates/pages/sbs_page.html:33
+#: templates/pages/page.html:103 templates/pages/sbs_page.html:33
 msgid "Insert content here"
 msgstr "Inhalt hier eingeben"
 
-#: templates/pages/page.html:106 templates/pois/poi.html:120
+#: templates/pages/page.html:107 templates/pois/poi.html:120
 #: templates/regions/list.html:33 templates/regions/region.html:85
 msgid "Status"
 msgstr "Status"
 
-#: templates/pages/page.html:124
+#: templates/pages/page.html:125
 msgid "Settings for all translations"
 msgstr "Einstellungen für alle Übersetzungen"
 
-#: templates/pages/page.html:134
+#: templates/pages/page.html:135
 msgid "Visibility"
 msgstr "Sichtbarkeit"
 
-#: templates/pages/page.html:142
+#: templates/pages/page.html:143
 msgid "Positioning"
 msgstr "Anordnung"
 
-#: templates/pages/page.html:143
+#: templates/pages/page.html:144
 msgid "Relationship"
 msgstr "Verhältnis"
 
-#: templates/pages/page.html:147
+#: templates/pages/page.html:148
 msgid "Page"
 msgstr "Seite"
 
-#: templates/pages/page.html:154
+#: templates/pages/page.html:155
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: templates/pages/page.html:156
+#: templates/pages/page.html:157
 msgid "Search page"
 msgstr "Seite suchen"
 
-#: templates/pages/page.html:159
+#: templates/pages/page.html:160
 msgid "Embed before content"
 msgstr "Vor Inhalt einbinden"
 
-#: templates/pages/page.html:160
+#: templates/pages/page.html:161
 msgid "Embed after content"
 msgstr "Nach Inhalt einbinden"
 
-#: templates/pages/page.html:167
+#: templates/pages/page.html:168
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: templates/pages/page.html:168
+#: templates/pages/page.html:169
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -724,33 +724,33 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: templates/pages/page.html:174 templates/pois/poi.html:129
+#: templates/pages/page.html:175 templates/pois/poi.html:129
 #: templates/regions/region.html:68
 msgid "Icon"
 msgstr "Icon"
 
-#: templates/pages/page.html:184 templates/pages/tree_row.html:82
+#: templates/pages/page.html:185 templates/pages/tree_row.html:82
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: templates/pages/page.html:186
+#: templates/pages/page.html:187
 msgid "Page is archived."
 msgstr "Die Seite wurde archiviert."
 
-#: templates/pages/page.html:189
+#: templates/pages/page.html:190
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: templates/pages/page.html:195 templates/pages/tree_row.html:91
+#: templates/pages/page.html:196 templates/pages/tree_row.html:91
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: templates/pages/page.html:197 templates/pages/tree_row.html:87
-#: views/pages/page.py:215
+#: templates/pages/page.html:198 templates/pages/tree_row.html:87
+#: views/pages/page.py:227
 msgid "You cannot delete a page which has children."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: templates/pages/page.html:200
+#: templates/pages/page.html:201
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
@@ -765,27 +765,31 @@ msgstr ""
 msgid "Go Back to Page Editor"
 msgstr "Zurück zum Seiten-Editor"
 
-#: templates/pages/tree.html:16
+#: templates/pages/tree.html:17
 msgid "Archived pages"
 msgstr "Archivierte Seiten"
 
-#: templates/pages/tree.html:38
+#: templates/pages/tree.html:39
 msgid "Upload"
 msgstr "Hochladen"
 
-#: templates/pages/tree.html:45
+#: templates/pages/tree.html:48 templates/pages/tree.html:52
 msgid "Create page"
 msgstr "Seite erstellen"
 
-#: templates/pages/tree.html:57 templates/pois/list.html:31
+#: templates/pages/tree.html:51
+msgid "You can only create pages in the default language"
+msgstr "Sie können Seiten nur in der Standard-Sprache anlegen"
+
+#: templates/pages/tree.html:65 templates/pois/list.html:31
 msgid "ID"
 msgstr ""
 
-#: templates/pages/tree.html:58
+#: templates/pages/tree.html:66
 msgid "Version"
 msgstr "Version"
 
-#: templates/pages/tree.html:75
+#: templates/pages/tree.html:83
 msgid "Options"
 msgstr "Optionen"
 
@@ -1447,7 +1451,7 @@ msgstr "Extra-Vorlage wurde erfolgreich erstellt."
 
 #: views/extra_templates/extra_templates.py:74
 #: views/language_tree/language_tree_node.py:70
-#: views/organizations/organizations.py:72 views/pages/page.py:139
+#: views/organizations/organizations.py:72 views/pages/page.py:151
 #: views/pages/sbs_page.py:109 views/pois/poi.py:122
 #: views/push_notifications/push_notifications.py:171
 #: views/regions/regions.py:78 views/roles/roles.py:71
@@ -1503,64 +1507,68 @@ msgstr "Organisation wurde erfolgreich erstellt."
 msgid "Organization saved successfully"
 msgstr "Organisation wurde erfolgreich gespeichert."
 
-#: views/pages/page.py:117
+#: views/pages/page.py:57
+msgid "You don't have the permission to edit this page."
+msgstr "Sie haben nicht die nötige Berechtigung, um diese Seite zu bearbeiten."
+
+#: views/pages/page.py:129
 msgid "Page was successfully created and published."
 msgstr "Seite wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/pages/page.py:119
+#: views/pages/page.py:131
 msgid "Page was successfully created."
 msgstr "Seite wurde erfolgreich erstellt."
 
-#: views/pages/page.py:122
+#: views/pages/page.py:134
 msgid "Translation was successfully created and published."
 msgstr "Übersetzung wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/pages/page.py:124 views/pages/sbs_page.py:103
+#: views/pages/page.py:136 views/pages/sbs_page.py:103
 msgid "Translation was successfully created."
 msgstr "Übersetzung wurde erfolgreich erstellt."
 
-#: views/pages/page.py:127
+#: views/pages/page.py:139
 msgid "Translation was successfully published."
 msgstr "Übersetzung wurde erfolgreich veröffentlich."
 
-#: views/pages/page.py:129 views/pages/sbs_page.py:105
+#: views/pages/page.py:141 views/pages/sbs_page.py:105
 msgid "Translation was successfully saved."
 msgstr "Übersetzung wurde erfolgreich gespeichert."
 
-#: views/pages/page.py:131 views/pages/sbs_page.py:107 views/pois/poi.py:114
+#: views/pages/page.py:143 views/pages/sbs_page.py:107 views/pois/poi.py:114
 #: views/regions/regions.py:89 views/users/region_users.py:113
 #: views/users/users.py:89
 msgid "No changes detected."
 msgstr "Keine Änderungen vorgenommen."
 
-#: views/pages/page.py:163
+#: views/pages/page.py:175
 msgid "Page was successfully archived."
 msgstr "Seite wurde erfolgreich archiviert."
 
-#: views/pages/page.py:182
+#: views/pages/page.py:194
 msgid "Page was successfully restored."
 msgstr "Seite wurde erfolgreich wiederhergestellt."
 
-#: views/pages/page.py:218
+#: views/pages/page.py:230
 msgid "Page was successfully deleted."
 msgstr "Seite wurde erfolgreich gelöscht."
 
-#: views/pages/page.py:316 views/pages/page.py:331
+#: views/pages/page.py:328 views/pages/page.py:343
 #, python-brace-format
 msgid "Information: The user {user} has this permission already."
 msgstr "Information: Der Nutzer {user} hat diese Berechtigung bereits"
 
-#: views/pages/page.py:324
+#: views/pages/page.py:336
 #, python-brace-format
 msgid "Success: The user {user} can now edit this page."
 msgstr "Erfolg: Der Nutzer {user} kann nun diese Seite bearbeiten"
 
-#: views/pages/page.py:339
+#: views/pages/page.py:351
 #, python-brace-format
 msgid "Success: The user {user} can now publish this page."
 msgstr "Erfolg: Der Nutzer {user} kann dieses Seite nurn veröffentlichen"
 
-#: views/pages/page.py:406
+#: views/pages/page.py:418
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the editors of this page, "
@@ -1570,12 +1578,12 @@ msgstr ""
 "bearbeiten wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin veröffentlichen"
 
-#: views/pages/page.py:412
+#: views/pages/page.py:424
 #, python-brace-format
 msgid "Success: The user {user} cannot edit this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr bearbeiten"
 
-#: views/pages/page.py:423
+#: views/pages/page.py:435
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the publishers of this "
@@ -1585,16 +1593,16 @@ msgstr ""
 "veröffentlichen wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin veröffentlichen"
 
-#: views/pages/page.py:429
+#: views/pages/page.py:441
 #, python-brace-format
 msgid "Success: The user {user} cannot publish this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr veröffentlichen"
 
-#: views/pages/page_form.py:162 views/pois/poi_form.py:72
+#: views/pages/page_form.py:168 views/pois/poi_form.py:72
 msgid "Public"
 msgstr "Öffentlich"
 
-#: views/pages/page_form.py:163 views/pois/poi_form.py:73
+#: views/pages/page_form.py:169 views/pois/poi_form.py:73
 msgid "Private"
 msgstr "Privat"
 
@@ -1603,6 +1611,12 @@ msgid "Please create at least one language node before creating pages."
 msgstr ""
 "Bitte erstellen Sie mindestens einen Sprach-Knoten, bevor Sie Seiten "
 "verwalten."
+
+#: views/pages/pages.py:52
+msgid "You don't have the permission to edit or create pages."
+msgstr ""
+"Sie haben nicht die nötige Berechtigung, um Seiten zu bearbeiten oder zu "
+"erstellen."
 
 #: views/pois/poi.py:97 views/pois/poi.py:144
 msgid "POI was successfully archived."

--- a/backend/cms/templates/pages/page.html
+++ b/backend/cms/templates/pages/page.html
@@ -15,6 +15,14 @@
                         {% with page_translation_form.instance.title as page_title %}
                         {% blocktrans %}Edit page "{{ page_title }}"{% endblocktrans %}
                         {% endwith %}
+                        {% get_current_language as LANGUAGE_CODE %}
+                        {% unify_laguage_code LANGUAGE_CODE as LANGUAGE_CODE %}
+                        {% if LANGUAGE_CODE != language.code %}
+                            {% get_page_translation page LANGUAGE_CODE as backend_translation %}
+                            {% if backend_translation %}
+                                ({% trans 'Title in' %} {% translated_language_name LANGUAGE_CODE %}: "{{ backend_translation.title }}")
+                            {% endif %}
+                        {% endif %}
                     {% else %}
                         {% trans 'Create new translation' %}
                     {% endif %}

--- a/backend/cms/templates/pages/page.html
+++ b/backend/cms/templates/pages/page.html
@@ -46,7 +46,6 @@
             {{page_translation_form.errors}}
             <ul class="flex flex-wrap" style="list-style: none;">
                 {% for other_language in languages %}
-                    <!--li class="mr-1 {% if other_language == language %}bg-blue-dark text-white font-bold{% else %}bg-white hover:bg-blue-dark text-blue-dark hover:text-white border-l border-t border-r border-blue-dark font-semibold{% endif %} inline-block py-2 px-4 rounded-t-lg"-->
                     <li class="mr-1 {% if other_language == language %}z-10{% endif %} -mb-1">
                         <div class="bg-white text-blue-dark {% if other_language != language %}hover:bg-blue-dark hover:text-white{% endif %} border-l-2 border-t-2 border-r-2 border-blue-dark font-bold rounded-t-lg">
                             <div class="border-b-2 border-white">
@@ -69,16 +68,18 @@
                         </div>
                     </li>
                 {% endfor %}
-                <li class="ml-5">
-                    {% with language.code|add:'__'|add:language.code as sbs_language_code %}
-                    <a class="bg-white text-blue-dark hover:bg-blue-dark hover:text-white font-semibold inline-block py-2 px-4 border-l-2 border-t-2 border-r-2 border-blue-dark rounded-t-lg" href="{% url 'sbs_edit_page' page_id=page.id region_slug=region.slug language_code=sbs_language_code %}">
-                        <i data-feather="columns"></i>
-                        <span style="vertical-align: super;">
-                            {% trans 'Side by side view' %}
-                        </span>
-                    </a>
-                    {% endwith %}
-                </li>
+                {% if page %}
+                    <li class="ml-5">
+                        {% with language.code|add:'__'|add:language.code as sbs_language_code %}
+                        <a class="bg-white text-blue-dark hover:bg-blue-dark hover:text-white font-semibold inline-block py-2 px-4 border-l-2 border-t-2 border-r-2 border-blue-dark rounded-t-lg" href="{% url 'sbs_edit_page' page_id=page.id region_slug=region.slug language_code=sbs_language_code %}">
+                            <i data-feather="columns"></i>
+                            <span style="vertical-align: super;">
+                                {% trans 'Side by side view' %}
+                            </span>
+                        </a>
+                        {% endwith %}
+                    </li>
+                {% endif %}
             </ul>
             <div class="w-full mb-4 rounded border-2 border-blue-dark bg-white">
                 <div class="w-full p-4">
@@ -179,7 +180,7 @@
                             <span class="filename"></span>
                         </label>
                     </div>
-                    {% if page %}
+                    {% if page and can_edit_page %}
                         <div class="pt-2 pb-4">
                             <span class="block font-bold mb-4">{% trans 'Archive page' %}</span>
                             {% if page.archived %}

--- a/backend/cms/templates/pages/tree.html
+++ b/backend/cms/templates/pages/tree.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% load mptt_tags %}
 {% load page_filters %}
+{% load rules %}
 
 {% block content %}
 <div class="table-header">
@@ -39,12 +40,19 @@
             </form>
         </div>
 
-        {% if region.default_language == language %}
-        <div class="w-1/4 flex flex-wrap justify-end">
-            <a href="{% url 'new_page' region_slug=region.slug language_code=language.code %}" class="bg-grey-dark hover:bg-integreat hover:text-grey-darkest text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
-                {% trans 'Create page' %}
-            </a>
-        </div>
+        {% has_perm 'cms.edit_page' request.user as can_edit_pages %}
+        {% if can_edit_pages %}
+            <div class="w-1/4 flex flex-wrap justify-end">
+                {% if region.default_language == language %}
+                    <a href="{% url 'new_page' region_slug=region.slug language_code=language.code %}" class="bg-blue hover:bg-blue-dark text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
+                        {% trans 'Create page' %}
+                    </a>
+                {% else %}
+                    <button title="{% trans 'You can only create pages in the default language' %} {{ region.default_language.translated_name }}." class="bg-grey text-white font-bold py-2 px-4 rounded cursor-not-allowed">
+                        {% trans 'Create page' %}
+                    </button>
+                {% endif %}
+            </div>
         {% endif %}
     </div>
 </div>

--- a/backend/cms/templates/pages/tree.html
+++ b/backend/cms/templates/pages/tree.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load static %}
 {% load mptt_tags %}
+{% load page_filters %}
 
 {% block content %}
 <div class="table-header">
@@ -41,7 +42,7 @@
         {% if region.default_language == language %}
         <div class="w-1/4 flex flex-wrap justify-end">
             <a href="{% url 'new_page' region_slug=region.slug language_code=language.code %}" class="bg-grey-dark hover:bg-integreat hover:text-grey-darkest text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
-	            {% trans 'Create page' %}
+                {% trans 'Create page' %}
             </a>
         </div>
         {% endif %}
@@ -54,26 +55,31 @@
             <tr class="border-b border-solid border-grey-light">
                 <th class="text-sm text-left uppercase py-3 pl-2 pr-4"></th>
                 <th class="text-sm text-left uppercase py-3 pl-4">{% trans 'ID' %}</th>
-                <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title' %}</th>
+                <th class="text-sm text-left uppercase py-3 pl-2">{% trans 'Version' %}</th>
+                <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
+                {% get_current_language as LANGUAGE_CODE %}
+                {% unify_laguage_code LANGUAGE_CODE as LANGUAGE_CODE %}
+                {% if LANGUAGE_CODE != language.code %}
+                    <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {% translated_language_name LANGUAGE_CODE %}</th>
+                {% endif %}
                 <th class="text-sm text-left uppercase py-3 px-2">
                     <div class="lang-grid flags whitespace-no-wrap">
-	                    {% for lang in languages %}
-		                    <a href="{% url 'pages' region_slug=region.slug language_code=lang.code %}">
-			                    <img src="{% static '' %}images/flags/{{ lang.code }}.png" title="{{ lang.name }}" />
-		                    </a>
-	                    {% endfor %}
+                        {% for lang in languages %}
+                            <a href="{% url 'pages' region_slug=region.slug language_code=lang.code %}">
+                                <span title="{{ lang.translated_name }}"><img src="{% static '' %}images/flags/{{ lang.code }}.png" /></span>
+                            </a>
+                        {% endfor %}
                     </div>
                 </th>
-                <th class="text-sm text-left uppercase py-3">{% trans 'Creator' %}</th>
                 <th class="text-sm text-left uppercase py-3">{% trans 'Last updated' %}</th>
-                <th class="text-sm text-left uppercase py-3">{% trans 'Created' %}</th>
                 <th class="text-sm text-left uppercase py-3 pl-2 pr-4">{% trans 'Options' %}</th>
             </tr>
         </thead>
         <tbody>
         {% if pages %}
             {% recursetree pages %}
-                {% include "pages/tree_row.html" with node=node %}
+                {% get_page_translation node language.code as page_translation %}
+                {% include "pages/tree_row.html" with page=node page_translation=page_translation %}
                 {% if not node.is_leaf_node %}
                     {{children}}
                 {% endif %}
@@ -82,7 +88,7 @@
             <tr>
                 <td></td>
                 <td colspan="5" class="px-2 py-3">
-	                {% trans 'No pages available yet.' %}
+                    {% trans 'No pages available yet.' %}
                 </td>
             </tr>
         {% endif %}

--- a/backend/cms/templates/pages/tree_row.html
+++ b/backend/cms/templates/pages/tree_row.html
@@ -1,43 +1,64 @@
 {% load i18n %}
 {% load page_filters %}
-<tr class="border-t border-solid border-grey-lighter hover:bg-grey-lightest{% if node.depth > 0 %} child level-{{node.depth}}{% endif %}">
+<tr class="border-t border-solid border-grey-lighter hover:bg-grey-lightest{% if page.depth > 0 %} child level-{{page.depth}}{% endif %}">
     <td class="single_icon">
         <span class="block py-3 pl-4 pr-2 cursor-move">
             <i data-feather="move" class="text-grey-darkest"></i>
         </span>
     </td>
     <td class="pl-4">
-        {{ node.id }}
+        {{ page.id }}
+    </td>
+    <td class="pl-4">
+        {{ page_translation.version }}
     </td>
     <td>
-        <a href="{% url 'edit_page' page_id=node.id region_slug=region.slug language_code=language.code %}" class="block py-3 px-2 text-grey-darkest">
-            {{ node|page_translation_title:language }}
+        <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_code=language.code %}" class="block py-3 px-2 text-grey-darkest">
+            {% if page_translation %}
+                {{ page_translation.title }}
+            {% else %}
+                <i>{% trans 'Translation not available' %}</i>
+            {% endif %}
         </a>
     </td>
+    {% get_current_language as LANGUAGE_CODE %}
+    {% unify_laguage_code LANGUAGE_CODE as LANGUAGE_CODE %}
+    {% if LANGUAGE_CODE != language.code %}
+        {% get_page_translation page LANGUAGE_CODE as backend_translation %}
+        <td>
+            <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_code=LANGUAGE_CODE %}" class="block py-3 px-2 text-grey-darkest">
+                {% if backend_translation %}
+                    {{ backend_translation.title }}
+                {% else %}
+                    <i>{% trans 'Translation not available' %}</i>
+                {% endif %}
+            </a>
+        </td>
+    {% endif %}
     <td class="whitespace-no-wrap">
         <div class="block py-3 px-2 text-grey-darkest">
             <div class="lang-grid">
                 {% for other_language in languages %}
-                    <a href="{% url 'edit_page' page_id=node.id region_slug=region.slug language_code=other_language.code %}">
-                        {% get_other_page_translation node other_language as other_translation %}
+                    <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_code=other_language.code %}">
+                        {% get_page_translation page other_language.code as other_translation %}
                         {% if other_translation %}
                             {% if other_translation.currently_in_translation %}
-	                            <span title="{% trans 'Currently in translation' %}">
+                                <span title="{% trans 'Currently in translation' %}">
                                     <i data-feather="clock" class="text-grey-darkest"></i>
-	                            </span>
+                                </span>
                             {% elif other_translation.is_outdated %}
-	                            <span title="{% trans 'Translation outdated' %}">
+                                <span title="{% trans 'Translation outdated' %}">
                                     <i data-feather="alert-triangle" class="text-grey-darkest"></i>
-	                            </span>
+                                </span>
                             {% else %}
-	                            <span title="{% trans 'Edit translation' %}">
+                                <span title="{% trans 'Edit translation' %}">
                                     <i data-feather="edit-2" class="text-grey-darkest"></i>
-	                            </span>
+                                </span>
                             {% endif %}
                         {% else %}
-	                        <span title="{% trans 'Create new translation' %}">
+                            <span title="{% trans 'Create new translation' %}">
                                 <i data-feather="plus" class="text-grey-darkest"></i>
-	                        </span>
+                            </span>
                         {% endif %}
                     </a>
                 {% endfor %}
@@ -45,48 +66,42 @@
         </div>
     </td>
     <td>
-        {{ node|page_translation_creator:language }}
-    </td>
-    <td>
-        {{ node|page_translation_last_updated:language }}
-    </td>
-    <td>
-        {{ node|page_translation_created_date:language }}
+        {{ page_translation.last_updated }}
     </td>
     <td class="pl-2 pr-4">
         <!-- TODO: add link to view page in web app -->
-        <a href="{% url 'view_page' page_id=node.id region_slug=region.slug language_code=language.code %}"
+        <a href="{% url 'view_page' page_id=page.id region_slug=region.slug language_code=language.code %}"
            target="_blank"
            title="{% trans 'View page' %}" class="py-3" style="padding-right:4px;">
             <i data-feather="eye" class="text-grey-darkest"></i>
         </a>
-        <a href="{% url 'edit_page' page_id=node.id region_slug=region.slug language_code=language.code %}" title="{% trans 'Edit page' %}" class="py-3" style="padding-left:4px;padding-right:4px;">
+        <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_code=language.code %}" title="{% trans 'Edit page' %}" class="py-3" style="padding-left:4px;padding-right:4px;">
             <i data-feather="edit" class="text-grey-darkest"></i>
         </a>
 
-        <button title="{% trans 'Archive page' %}" class="py-3" style="padding-left:4px;" onclick="confirmation_popup(event, '#confirm_archive_page_{{ node.id }}')">
+        <button title="{% trans 'Archive page' %}" class="py-3" style="padding-left:4px;" onclick="confirmation_popup(event, '#confirm_archive_page_{{ page.id }}')">
             <i data-feather="archive" class="text-grey-darkest"></i>
         </button>
         {% if user.is_superuser or user.is_staff %}
-            {% if node.children.all %}
+            {% if page.children.all %}
                 <button title="{% trans 'You cannot delete a page which has children.' %}" class="py-3" style="padding-left:4px;">
                     <i data-feather="trash-2" class="text-grey"></i>
                 </button>
             {% else %}
-                <button title="{% trans 'Delete page' %}" class="py-3" style="padding-left:4px;" onclick="confirmation_popup(event, '#confirm_delete_page_{{ node.id }}')">
+                <button title="{% trans 'Delete page' %}" class="py-3" style="padding-left:4px;" onclick="confirmation_popup(event, '#confirm_delete_page_{{ page.id }}')">
                     <i data-feather="trash-2" class="text-grey-darkest"></i>
                 </button>
             {% endif %}
         {% endif %}
-        <a href="{% url 'download_page' page_id=node.id region_slug=region.slug language_code=language.code %}"
+        <a href="{% url 'download_page' page_id=page.id region_slug=region.slug language_code=language.code %}"
            title="{% trans 'Download page' %}" class="py-3" style="padding-left:4px;padding-right:4px;">
              <i data-feather="download" class="text-grey-darkest"></i>
         </a>
     </td>
 </tr>
-{% include "./confirmation_popups/archive_page.html" with page=node %}
+{% include "./confirmation_popups/archive_page.html" with page=page %}
 {% if user.is_superuser or user.is_staff %}
-    {% if not node.children.all %}
-        {% include "./confirmation_popups/delete_page.html" with page=node %}
+    {% if not page.children.all %}
+        {% include "./confirmation_popups/delete_page.html" with page=page %}
     {% endif %}
 {% endif %}

--- a/backend/cms/templatetags/page_filters.py
+++ b/backend/cms/templatetags/page_filters.py
@@ -1,58 +1,20 @@
 from django import template
 
+from ..models import Language
+
 register = template.Library()
 
+@register.simple_tag
+def get_page_translation(page, language_code):
+    return page.page_translations.filter(language__code=language_code).first()
+
+# Unify the language codes of backend and content languages
+@register.simple_tag
+def unify_laguage_code(language_code):
+    if language_code == 'en-us':
+        return 'en-gb'
+    return language_code
 
 @register.simple_tag
-def get_other_page_translation(page, language):
-    return page.page_translations.filter(language=language).first()
-
-@register.filter
-def page_translation_title(page, language):
-    all_page_translations = page.page_translations
-    page_translation = all_page_translations.filter(language__code=language.code)
-    if page_translation.exists():
-        return page_translation.first().title
-    if all_page_translations.exists():
-        page_translation = all_page_translations.first()
-        return '{title} ({language})'.format(
-            title=page_translation.title,
-            language=page_translation.language
-        )
-    return ''
-
-@register.filter
-def page_translation_creator(page, language):
-    all_page_translations = page.page_translations
-    page_translation = all_page_translations.filter(language__code=language.code)
-    if page_translation.exists():
-        return page_translation.first().creator
-    if all_page_translations.exists():
-        page_translation = all_page_translations.first()
-        return '{creator} ({language})'.format(
-            creator=page_translation.creator,
-            language=page_translation.language
-        )
-    return ''
-
-
-@register.filter
-def page_translation_last_updated(page, language):
-    all_page_translations = page.page_translations
-    page_translation = all_page_translations.filter(language__code=language.code)
-    if page_translation.exists():
-        return page_translation.first().last_updated
-    if all_page_translations.exists():
-        return all_page_translations.first().last_updated
-    return ''
-
-
-@register.filter
-def page_translation_created_date(page, language):
-    all_page_translations = page.page_translations
-    page_translation = all_page_translations.filter(language__code=language.code)
-    if page_translation.exists():
-        return page_translation.first().created_date
-    if all_page_translations.exists():
-        return all_page_translations.first().created_date
-    return ''
+def translated_language_name(language_code):
+    return Language.objects.get(code=language_code).translated_name

--- a/backend/cms/views/pages/page_form.py
+++ b/backend/cms/views/pages/page_form.py
@@ -66,6 +66,7 @@ class PageForm(forms.ModelForm):
         # pop kwarg to make sure the super class does not get this param
         self.region = kwargs.pop('region', None)
         language = kwargs.pop('language', None)
+        disabled = kwargs.pop('disabled', None)
 
         # add initial kwarg to make sure changed_data is preserved
         kwargs['initial'] = {
@@ -74,6 +75,11 @@ class PageForm(forms.ModelForm):
 
         # instantiate ModelForm
         super(PageForm, self).__init__(*args, **kwargs)
+
+        # If form is disabled because the user has no permissions to edit the page, disable all form fields
+        if disabled:
+            for _, field in self.fields.items():
+                field.disabled = True
 
         if len(args) == 1:
             # dirty hack to remove fields when submitted by POST
@@ -178,6 +184,7 @@ class PageTranslationForm(forms.ModelForm):
         # pop kwarg to make sure the super class does not get this param
         self.region = kwargs.pop('region', None)
         self.language = kwargs.pop('language', None)
+        disabled = kwargs.pop('disabled', None)
 
         # to set the public value through the submit button, we have to overwrite the field value for public.
         # we could also do this in the save() function, but this would mean that it is not recognized in changed_data.
@@ -194,6 +201,11 @@ class PageTranslationForm(forms.ModelForm):
             logger.info('changed POST arg public manually to True')
 
         super(PageTranslationForm, self).__init__(*args, **kwargs)
+
+        # If form is disabled because the user has no permissions to edit the page, disable all form fields
+        if disabled:
+            for _, field in self.fields.items():
+                field.disabled = True
 
         self.fields['public'].widget = forms.Select(choices=self.PUBLIC_CHOICES)
 

--- a/backend/cms/views/pages/page_form.py
+++ b/backend/cms/views/pages/page_form.py
@@ -219,7 +219,8 @@ class PageTranslationForm(forms.ModelForm):
             page_translation.language = self.language
 
         page_translation.version = page_translation.version + 1
-        page_translation.save(force_insert=True)
+        page_translation.pk = None
+        page_translation.save()
 
         return page_translation
 

--- a/backend/cms/views/pages/pages.py
+++ b/backend/cms/views/pages/pages.py
@@ -48,6 +48,9 @@ class PageTreeView(PermissionRequiredMixin, TemplateView):
         # all other languages of current region
         languages = region.languages
 
+        if not request.user.has_perm('cms.edit_page'):
+            messages.warning(request, _("You don't have the permission to edit or create pages."))
+
         return render(
             request,
             self.template_name,

--- a/dev-tools/loadtestdata.sh
+++ b/dev-tools/loadtestdata.sh
@@ -4,15 +4,13 @@
 
 cd $(dirname "$BASH_SOURCE")/..
 source .venv/bin/activate
-# Set docker settings environment variable if postgres container is running
 
-export DJANGO_SETTINGS_MODULE=backend.settings
-if [ -x "$(command -v docker)" ]; then
-    docker ps -q -f name=integreat_django_postgres
-    if [[ $? == 0 ]]; then
-        export DJANGO_SETTINGS_MODULE=backend.docker_settings
-    fi
+# Check if docker is installed and docker socket is available
+if [ -x "$(command -v docker)" ] && docker ps > /dev/null 2>&1; then
+    export DJANGO_SETTINGS_MODULE=backend.docker_settings
 fi
 
+# Create new dummy user if not exists (otherwise the import might fail due to constraints)
+integreat-cms createsuperuser --noinput  --username 'dummy_user' --email 'test@test.test' > /dev/null 2>&1
 integreat-cms loaddata backend/cms/fixtures/test_data.json
 integreat-cms loaddata backend/cms/fixtures/extra_templates.json

--- a/dev-tools/migrate.sh
+++ b/dev-tools/migrate.sh
@@ -5,14 +5,16 @@
 
 cd $(dirname "$BASH_SOURCE")/..
 source .venv/bin/activate
-# Set docker settings environment variable if postgres container is running
 
-export DJANGO_SETTINGS_MODULE=backend.settings
-if [ -x "$(command -v docker)" ]; then
-    docker ps -q -f name=integreat_django_postgres
-    if [[ $? == 0 ]]; then
-        export DJANGO_SETTINGS_MODULE=backend.docker_settings
+# Check if docker is installed and docker socket is available
+if [ -x "$(command -v docker)" ] && docker ps > /dev/null 2>&1; then
+    # Check if postgres container is running
+    if [ ! "$(docker ps -q -f name=integreat_django_postgres)" ]; then
+        echo "The postgres database docker container is not running." >&2
+        exit 1
     fi
+    # Set docker settings environment variable
+    export DJANGO_SETTINGS_MODULE=backend.docker_settings
 fi
 
 integreat-cms makemigrations cms

--- a/dev-tools/prune_database.sh
+++ b/dev-tools/prune_database.sh
@@ -3,14 +3,18 @@
 # This script can be used to prune the complete postgres database.
 # It stops and removes the docker container and removes all database-related directories.
 
-# Stop Postgres Docker container
-if [ "$(docker ps -q -f name=integreat_django_postgres)" ]; then
-    docker stop integreat_django_postgres
-fi
-
-# Remove Postgres Docker container
-if [ "$(docker ps -aq -f status=exited -f name=integreat_django_postgres)" ]; then
-    docker rm integreat_django_postgres
+# Check if docker is installed and docker socket is available
+if [ -x "$(command -v docker)" ] && docker ps > /dev/null 2>&1; then
+    # Check if postgres container is running
+    if [ "$(docker ps -q -f name=integreat_django_postgres)" ]; then
+        # Stop Postgres Docker container
+        docker stop integreat_django_postgres
+    fi
+    # Check if a stopped database container exists
+    if [ "$(docker ps -aq -f status=exited -f name=integreat_django_postgres)" ]; then
+        # Remove Postgres Docker container
+        docker rm integreat_django_postgres
+    fi
 fi
 
 # Remove all database related files

--- a/dev-tools/run.sh
+++ b/dev-tools/run.sh
@@ -7,51 +7,57 @@
 cd $(dirname "$BASH_SOURCE")/..
 source .venv/bin/activate
 
+
 # Re-generating translation file and compile it
 cd backend/cms
+# Reset environment variable to make sure makemessages works
 export DJANGO_SETTINGS_MODULE=
-integreat-cms makemessages -a
+integreat-cms makemessages -l de
 integreat-cms compilemessages
-
 cd ../..
 
-export DJANGO_SETTINGS_MODULE=backend.settings
-if [ -x "$(command -v docker)" ]; then
-    docker ps -q -f name=integreat_django_postgres
-    if [[ $? == 0 ]]; then
-        echo "Using Docker"
-        export DJANGO_SETTINGS_MODULE=backend.docker_settings
+# Ignore POT-Creation-Date of otherwise unchanged translation file
+if git diff --shortstat backend/cms/locale/de/LC_MESSAGES/django.po | grep -q "1 file changed, 1 insertion(+), 1 deletion(-)"; then
+    # Check if script was called with sudo (e.g. for docker) and make sure git checkout is not called as root (would change the file permissions)
+    if [ -z "$SUDO_USER" ]; then
+        git checkout -- backend/cms/locale/de/LC_MESSAGES/django.po
+    else
+        # Execute command as user who executed sudo (inbuilt environment variable)
+        su -c "git checkout -- backend/cms/locale/de/LC_MESSAGES/django.po" $SUDO_USER
     fi
 fi
 
-# Start Postgres Docker container
-if [[ "$DJANGO_SETTINGS_MODULE" == "backend.docker_settings" ]]; then
-    if [ "$(docker ps -aq -f status=exited -f name=integreat_django_postgres)" ]; then
-        # Start the existing container
-        docker start integreat_django_postgres > /dev/null 2>&1
-    else    
-        # Run new container
-        docker run -d --name "integreat_django_postgres" -e "POSTGRES_USER=integreat" -e "POSTGRES_PASSWORD=password" -e "POSTGRES_DB=integreat" -v "$(pwd)/.postgres:/var/lib/postgresql" -p 5433:5432 postgres > /dev/null 2>&1
-        echo -n "Waiting for postgres database container to be ready..."
-        until docker exec -it integreat_django_postgres psql -U integreat -d integreat -c "select 1" > /dev/null 2>&1; do
-          sleep 0.1
-          echo -n "."
-        done
-        echo ""
+# Check if docker is installed and docker socket is available
+if [ -x "$(command -v docker)" ] && docker ps > /dev/null 2>&1; then
+    export DJANGO_SETTINGS_MODULE=backend.docker_settings
+    # Check if postgres database container is already running
+    if [ ! "$(docker ps -q -f name=integreat_django_postgres)" ]; then
+        # Check if stopped container is available
+        if [ "$(docker ps -aq -f status=exited -f name=integreat_django_postgres)" ]; then
+            # Start the existing container
+            docker start integreat_django_postgres > /dev/null 2>&1
+        else
+            # Run new container
+            docker run -d --name "integreat_django_postgres" -e "POSTGRES_USER=integreat" -e "POSTGRES_PASSWORD=password" -e "POSTGRES_DB=integreat" -v "$(pwd)/.postgres:/var/lib/postgresql" -p 5433:5432 postgres > /dev/null 2>&1
+            echo -n "Waiting for postgres database container to be ready..."
+            until docker exec -it integreat_django_postgres psql -U integreat -d integreat -c "select 1" > /dev/null 2>&1; do
+              sleep 0.1
+              echo -n "."
+            done
+            echo ""
+            # Import test data
+            ./dev-tools/loadtestdata.sh
+        fi
     fi
 fi
 
-# Migrate new database
+# Migrate database
 ./dev-tools/migrate.sh
-# Create new dummy user (otherwise the import might fail due to constraints)
-integreat-cms createsuperuser --noinput  --username 'dummy_user' --email 'test@test.test'
-# Import test data
-./dev-tools/loadtestdata.sh
 
 # Start Integreat CMS
 integreat-cms runserver localhost:8000
 
-if [[ "$DJANGO_SETTINGS_MODULE" == "backend.docker_settings" ]]; then
+if [ -x "$(command -v docker)" ] && docker ps > /dev/null 2>&1; then
     # Stop the postgres database docker container
-    docker stop integreat_django_postgres > /dev/null 2>&1
+    docker stop integreat_django_postgres
 fi


### PR DESCRIPTION
- If content and backend language differ, I show two columns in the page view. In the first column there is the page translation title in the content language, in the second column in the backend language. This makes it easier for content creators to manage translations in unknown languages. (Fixes #82)
- If a user has the permissions to view all pages, but not to edit them, the page form gets disabled and a small notification is shown. Thus, it is clear whether or not someone can edit a page and why. (Fixes #157)
- Additionally, I fixed a small bug where the template for new pages could not be rendered. This was due to the tab view and the links to different translation of a not yet existing page. I solved it by showing only one tab when creating a page, and all additional tabs when editing a page.