### PR TITLE
Fix positioning of right column in page form

### DIFF
--- a/backend/cms/templates/pages/page.html
+++ b/backend/cms/templates/pages/page.html
@@ -140,7 +140,7 @@
                 </div>
             </div>
         </div>
-        <div class="w-1/3 pl-4 flex flex-wrap">
+        <div class="w-1/3 pl-4 flex flex-wrap flex-col">
             <ul class="flex" style="list-style: none;">
                 <li class="z-10" style="margin-bottom: -0.1rem;">
                     <div class="bg-white text-blue-dark border-l-2 border-t-2 border-r-2 border-blue-dark font-bold rounded-t-lg py-2 px-4">


### PR DESCRIPTION
I finally found the cause of the weird positioning of the "settings for all translations"-tab in the page form. This does not solve the problem when the tabs are shown in two lines though.