### PR TITLE
Implement 2FA auth using webauthn

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -31,6 +31,9 @@ ALLOWED_HOSTS = [
     '0.0.0.0'
 ]
 
+# Needed for webauthn (this is a setting in case the application runs behind a proxy)
+HOSTNAME = 'localhost'
+BASE_URL = 'http://localhost:8000'
 
 # Application definition
 

--- a/backend/cms/decorators.py
+++ b/backend/cms/decorators.py
@@ -1,6 +1,8 @@
+import time
 from functools import wraps
 
 from django.core.exceptions import PermissionDenied
+from django.shortcuts import redirect
 
 from .models import Region
 
@@ -27,4 +29,13 @@ def region_permission_required(function):
         if region in user.profile.regions.all():
             return function(request, *args, **kwargs)
         raise PermissionDenied
+    return wrap
+
+def modify_mfa_authenticated(function):
+    @wraps(function)
+    def wrap(request, *args, **kwargs):
+        if not 'modify_mfa_authentication_time' in request.session or request.session['modify_mfa_authentication_time'] < (time.time() - 5 * 60):
+            request.session['mfa_redirect_url'] = request.path
+            return redirect('user_settings_auth_modify_mfa')
+        return function(request, *args, **kwargs)
     return wrap

--- a/backend/cms/locale/de/LC_MESSAGES/django.po
+++ b/backend/cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-23 13:30+0000\n"
+"POT-Creation-Date: 2019-11-30 11:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Timo Ludwig <ludwig@integreat-app.de>\n"
 "Language-Team:\n"
@@ -174,104 +174,114 @@ msgid "Author Chat"
 msgstr "Autorenchat"
 
 #: templates/_base.html:94
+#, fuzzy
+#| msgid "General Settings"
+msgid "User Settings"
+msgstr "Allgemeine Einstellungen"
+
+#: templates/_base.html:98
 msgid "Django Administration"
 msgstr "Django Administration"
 
-#: templates/_base.html:98
+#: templates/_base.html:102
 msgid "Log out"
 msgstr "Abmelden"
 
-#: templates/_base.html:105 templates/registration/login.html:10
+#: templates/_base.html:109 templates/registration/login.html:10
+#: templates/registration/login_mfa.html:10
+#: templates/settings/mfa/add_key.html:10
+#: templates/settings/mfa/authenticate.html:10
+#: templates/settings/mfa/delete.html:10
 msgid "Integreat Logo"
 msgstr "Integreat Logo"
 
-#: templates/_base.html:111
+#: templates/_base.html:115
 msgid "My Dashboard"
 msgstr "Mein Dashboard"
 
-#: templates/_base.html:115
+#: templates/_base.html:119
 msgid "Translation Report"
 msgstr "Übersetzungs-Bericht"
 
-#: templates/_base.html:120 templates/analytics/translation_coverage.html:7
+#: templates/_base.html:124 templates/analytics/translation_coverage.html:7
 #: templates/regions/region.html:132
 #: templates/statistics/statistics_dashboard.html:8
 msgid "Statistics"
 msgstr "Statistiken"
 
-#: templates/_base.html:125
+#: templates/_base.html:129
 msgid "Media Library"
 msgstr "Medienbibliothek"
 
-#: templates/_base.html:129 templates/pages/tree.html:12
+#: templates/_base.html:133 templates/pages/tree.html:12
 #: templates/regions/region.html:206
 msgid "Pages"
 msgstr "Seiten"
 
-#: templates/_base.html:133 templates/regions/region.html:207
+#: templates/_base.html:137 templates/regions/region.html:207
 msgid "Events"
 msgstr "Veranstaltungen"
 
-#: templates/_base.html:137 templates/pois/list.html:9
+#: templates/_base.html:141 templates/pois/list.html:9
 msgid "Points of Interest"
 msgstr "POIs"
 
-#: templates/_base.html:141 templates/_base.html:186
+#: templates/_base.html:145 templates/_base.html:190
 #: templates/regions/region.html:204
 msgid "Users"
 msgstr "Benutzer"
 
-#: templates/_base.html:145 templates/_base.html:202
+#: templates/_base.html:149 templates/_base.html:206
 msgid "Feedback"
 msgstr "Feedback"
 
-#: templates/_base.html:149
+#: templates/_base.html:153
 msgid "Push Notifications"
 msgstr "Push-Benachrichtigungen"
 
-#: templates/_base.html:153
+#: templates/_base.html:157
 msgid "PDF Export"
 msgstr "PDF Export"
 
-#: templates/_base.html:157 templates/extras/list.html:9
+#: templates/_base.html:161 templates/extras/list.html:9
 msgid "Extras"
 msgstr "Extras"
 
-#: templates/_base.html:161
+#: templates/_base.html:165
 msgid "Imprint"
 msgstr "Impressum"
 
-#: templates/_base.html:165 templates/language_tree/tree.html:9
+#: templates/_base.html:169 templates/language_tree/tree.html:9
 msgid "Language tree"
 msgstr "Sprach-Baum"
 
-#: templates/_base.html:169 templates/_base.html:206
+#: templates/_base.html:173 templates/_base.html:210
 #: templates/statistics/statistics_dashboard.html:62
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: templates/_base.html:174
+#: templates/_base.html:178
 msgid "Admin Dashboard"
 msgstr "Admin Dashboard"
 
-#: templates/_base.html:178 templates/users/admin/user.html:92
+#: templates/_base.html:182 templates/users/admin/user.html:92
 msgid "Regions"
 msgstr "Regionen"
 
-#: templates/_base.html:182 templates/regions/region.html:205
+#: templates/_base.html:186 templates/regions/region.html:205
 msgid "Languages"
 msgstr "Sprachen"
 
-#: templates/_base.html:190 templates/users/admin/user.html:87
+#: templates/_base.html:194 templates/users/admin/user.html:87
 #: templates/users/region/user.html:77
 msgid "Roles"
 msgstr "Rollen"
 
-#: templates/_base.html:194
+#: templates/_base.html:198
 msgid "Organizations"
 msgstr "Organisationen"
 
-#: templates/_base.html:198
+#: templates/_base.html:202
 msgid "Extra templates"
 msgstr "Extra-Vorlagen"
 
@@ -428,7 +438,7 @@ msgstr "Extra-Vorlagen verwalten"
 msgid "Active since"
 msgstr "Aktiv seit"
 
-#: templates/extras/list.html:33
+#: templates/extras/list.html:33 templates/settings/user.html:16
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -576,7 +586,7 @@ msgstr "Organisation \"%(organization_name)s\" bearbeiten"
 msgid "Create new organization"
 msgstr "Neue Organisation erstellen"
 
-#: templates/organizations/organization.html:22 templates/pages/page.html:65
+#: templates/organizations/organization.html:22 templates/pages/page.html:66
 #: templates/regions/region.html:22
 msgid "Publish"
 msgstr "Veröffentlichen"
@@ -605,7 +615,7 @@ msgstr "Thumbnail der Organisation"
 msgid "Enter the organization's thumbnail here"
 msgstr "Name der Organisations-Thumbnail hier eingeben"
 
-#: templates/organizations/organization.html:66 templates/pages/page.html:194
+#: templates/organizations/organization.html:66 templates/pages/page.html:205
 #: templates/pois/poi.html:134 templates/regions/region.html:90
 msgid "Set icon"
 msgstr "Icon festlegen"
@@ -647,7 +657,7 @@ msgstr "Erlaubnis zum Veröffentlichen erteilen"
 msgid "Archived Pages"
 msgstr "Archivierte Seiten"
 
-#: templates/pages/archive.html:21 templates/pages/page.html:131
+#: templates/pages/archive.html:21 templates/pages/page.html:132
 #: templates/pois/list.html:32 templates/pois/poi.html:36
 #: templates/push_notifications/list.html:24
 #: templates/push_notifications/push_notification.html:49
@@ -711,117 +721,113 @@ msgstr "Alle Übersetzungen dieser Seite werden gelöscht."
 msgid "Yes, delete this page now."
 msgstr "Ja, die Seite jetzt löschen."
 
-#: templates/pages/page.html:40
+#: templates/pages/page.html:41
 #, python-format
 msgid "Edit page \"%(page_title)s\""
 msgstr "Seite \"%(page_title)s\" bearbeiten"
 
-#: templates/pages/page.html:47 templates/pages/tree.html:72
+#: templates/pages/page.html:48 templates/pages/tree.html:72
 #: templates/pages/tree.html:76
 msgid "Title in"
 msgstr "Titel auf"
 
-#: templates/pages/page.html:51 templates/pages/tree_row.html:69
+#: templates/pages/page.html:52 templates/pages/tree_row.html:69
 msgid "Create new translation"
 msgstr "Neue Übersetzung erstellen"
 
-#: templates/pages/page.html:54
+#: templates/pages/page.html:55
 msgid "Create new page"
 msgstr "Neue Seite erstellen"
 
-#: templates/pages/page.html:61
+#: templates/pages/page.html:62
 msgid "Save as draft"
 msgstr "Als Entwurf speichern"
 
-#: templates/pages/page.html:67
+#: templates/pages/page.html:68
 msgid "Submit for review"
 msgstr "Zur Überprüfung vorlegen"
 
-#: templates/pages/page.html:103
+#: templates/pages/page.html:104
 msgid "Side by side view"
 msgstr "Übersetzungen nebeneinander anzeigen"
 
-#: templates/pages/page.html:113 templates/pages/tree.html:70
+#: templates/pages/page.html:114 templates/pages/tree.html:70
 msgid "Version"
 msgstr "Version"
 
-#: templates/pages/page.html:115 templates/pages/tree.html:71
+#: templates/pages/page.html:116 templates/pages/tree.html:71
 #: templates/pois/poi.html:121 templates/regions/list.html:34
 #: templates/regions/region.html:97
 msgid "Status"
 msgstr "Status"
 
-#: templates/pages/page.html:118 templates/pois/poi.html:73
+#: templates/pages/page.html:119 templates/pois/poi.html:73
 #: templates/regions/region.html:54
 msgid "Permalink"
 msgstr ""
 
-#: templates/pages/page.html:120 templates/pois/poi.html:75
+#: templates/pages/page.html:121 templates/pois/poi.html:75
 #: templates/regions/region.html:56
 msgid " Leave blank to generate unique permalink from title"
 msgstr ""
 " Dieses Feld freilassen, um eine eindeutigen Permalink aus dem Titel zu "
 "generieren"
 
-#: templates/pages/page.html:132 templates/pages/sbs_page.html:30
+#: templates/pages/page.html:133 templates/pages/sbs_page.html:30
 #: templates/pois/poi.html:37
 msgid "Insert title here"
 msgstr "Titel hier eingeben"
 
-#: templates/pages/page.html:134
+#: templates/pages/page.html:135
 #: templates/push_notifications/push_notification.html:54
 msgid "Content"
 msgstr "Inhalt"
 
-#: templates/pages/page.html:135 templates/pages/sbs_page.html:33
+#: templates/pages/page.html:136 templates/pages/sbs_page.html:33
 msgid "Insert content here"
 msgstr "Inhalt hier eingeben"
 
-#: templates/pages/page.html:137
+#: templates/pages/page.html:138
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
 
-#: templates/pages/page.html:139
+#: templates/pages/page.html:140
 msgid "This change does not require an update of the translations"
 msgstr "Diese Änderung erfordert keine angepasste Übersetzung"
 
-#: templates/pages/page.html:150
+#: templates/pages/page.html:151
 msgid "Settings for all translations"
 msgstr "Einstellungen für alle Übersetzungen"
 
-#: templates/pages/page.html:158
+#: templates/pages/page.html:159
 msgid "Positioning"
 msgstr "Anordnung"
 
-#: templates/pages/page.html:159
+#: templates/pages/page.html:160
 msgid "Relationship"
 msgstr "Verhältnis"
 
-#: templates/pages/page.html:163
+#: templates/pages/page.html:164
 msgid "Page"
 msgstr "Seite"
 
-#: templates/pages/page.html:170
+#: templates/pages/page.html:171
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: templates/pages/page.html:172
-msgid "Search page"
-msgstr "Seite suchen"
-
-#: templates/pages/page.html:175
+#: templates/pages/page.html:186
 msgid "Embed before content"
 msgstr "Vor Inhalt einbinden"
 
-#: templates/pages/page.html:176
+#: templates/pages/page.html:187
 msgid "Embed after content"
 msgstr "Nach Inhalt einbinden"
 
-#: templates/pages/page.html:183
+#: templates/pages/page.html:194
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: templates/pages/page.html:184
+#: templates/pages/page.html:195
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -829,61 +835,61 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: templates/pages/page.html:190 templates/pois/poi.html:130
+#: templates/pages/page.html:201 templates/pois/poi.html:130
 #: templates/regions/region.html:81
 msgid "Icon"
 msgstr "Icon"
 
-#: templates/pages/page.html:200 templates/pages/tree_row.html:94
+#: templates/pages/page.html:211 templates/pages/tree_row.html:94
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: templates/pages/page.html:202
+#: templates/pages/page.html:213
 msgid "Page is archived."
 msgstr "Die Seite wurde archiviert."
 
-#: templates/pages/page.html:205
+#: templates/pages/page.html:216
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: templates/pages/page.html:211 templates/pages/tree_row.html:103
+#: templates/pages/page.html:222 templates/pages/tree_row.html:103
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: templates/pages/page.html:213 templates/pages/tree_row.html:99
-#: views/pages/page.py:237
+#: templates/pages/page.html:224 templates/pages/tree_row.html:99
+#: views/pages/page.py:236
 msgid "You cannot delete a page which has children."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: templates/pages/page.html:216
+#: templates/pages/page.html:227
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
-#: templates/pages/page.html:255
+#: templates/pages/page.html:305
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
-#: templates/pages/page.html:276
+#: templates/pages/page.html:325
 msgid "Location"
 msgstr "Ort"
 
-#: templates/pages/page.html:283
+#: templates/pages/page.html:332
 msgid "Link"
 msgstr "Link"
 
-#: templates/pages/page.html:290
+#: templates/pages/page.html:339
 msgid "Phone"
 msgstr "Telefon"
 
-#: templates/pages/page.html:297
+#: templates/pages/page.html:346
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
-#: templates/pages/page.html:304
+#: templates/pages/page.html:353
 msgid "Email"
 msgstr "Email"
 
-#: templates/pages/page.html:311
+#: templates/pages/page.html:360
 msgid "Hint"
 msgstr "Tipp"
 
@@ -1278,6 +1284,7 @@ msgstr "Der Benutzername oder das Passwort ist falsch."
 
 #: templates/registration/login.html:18
 #: templates/registration/password_reset_form.html:16
+#: templates/settings/mfa/authenticate.html:18
 msgid "Please try again."
 msgstr "Bitte versuchen Sie es erneut."
 
@@ -1289,16 +1296,28 @@ msgstr ""
 #: templates/registration/login.html:36 templates/registration/login.html:38
 #: templates/registration/password_reset_confirm.html:22
 #: templates/registration/password_reset_confirm.html:24
+#: templates/settings/mfa/authenticate.html:26
+#: templates/settings/mfa/authenticate.html:28
 msgid "Password"
 msgstr "Passwort"
 
 #: templates/registration/login.html:43
+#: templates/settings/mfa/authenticate.html:33
 msgid "Log in"
 msgstr "Anmelden"
 
 #: templates/registration/login.html:46
 msgid "Forgot your password?"
 msgstr "Passwort vergessen?"
+
+#: templates/registration/login_mfa.html:15
+msgid "Unable to verify your 2FA key, please try again."
+msgstr ""
+
+#: templates/registration/login_mfa.html:21
+msgid ""
+"Please authenticate using your 2FA key by following your browser instructions"
+msgstr ""
 
 #: templates/registration/password_reset_confirm.html:9
 msgid "Choose new password"
@@ -1413,9 +1432,105 @@ msgstr "Berechtigungen der Rolle"
 msgid "Admin Settings"
 msgstr "Administrator-Einstellungen"
 
+#: templates/settings/mfa/add_key.html:16
+msgid "Something went wrong during 2FA registration"
+msgstr ""
+
+#: templates/settings/mfa/add_key.html:20
+msgid ""
+"Please enter a nickname for your new key. This nickname can be used to find "
+"the correct key in case you need to revoke authentication."
+msgstr ""
+
+#: templates/settings/mfa/add_key.html:24
+#: templates/settings/mfa/add_key.html:26
+#, fuzzy
+#| msgid "Native name"
+msgid "Nickname"
+msgstr "Nativer Name"
+
+#: templates/settings/mfa/add_key.html:31
+msgid "Add 2FA key"
+msgstr ""
+
+#: templates/settings/mfa/add_key.html:38 templates/settings/mfa/delete.html:37
+msgid "It seems like your browser does not support webauthn"
+msgstr ""
+
+#: templates/settings/mfa/authenticate.html:18
+#, fuzzy
+#| msgid "The username or the password is incorrect."
+msgid "The password is incorrect."
+msgstr "Der Benutzername oder das Passwort ist falsch."
+
+#: templates/settings/mfa/authenticate.html:22
+msgid "Please authenticate to change security related settings"
+msgstr ""
+
+#: templates/settings/mfa/delete.html:18
+msgid "Remove the last key"
+msgstr ""
+
+#: templates/settings/mfa/delete.html:19
+msgid ""
+"This is your last key, once removed you will be able to log in without a "
+"second factor"
+msgstr ""
+
+#: templates/settings/mfa/delete.html:21
+msgid "Remove key"
+msgstr ""
+
+#: templates/settings/mfa/delete.html:22
+msgid ""
+"Once you remove the key you will need to use one of the other available keys "
+"to log into your account. PLease make sure that you have at least one extra "
+"key available to log in before removing this key."
+msgstr ""
+
+#: templates/settings/mfa/delete.html:30
+#, fuzzy
+#| msgid "Delete page"
+msgid "Delete 2FA key"
+msgstr "Seite löschen"
+
 #: templates/settings/settings.html:11
 msgid "Settings for"
 msgstr "Einstellungen für"
+
+#: templates/settings/user.html:8
+#, fuzzy
+#| msgid "General Settings"
+msgid "User settings"
+msgstr "Allgemeine Einstellungen"
+
+#: templates/settings/user.html:9
+msgid "Registered 2FA key"
+msgstr ""
+
+#: templates/settings/user.html:13
+#, fuzzy
+#| msgid "Native name"
+msgid "Key name"
+msgstr "Nativer Name"
+
+#: templates/settings/user.html:14
+#, fuzzy
+#| msgid "Last Name"
+msgid "Last usage"
+msgstr "Nachname"
+
+#: templates/settings/user.html:15
+msgid "Date added"
+msgstr ""
+
+#: templates/settings/user.html:30
+msgid "No 2FA keys have been added yet."
+msgstr ""
+
+#: templates/settings/user.html:36
+msgid "Add a new 2FA key"
+msgstr ""
 
 #: templates/statistics/statistics_dashboard.html:14
 msgid "Page views"
@@ -1609,7 +1724,7 @@ msgstr "Extra-Vorlage wurde erfolgreich erstellt."
 
 #: views/extra_templates/extra_templates.py:74
 #: views/language_tree/language_tree_node.py:70
-#: views/organizations/organizations.py:72 views/pages/page.py:120
+#: views/organizations/organizations.py:72 views/pages/page.py:119
 #: views/pages/sbs_page.py:110 views/pois/poi.py:122
 #: views/push_notifications/push_notifications.py:171
 #: views/regions/regions.py:79 views/roles/roles.py:71
@@ -1665,73 +1780,73 @@ msgstr "Organisation wurde erfolgreich erstellt."
 msgid "Organization saved successfully"
 msgstr "Organisation wurde erfolgreich gespeichert."
 
-#: views/pages/page.py:63
+#: views/pages/page.py:62
 msgid "You don't have the permission to edit this page."
 msgstr "Sie haben nicht die nötige Berechtigung, um diese Seite zu bearbeiten."
 
-#: views/pages/page.py:132 views/pages/sbs_page.py:108 views/pois/poi.py:114
+#: views/pages/page.py:131 views/pages/sbs_page.py:108 views/pois/poi.py:114
 #: views/regions/regions.py:90 views/users/region_users.py:114
 #: views/users/users.py:90
 msgid "No changes detected."
 msgstr "Keine Änderungen vorgenommen."
 
-#: views/pages/page.py:152
+#: views/pages/page.py:151
 msgid "Page was successfully created and published."
 msgstr "Seite wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/pages/page.py:154
+#: views/pages/page.py:153
 msgid "Page was successfully created."
 msgstr "Seite wurde erfolgreich erstellt."
 
-#: views/pages/page.py:157
+#: views/pages/page.py:156
 msgid "Translation was successfully created and published."
 msgstr "Übersetzung wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/pages/page.py:159 views/pages/sbs_page.py:104
+#: views/pages/page.py:158 views/pages/sbs_page.py:104
 msgid "Translation was successfully created."
 msgstr "Übersetzung wurde erfolgreich erstellt."
 
-#: views/pages/page.py:162
+#: views/pages/page.py:161
 msgid "Translation was successfully published."
 msgstr "Übersetzung wurde erfolgreich veröffentlicht."
 
-#: views/pages/page.py:164 views/pages/sbs_page.py:106
+#: views/pages/page.py:163 views/pages/sbs_page.py:106
 msgid "Translation was successfully saved."
 msgstr "Übersetzung wurde erfolgreich gespeichert."
 
-#: views/pages/page.py:184
+#: views/pages/page.py:183
 msgid "Page was successfully archived."
 msgstr "Seite wurde erfolgreich archiviert."
 
-#: views/pages/page.py:203
+#: views/pages/page.py:202
 msgid "Page was successfully restored."
 msgstr "Seite wurde erfolgreich wiederhergestellt."
 
-#: views/pages/page.py:240
+#: views/pages/page.py:239
 msgid "Page was successfully deleted."
 msgstr "Seite wurde erfolgreich gelöscht."
 
-#: views/pages/page.py:300
+#: views/pages/page.py:299
 #, python-brace-format
 msgid "The page \"{page}\" was successfully moved."
 msgstr "Die Seite \"{page}\" wurde erfolgreich verschoben."
 
-#: views/pages/page.py:369 views/pages/page.py:384
+#: views/pages/page.py:368 views/pages/page.py:383
 #, python-brace-format
 msgid "Information: The user {user} has this permission already."
 msgstr "Information: Der Nutzer {user} hat diese Berechtigung bereits"
 
-#: views/pages/page.py:377
+#: views/pages/page.py:376
 #, python-brace-format
 msgid "Success: The user {user} can now edit this page."
 msgstr "Erfolg: Der Nutzer {user} kann nun diese Seite bearbeiten"
 
-#: views/pages/page.py:392
+#: views/pages/page.py:391
 #, python-brace-format
 msgid "Success: The user {user} can now publish this page."
 msgstr "Erfolg: Der Nutzer {user} kann dieses Seite nurn veröffentlichen"
 
-#: views/pages/page.py:467
+#: views/pages/page.py:466
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the editors of this page, "
@@ -1741,12 +1856,12 @@ msgstr ""
 "bearbeiten wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin veröffentlichen"
 
-#: views/pages/page.py:473
+#: views/pages/page.py:472
 #, python-brace-format
 msgid "Success: The user {user} cannot edit this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr bearbeiten"
 
-#: views/pages/page.py:484
+#: views/pages/page.py:483
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the publishers of this "
@@ -1756,7 +1871,7 @@ msgstr ""
 "veröffentlichen wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin veröffentlichen"
 
-#: views/pages/page.py:490
+#: views/pages/page.py:489
 #, python-brace-format
 msgid "Success: The user {user} cannot publish this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr veröffentlichen"
@@ -1857,11 +1972,19 @@ msgstr "Region wurde erfolgreich gelöscht."
 msgid "The passwords do not match."
 msgstr "Die Passwörter stimmen nicht überein."
 
-#: views/registration/registration.py:32
+#: views/registration/registration.py:71 views/registration/registration.py:89
+msgid "You need to log in first"
+msgstr ""
+
+#: views/registration/registration.py:74
+msgid "You are already logged in"
+msgstr ""
+
+#: views/registration/registration.py:135
 msgid "You have been successfully logged off."
 msgstr "Sie wurden erfolgreich abgemeldet."
 
-#: views/registration/registration.py:44
+#: views/registration/registration.py:147
 msgid ""
 "A message with instructions for resetting your password has been sent to the "
 "e-mail address provided."
@@ -1869,11 +1992,11 @@ msgstr ""
 "Eine Nachricht mit Anweisungen zum Zurücksetzen IhresPasswort wurde an die "
 "angegebene E-Mail Adresse geschickt."
 
-#: views/registration/registration.py:69
+#: views/registration/registration.py:172
 msgid "Your password has been successfully changed."
 msgstr "Ihr Passwort wurde erfolgreich geändert."
 
-#: views/registration/registration.py:70
+#: views/registration/registration.py:173
 msgid "You can now log in with your new password."
 msgstr "Sie können sich jetzt mit dem neuen Passwort einloggen."
 
@@ -1884,6 +2007,22 @@ msgstr "Rolle wurde erfolgreich gespeichert."
 #: views/roles/roles.py:65
 msgid "Role created successfully"
 msgstr "Rolle wurde erfolgreich erstellt."
+
+#: views/settings/mfa/mfa.py:59
+#, fuzzy
+#| msgid "The username or the password is incorrect."
+msgid "The provided password is not correct"
+msgstr "Der Benutzername oder das Passwort ist falsch."
+
+#: views/settings/mfa/mfa.py:110
+#, fuzzy
+#| msgid "Maybe it's already been used."
+msgid "This nickname has already been used"
+msgstr "Vielleicht wurde er schon genutzt."
+
+#: views/settings/mfa/mfa.py:114
+msgid "You already registered this key"
+msgstr ""
 
 #: views/statistics/statistics.py:59
 msgid "Please enter a correct start and enddate"
@@ -1919,6 +2058,9 @@ msgstr "Benutzer wurde erfolgreich erstellt."
 #: views/users/region_users.py:134 views/users/users.py:108
 msgid "User was successfully deleted."
 msgstr "Benutzer wurde erfolgreich gelöscht."
+
+#~ msgid "Search page"
+#~ msgstr "Seite suchen"
 
 #~ msgid "Coordinates"
 #~ msgstr "Koordinaten"

--- a/backend/cms/locale/de/LC_MESSAGES/django.po
+++ b/backend/cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-30 11:40+0000\n"
+"POT-Creation-Date: 2019-11-30 12:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Timo Ludwig <ludwig@integreat-app.de>\n"
 "Language-Team:\n"
@@ -174,10 +174,8 @@ msgid "Author Chat"
 msgstr "Autorenchat"
 
 #: templates/_base.html:94
-#, fuzzy
-#| msgid "General Settings"
 msgid "User Settings"
-msgstr "Allgemeine Einstellungen"
+msgstr "Benutzereinstellungen"
 
 #: templates/_base.html:98
 msgid "Django Administration"
@@ -438,7 +436,7 @@ msgstr "Extra-Vorlagen verwalten"
 msgid "Active since"
 msgstr "Aktiv seit"
 
-#: templates/extras/list.html:33 templates/settings/user.html:16
+#: templates/extras/list.html:33 templates/settings/user.html:18
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -1313,11 +1311,15 @@ msgstr "Passwort vergessen?"
 #: templates/registration/login_mfa.html:15
 msgid "Unable to verify your 2FA key, please try again."
 msgstr ""
+"Die 2-Faktor-Authentifizierung konnte nicht durchgeführt werden, bitte "
+"versuchen Sie es erneut."
 
 #: templates/registration/login_mfa.html:21
 msgid ""
 "Please authenticate using your 2FA key by following your browser instructions"
 msgstr ""
+"Bitte authentifizieren Sie sich mit ihrem zweiten Faktor, folgen Sie dazu "
+"den Instruktionen die im Browser angezeigt werden"
 
 #: templates/registration/password_reset_confirm.html:9
 msgid "Choose new password"
@@ -1435,102 +1437,124 @@ msgstr "Administrator-Einstellungen"
 #: templates/settings/mfa/add_key.html:16
 msgid "Something went wrong during 2FA registration"
 msgstr ""
+"Während der Registrierung eines neuen Schlüssels ist ein Fehler aufgetreten"
 
 #: templates/settings/mfa/add_key.html:20
 msgid ""
 "Please enter a nickname for your new key. This nickname can be used to find "
 "the correct key in case you need to revoke authentication."
 msgstr ""
+"Bitte wählen Sie einen Namen für den neuen Schlüssel. Dieser Name kann "
+"verwendet werden um den Schlüssel später zum Bearbeiten der Einstellungen zu "
+"identifizieren."
 
 #: templates/settings/mfa/add_key.html:24
 #: templates/settings/mfa/add_key.html:26
-#, fuzzy
-#| msgid "Native name"
 msgid "Nickname"
-msgstr "Nativer Name"
+msgstr "Schlüsselname"
 
 #: templates/settings/mfa/add_key.html:31
 msgid "Add 2FA key"
-msgstr ""
+msgstr "2FA Schlüssel hinzufügen"
 
 #: templates/settings/mfa/add_key.html:38 templates/settings/mfa/delete.html:37
 msgid "It seems like your browser does not support webauthn"
 msgstr ""
+"Ihr Browser unterstützt leider kein webauthn, es kann kein Schlüssel "
+"hinzugefügt werden"
 
 #: templates/settings/mfa/authenticate.html:18
-#, fuzzy
-#| msgid "The username or the password is incorrect."
 msgid "The password is incorrect."
-msgstr "Der Benutzername oder das Passwort ist falsch."
+msgstr "Das Passwort ist falsch."
 
 #: templates/settings/mfa/authenticate.html:22
 msgid "Please authenticate to change security related settings"
 msgstr ""
+"Bitte loggen Sie sich erneut ein, um sicherheitsrelevante Einstellungen zu "
+"bearbeiten."
 
 #: templates/settings/mfa/delete.html:18
 msgid "Remove the last key"
-msgstr ""
+msgstr "Entfernung des letzten Schlüssels"
 
 #: templates/settings/mfa/delete.html:19
 msgid ""
 "This is your last key, once removed you will be able to log in without a "
 "second factor"
 msgstr ""
+"Dies ist der letzte Schlüssel. Sobald dieser entfernt wurde, ist ein Login "
+"ohne zusätzliche Authentifizierung möglich"
 
 #: templates/settings/mfa/delete.html:21
 msgid "Remove key"
-msgstr ""
+msgstr "Schlüssel entfernen"
 
 #: templates/settings/mfa/delete.html:22
 msgid ""
 "Once you remove the key you will need to use one of the other available keys "
-"to log into your account. PLease make sure that you have at least one extra "
+"to log into your account. Please make sure that you have at least one extra "
 "key available to log in before removing this key."
 msgstr ""
+"Sobald Sie diesen Schlüssel entfernt haben müssen Sie sich mit einem der "
+"übrigen Schlüssel anmelden. Bitte stellen Sie sicher, dass ihnen mindestens "
+"einer der aktuell registrierten Schlüssel vorliegen bevor Sie diesen "
+"Schlüssel entfernen."
 
 #: templates/settings/mfa/delete.html:30
-#, fuzzy
-#| msgid "Delete page"
 msgid "Delete 2FA key"
-msgstr "Seite löschen"
+msgstr "Schlüssel entfernen"
 
 #: templates/settings/settings.html:11
 msgid "Settings for"
 msgstr "Einstellungen für"
 
 #: templates/settings/user.html:8
-#, fuzzy
-#| msgid "General Settings"
 msgid "User settings"
-msgstr "Allgemeine Einstellungen"
+msgstr "Benutzereinstellungen"
 
 #: templates/settings/user.html:9
 msgid "Registered 2FA key"
-msgstr ""
-
-#: templates/settings/user.html:13
-#, fuzzy
-#| msgid "Native name"
-msgid "Key name"
-msgstr "Nativer Name"
-
-#: templates/settings/user.html:14
-#, fuzzy
-#| msgid "Last Name"
-msgid "Last usage"
-msgstr "Nachname"
+msgstr "Hinterlegte 2-Faktor-Schlüssel"
 
 #: templates/settings/user.html:15
+msgid "Key name"
+msgstr "Schlüsselname"
+
+#: templates/settings/user.html:16
+msgid "Last usage"
+msgstr "Letzte verwendung"
+
+#: templates/settings/user.html:17
 msgid "Date added"
-msgstr ""
+msgstr "Hinzugefügt am"
 
-#: templates/settings/user.html:30
+#: templates/settings/user.html:32
 msgid "No 2FA keys have been added yet."
-msgstr ""
+msgstr "Es wurden noch keine 2-Faktor-Schlüssel hinzugefügt."
 
-#: templates/settings/user.html:36
+#: templates/settings/user.html:38
 msgid "Add a new 2FA key"
+msgstr "Neuen Schlüssel hinzufügen"
+
+#: templates/settings/user.html:42
+msgid ""
+"You can use your FIDO2 keys to secure your account. Once you added a key to "
+"your account you won't be able to log in without using the key."
 msgstr ""
+"Sie können einen FIDO2 2-Faktor-Schlüsssel verwenden um Ihren Account "
+"abzusichern. Sobald ein Schlüssel hinzugefügt wurde, ist ein Login nur noch "
+"mit diesem möglich."
+
+#: templates/settings/user.html:43
+msgid ""
+"To make sure that you don't loose access to your account when you loose your "
+"FIDO2 key it is recommended to add multiple keys. Just make sure to keep at "
+"least one key at a secure place."
+msgstr ""
+"Um sicherzustellen, dass Sie den Zugriff auf Ihren Account nicht verlieren, "
+"wenn Sie Ihren Sicherheitsschlüssel nicht mehr verwenden können, wird "
+"empfohlen mindestens einen weiteren Schlüssel zu hinterlegen. Diesen "
+"Ersatzschlüssel sollten Sie an einem sicheren Ort aufbewahren."
 
 #: templates/statistics/statistics_dashboard.html:14
 msgid "Page views"
@@ -1972,19 +1996,19 @@ msgstr "Region wurde erfolgreich gelöscht."
 msgid "The passwords do not match."
 msgstr "Die Passwörter stimmen nicht überein."
 
-#: views/registration/registration.py:71 views/registration/registration.py:89
+#: views/registration/registration.py:66 views/registration/registration.py:84
 msgid "You need to log in first"
-msgstr ""
+msgstr "Sie müssen sich zunäachst einloggen"
 
-#: views/registration/registration.py:74
+#: views/registration/registration.py:69
 msgid "You are already logged in"
-msgstr ""
+msgstr "Sie sind bereits eingeloggt"
 
-#: views/registration/registration.py:135
+#: views/registration/registration.py:130
 msgid "You have been successfully logged off."
 msgstr "Sie wurden erfolgreich abgemeldet."
 
-#: views/registration/registration.py:147
+#: views/registration/registration.py:142
 msgid ""
 "A message with instructions for resetting your password has been sent to the "
 "e-mail address provided."
@@ -1992,11 +2016,11 @@ msgstr ""
 "Eine Nachricht mit Anweisungen zum Zurücksetzen IhresPasswort wurde an die "
 "angegebene E-Mail Adresse geschickt."
 
-#: views/registration/registration.py:172
+#: views/registration/registration.py:167
 msgid "Your password has been successfully changed."
 msgstr "Ihr Passwort wurde erfolgreich geändert."
 
-#: views/registration/registration.py:173
+#: views/registration/registration.py:168
 msgid "You can now log in with your new password."
 msgstr "Sie können sich jetzt mit dem neuen Passwort einloggen."
 
@@ -2008,21 +2032,21 @@ msgstr "Rolle wurde erfolgreich gespeichert."
 msgid "Role created successfully"
 msgstr "Rolle wurde erfolgreich erstellt."
 
-#: views/settings/mfa/mfa.py:59
+#: views/settings/mfa/mfa.py:52
 #, fuzzy
 #| msgid "The username or the password is incorrect."
 msgid "The provided password is not correct"
 msgstr "Der Benutzername oder das Passwort ist falsch."
 
-#: views/settings/mfa/mfa.py:110
+#: views/settings/mfa/mfa.py:103
 #, fuzzy
 #| msgid "Maybe it's already been used."
 msgid "This nickname has already been used"
 msgstr "Vielleicht wurde er schon genutzt."
 
-#: views/settings/mfa/mfa.py:114
+#: views/settings/mfa/mfa.py:107
 msgid "You already registered this key"
-msgstr ""
+msgstr "Sie haben diesen Schlüssel bereits registriert"
 
 #: views/statistics/statistics.py:59
 msgid "Please enter a correct start and enddate"

--- a/backend/cms/locale/de/LC_MESSAGES/django.po
+++ b/backend/cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-30 12:24+0000\n"
+"POT-Creation-Date: 2019-11-30 12:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Timo Ludwig <ludwig@integreat-app.de>\n"
 "Language-Team:\n"
@@ -1996,19 +1996,19 @@ msgstr "Region wurde erfolgreich gelöscht."
 msgid "The passwords do not match."
 msgstr "Die Passwörter stimmen nicht überein."
 
-#: views/registration/registration.py:66 views/registration/registration.py:84
+#: views/registration/registration.py:64 views/registration/registration.py:82
 msgid "You need to log in first"
 msgstr "Sie müssen sich zunäachst einloggen"
 
-#: views/registration/registration.py:69
+#: views/registration/registration.py:67
 msgid "You are already logged in"
 msgstr "Sie sind bereits eingeloggt"
 
-#: views/registration/registration.py:130
+#: views/registration/registration.py:128
 msgid "You have been successfully logged off."
 msgstr "Sie wurden erfolgreich abgemeldet."
 
-#: views/registration/registration.py:142
+#: views/registration/registration.py:140
 msgid ""
 "A message with instructions for resetting your password has been sent to the "
 "e-mail address provided."
@@ -2016,11 +2016,11 @@ msgstr ""
 "Eine Nachricht mit Anweisungen zum Zurücksetzen IhresPasswort wurde an die "
 "angegebene E-Mail Adresse geschickt."
 
-#: views/registration/registration.py:167
+#: views/registration/registration.py:165
 msgid "Your password has been successfully changed."
 msgstr "Ihr Passwort wurde erfolgreich geändert."
 
-#: views/registration/registration.py:168
+#: views/registration/registration.py:166
 msgid "You can now log in with your new password."
 msgstr "Sie können sich jetzt mit dem neuen Passwort einloggen."
 
@@ -2032,19 +2032,19 @@ msgstr "Rolle wurde erfolgreich gespeichert."
 msgid "Role created successfully"
 msgstr "Rolle wurde erfolgreich erstellt."
 
-#: views/settings/mfa/mfa.py:52
+#: views/settings/mfa/mfa.py:50
 #, fuzzy
 #| msgid "The username or the password is incorrect."
 msgid "The provided password is not correct"
 msgstr "Der Benutzername oder das Passwort ist falsch."
 
-#: views/settings/mfa/mfa.py:103
+#: views/settings/mfa/mfa.py:101
 #, fuzzy
 #| msgid "Maybe it's already been used."
 msgid "This nickname has already been used"
 msgstr "Vielleicht wurde er schon genutzt."
 
-#: views/settings/mfa/mfa.py:107
+#: views/settings/mfa/mfa.py:105
 msgid "You already registered this key"
 msgstr "Sie haben diesen Schlüssel bereits registriert"
 

--- a/backend/cms/models/__init__.py
+++ b/backend/cms/models/__init__.py
@@ -35,3 +35,5 @@ from .configuration import Configuration
 from .organization import Organization
 
 from .user_profile import UserProfile
+
+from .user_mfa import UserMfa

--- a/backend/cms/models/user_mfa.py
+++ b/backend/cms/models/user_mfa.py
@@ -8,6 +8,8 @@ class UserMfa(models.Model):
     key_id = models.BinaryField(max_length=255, null=False)
     public_key = models.BinaryField(max_length=255, null=False)
     sign_count = models.IntegerField(null=False)
+    last_usage = models.DateTimeField(null=True)
+    created_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
         return self.user.username + str(self.key_id)

--- a/backend/cms/models/user_mfa.py
+++ b/backend/cms/models/user_mfa.py
@@ -14,6 +14,4 @@ class UserMfa(models.Model):
 
     class Meta:
         default_permissions = ()
-        constraints = [
-            models.UniqueConstraint(fields=['user', 'name'], name='unique_key_nickname')
-        ]
+        unique_together = (('user', 'name', ), )

--- a/backend/cms/models/user_mfa.py
+++ b/backend/cms/models/user_mfa.py
@@ -1,0 +1,19 @@
+from django.db import models
+from django.conf import settings
+
+class UserMfa(models.Model):
+
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='mfa_keys', on_delete=models.CASCADE)
+    name = models.CharField(max_length=200)
+    key_id = models.BinaryField(max_length=255, null=False)
+    public_key = models.BinaryField(max_length=255, null=False)
+    sign_count = models.IntegerField(null=False)
+
+    def __str__(self):
+        return self.user.username + str(self.key_id)
+
+    class Meta:
+        default_permissions = ()
+        constraints = [
+            models.UniqueConstraint(fields=['user', 'name'], name='unique_key_nickname')
+        ]

--- a/backend/cms/static/js/mfa-utils.js
+++ b/backend/cms/static/js/mfa-utils.js
@@ -1,0 +1,76 @@
+// Based on https://github.com/duo-labs/py_webauthn/blob/master/flask_demo/static/js/webauthn.js
+function b64enc(buf) {
+    return base64js.fromByteArray(buf)
+                .replace(/\+/g, "-")
+                .replace(/\//g, "_")
+                .replace(/=/g, "");
+}
+
+function b64RawEnc(buf) {
+    return base64js.fromByteArray(buf)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function hexEncode(buf) {
+    return Array.from(buf)
+        .map(function(x) {
+            return ("0" + x.toString(16)).substr(-2);
+        })
+        .join("");
+}
+
+
+const transformCredentialRequestOptions = (credentialRequestOptionsFromServer) => {
+    let {challenge, allowCredentials} = credentialRequestOptionsFromServer;
+
+    challenge = Uint8Array.from(
+        atob(challenge), c => c.charCodeAt(0));
+
+    allowCredentials = allowCredentials.map(credentialDescriptor => {
+        let {id} = credentialDescriptor;
+        id = id.replace(/\_/g, "/").replace(/\-/g, "+");
+        id = Uint8Array.from(atob(id), c => c.charCodeAt(0));
+        return Object.assign({}, credentialDescriptor, {id});
+    });
+
+    const transformedCredentialRequestOptions = Object.assign(
+        {},
+        credentialRequestOptionsFromServer,
+        {challenge, allowCredentials});
+
+    return transformedCredentialRequestOptions;
+};
+
+const transformAssertionForServer = (newAssertion) => {
+    const authData = new Uint8Array(newAssertion.response.authenticatorData);
+    const clientDataJSON = new Uint8Array(newAssertion.response.clientDataJSON);
+    const rawId = new Uint8Array(newAssertion.rawId);
+    const sig = new Uint8Array(newAssertion.response.signature);
+    const assertionClientExtensions = newAssertion.getClientExtensionResults();
+
+    return {
+        id: newAssertion.id,
+        rawId: b64enc(rawId),
+        type: newAssertion.type,
+        authData: b64RawEnc(authData),
+        clientData: b64RawEnc(clientDataJSON),
+        signature: hexEncode(sig),
+        assertionClientExtensions: JSON.stringify(assertionClientExtensions)
+    };
+};
+
+function transformCredentialCreateOptions(credentialCreateOptionsFromServer) {
+    let {challenge, user} = credentialCreateOptionsFromServer;
+    user.id = Uint8Array.from(
+        credentialCreateOptionsFromServer.user.id, c => c.charCodeAt(0));
+
+    challenge = Uint8Array.from(
+        atob(credentialCreateOptionsFromServer.challenge), c => c.charCodeAt(0));
+    
+    const transformedCredentialCreateOptions = Object.assign(
+            {}, credentialCreateOptionsFromServer,
+            {challenge, user});
+
+    return transformedCredentialCreateOptions;
+};

--- a/backend/cms/templates/_base.html
+++ b/backend/cms/templates/_base.html
@@ -88,6 +88,10 @@
             <a href="/" class="relative block pl-10 pr-4 py-3 text-grey-darkest hover:bg-grey">
                 <i data-feather="message-square" class="absolute"></i>
 	            {% trans 'Author Chat' %}
+			</a>
+			<a href="{% url 'user_settings' %}" class="relative block pl-10 pr-4 py-3 text-grey-darkest hover:bg-grey">
+                <i data-feather="settings" class="absolute"></i>
+	            {% trans 'User Settings' %}
             </a>
             <a href="/admin" class="break-words relative block pl-10 pr-4 py-3 text-grey-darkest hover:bg-grey">
                 <i data-feather="grid" class="absolute"></i>

--- a/backend/cms/templates/_raw.html
+++ b/backend/cms/templates/_raw.html
@@ -17,6 +17,7 @@
     {% compress js %}
     <script src="{% static 'umbrellajs/umbrella.js' %}"></script>
     <script src="{% static 'feather-icons/dist/feather.js' %}"></script>
+    <script src="{% static 'base64-js/base64js.min.js' %}"></script>
     {% endcompress %}
 </head>
 <body>

--- a/backend/cms/templates/registration/login_mfa.html
+++ b/backend/cms/templates/registration/login_mfa.html
@@ -1,0 +1,141 @@
+{% extends "_raw.html" %}
+{% load i18n %}
+{% block raw_content %}
+{% load static %}
+{% load widget_tweaks %}
+<div id="no-session" class="flex flex-wrap flex-col justify-center px-3 py-10">
+    <div class="mx-auto w-full max-w-xs">
+        <div class="mb-3" style="padding: 0 50px;">
+            <a href="/">
+                <img src="{% static 'images/integreat-logo.png' %}" alt="{% trans 'Integreat Logo' %}" class="w-full" />
+            </a>
+        </div>
+        <div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+            <div class="auth-error bg-red-lightest border-l-4 border-red text-red-dark px-4 py-3 mb-5 hidden" role="alert">
+                <p>{% trans 'Unable to verify your 2FA key, please try again.' %}</p>
+            </div>
+            <div class="mb-3">
+                {% include "messages.html" %}
+            </div>
+            <div class="mb-3">
+                {% trans 'Please authenticate using your 2FA key by following your browser instructions' %}
+            </div>
+        </div>
+        <p class="text-center text-grey text-xs">
+	        &copy;2018 Tür an Tür - Digital Factory gGmbH
+        </p>
+    </div>
+</div>
+{% endblock %}
+
+{% block javascript_nocompress %}
+<script>
+    window.django_csrf_token = '{{ csrf_token }}';
+</script>
+
+{% endblock %}
+
+{% block javascript %}
+<script>
+    // Based on https://github.com/duo-labs/py_webauthn/blob/master/flask_demo/static/js/webauthn.js
+    function b64enc(buf) {
+        return base64js.fromByteArray(buf)
+                    .replace(/\+/g, "-")
+                    .replace(/\//g, "_")
+                    .replace(/=/g, "");
+    }
+
+    function b64RawEnc(buf) {
+        return base64js.fromByteArray(buf)
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_");
+    }
+
+    function hexEncode(buf) {
+        return Array.from(buf)
+            .map(function(x) {
+                return ("0" + x.toString(16)).substr(-2);
+            })
+            .join("");
+    }
+
+
+    const transformCredentialRequestOptions = (credentialRequestOptionsFromServer) => {
+        let {challenge, allowCredentials} = credentialRequestOptionsFromServer;
+
+        challenge = Uint8Array.from(
+            atob(challenge), c => c.charCodeAt(0));
+
+        allowCredentials = allowCredentials.map(credentialDescriptor => {
+            let {id} = credentialDescriptor;
+            id = id.replace(/\_/g, "/").replace(/\-/g, "+");
+            id = Uint8Array.from(atob(id), c => c.charCodeAt(0));
+            return Object.assign({}, credentialDescriptor, {id});
+        });
+
+        const transformedCredentialRequestOptions = Object.assign(
+            {},
+            credentialRequestOptionsFromServer,
+            {challenge, allowCredentials});
+
+        return transformedCredentialRequestOptions;
+    };
+
+    const transformAssertionForServer = (newAssertion) => {
+        const authData = new Uint8Array(newAssertion.response.authenticatorData);
+        const clientDataJSON = new Uint8Array(newAssertion.response.clientDataJSON);
+        const rawId = new Uint8Array(newAssertion.rawId);
+        const sig = new Uint8Array(newAssertion.response.signature);
+        const assertionClientExtensions = newAssertion.getClientExtensionResults();
+
+        return {
+            id: newAssertion.id,
+            rawId: b64enc(rawId),
+            type: newAssertion.type,
+            authData: b64RawEnc(authData),
+            clientData: b64RawEnc(clientDataJSON),
+            signature: hexEncode(sig),
+            assertionClientExtensions: JSON.stringify(assertionClientExtensions)
+        };
+    };
+
+    window.addEventListener('load', async () => {
+        try {
+            const webauthn_assert = await(await fetch('{% url "login_mfa_assert" %}')).json();
+            
+            const transformedCredentialRequestOptions = transformCredentialRequestOptions(
+                webauthn_assert);
+
+            // request the authenticator to create an assertion signature using the
+            // credential private key
+            let assertion;
+            assertion = await navigator.credentials.get({
+                publicKey: transformedCredentialRequestOptions,
+            });
+
+            // we now have an authentication assertion! encode the byte arrays contained
+            // in the assertion data as strings for posting to the server
+            const transformedAssertionForServer = transformAssertionForServer(assertion);
+
+            const result = await fetch("{% url 'login_mfa_verify' %}", {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': window.django_csrf_token
+                },
+                body: JSON.stringify(transformedAssertionForServer)
+            });
+            const data = await result.json();
+            if(data.success) {
+                location.href = "/"
+            } else {
+                document.querySelector('.auth-error').classList.remove('hidden');
+                setTimeout(() => location.href = '/', 2000);
+            }
+        } catch (e) {
+            document.querySelector('.auth-error').classList.remove('hidden');
+            setTimeout(() => location.href = '/', 2000);
+        }
+    });
+</script>
+{% endblock %}

--- a/backend/cms/templates/registration/login_mfa.html
+++ b/backend/cms/templates/registration/login_mfa.html
@@ -36,69 +36,9 @@
 {% endblock %}
 
 {% block javascript %}
+<script src="{% static 'js/mfa-utils.js' %}"></script>
 <script>
     // Based on https://github.com/duo-labs/py_webauthn/blob/master/flask_demo/static/js/webauthn.js
-    function b64enc(buf) {
-        return base64js.fromByteArray(buf)
-                    .replace(/\+/g, "-")
-                    .replace(/\//g, "_")
-                    .replace(/=/g, "");
-    }
-
-    function b64RawEnc(buf) {
-        return base64js.fromByteArray(buf)
-        .replace(/\+/g, "-")
-        .replace(/\//g, "_");
-    }
-
-    function hexEncode(buf) {
-        return Array.from(buf)
-            .map(function(x) {
-                return ("0" + x.toString(16)).substr(-2);
-            })
-            .join("");
-    }
-
-
-    const transformCredentialRequestOptions = (credentialRequestOptionsFromServer) => {
-        let {challenge, allowCredentials} = credentialRequestOptionsFromServer;
-
-        challenge = Uint8Array.from(
-            atob(challenge), c => c.charCodeAt(0));
-
-        allowCredentials = allowCredentials.map(credentialDescriptor => {
-            let {id} = credentialDescriptor;
-            id = id.replace(/\_/g, "/").replace(/\-/g, "+");
-            id = Uint8Array.from(atob(id), c => c.charCodeAt(0));
-            return Object.assign({}, credentialDescriptor, {id});
-        });
-
-        const transformedCredentialRequestOptions = Object.assign(
-            {},
-            credentialRequestOptionsFromServer,
-            {challenge, allowCredentials});
-
-        return transformedCredentialRequestOptions;
-    };
-
-    const transformAssertionForServer = (newAssertion) => {
-        const authData = new Uint8Array(newAssertion.response.authenticatorData);
-        const clientDataJSON = new Uint8Array(newAssertion.response.clientDataJSON);
-        const rawId = new Uint8Array(newAssertion.rawId);
-        const sig = new Uint8Array(newAssertion.response.signature);
-        const assertionClientExtensions = newAssertion.getClientExtensionResults();
-
-        return {
-            id: newAssertion.id,
-            rawId: b64enc(rawId),
-            type: newAssertion.type,
-            authData: b64RawEnc(authData),
-            clientData: b64RawEnc(clientDataJSON),
-            signature: hexEncode(sig),
-            assertionClientExtensions: JSON.stringify(assertionClientExtensions)
-        };
-    };
-
     window.addEventListener('load', async () => {
         try {
             const webauthn_assert = await(await fetch('{% url "login_mfa_assert" %}')).json();

--- a/backend/cms/templates/settings/mfa/add_key.html
+++ b/backend/cms/templates/settings/mfa/add_key.html
@@ -48,33 +48,12 @@
 </script>
 {% endblock %}
 {% block javascript %}
+<script src="{% static 'js/mfa-utils.js' %}"></script>
 <script>
     // Based on https://github.com/duo-labs/py_webauthn/blob/master/flask_demo/static/js/webauthn.js
-    function b64enc(arrayBuffer) {
-        return base64js.fromByteArray(arrayBuffer)
-                   .replace(/\+/g, "-")
-                   .replace(/\//g, "_")
-                   .replace(/=/g, "");
-    }
-
     if(!navigator.credentials.create) {
         document.querySelector('.add-mfa').classList.add('hidden');
         document.querySelector('.mfa-not-supported').classList.remove('hidden');
-    }
-
-    function transformCredentialCreateOptions(credentialCreateOptionsFromServer) {
-        let {challenge, user} = credentialCreateOptionsFromServer;
-        user.id = Uint8Array.from(
-            credentialCreateOptionsFromServer.user.id, c => c.charCodeAt(0));
-
-        challenge = Uint8Array.from(
-            atob(credentialCreateOptionsFromServer.challenge), c => c.charCodeAt(0));
-        
-        const transformedCredentialCreateOptions = Object.assign(
-                {}, credentialCreateOptionsFromServer,
-                {challenge, user});
-
-        return transformedCredentialCreateOptions;
     }
 
     const addMfaForm = document.querySelector('form[data-action="add2FaKey"]');

--- a/backend/cms/templates/settings/mfa/add_key.html
+++ b/backend/cms/templates/settings/mfa/add_key.html
@@ -1,0 +1,137 @@
+{% extends "_raw.html" %}
+{% load i18n %}
+{% block raw_content %}
+{% load static %}
+{% load widget_tweaks %}
+<div id="no-session" class="flex flex-wrap flex-col justify-center px-3 py-10">
+    <div class="mx-auto w-full max-w-xs">
+        <div class="mb-3" style="padding: 0 50px;">
+            <a href="/">
+                <img src="{% static 'images/integreat-logo.png' %}" alt="{% trans 'Integreat Logo' %}" class="w-full" />
+            </a>
+        </div>
+        <div class="add-mfa bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+            <form data-action="add2FaKey">
+                <div class="bg-red-lightest border-l-4 border-red text-red-dark px-4 py-3 mb-5 hidden add-mfa-error" role="alert">
+                    <p>{% trans 'Something went wrong during 2FA registration' %}</p>
+                    <p class="add-mfa-error-msg"></p>
+                </div>
+                <div class="mb-6">
+                    <p>{% trans 'Please enter a nickname for your new key. This nickname can be used to find the correct key in case you need to revoke authentication.' %}</p>
+                </div>
+                <div class="mb-4">
+                    <label class="block text-grey-darker text-sm font-bold mb-2" for="nickname">
+	                    {% trans 'Nickname' %}
+                    </label>
+	                {% trans 'Nickname' as nickname_placeholder%}
+                    {% render_field form.nickname id="nickname" placeholder=nickname_placeholder class="shadow appearance-none border rounded w-full py-2 px-3 text-grey-darker leading-tight focus:outline-none focus:shadow-outline" %}
+                </div>
+                <div class="flex items-center justify-between">
+                    <button type="submit" class="bg-integreat hover:bg-grey-dark hover:text-white text-grey-darkest font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
+	                    {% trans 'Add 2FA key' %}
+                    </button>
+                </div>
+            </form>
+        </div>
+        <div class="mfa-not-supported bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4 hidden">
+            <div class="mb-6">
+                <p>{% trans 'It seems like your browser does not support webauthn' %}</p>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block javascript_nocompress %}
+<script>
+    window.django_csrf_token = '{{ csrf_token }}';
+</script>
+{% endblock %}
+{% block javascript %}
+<script>
+    // Based on https://github.com/duo-labs/py_webauthn/blob/master/flask_demo/static/js/webauthn.js
+    function b64enc(arrayBuffer) {
+        return base64js.fromByteArray(arrayBuffer)
+                   .replace(/\+/g, "-")
+                   .replace(/\//g, "_")
+                   .replace(/=/g, "");
+    }
+
+    if(!navigator.credentials.create) {
+        document.querySelector('.add-mfa').classList.add('hidden');
+        document.querySelector('.mfa-not-supported').classList.remove('hidden');
+    }
+
+    function transformCredentialCreateOptions(credentialCreateOptionsFromServer) {
+        let {challenge, user} = credentialCreateOptionsFromServer;
+        user.id = Uint8Array.from(
+            credentialCreateOptionsFromServer.user.id, c => c.charCodeAt(0));
+
+        challenge = Uint8Array.from(
+            atob(credentialCreateOptionsFromServer.challenge), c => c.charCodeAt(0));
+        
+        const transformedCredentialCreateOptions = Object.assign(
+                {}, credentialCreateOptionsFromServer,
+                {challenge, user});
+
+        return transformedCredentialCreateOptions;
+    }
+
+    const addMfaForm = document.querySelector('form[data-action="add2FaKey"]');
+    const nicknameField = document.querySelector('input[name="nickname"]');
+
+    addMfaForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        try {
+            document.querySelector('.add-mfa-error').classList.add('hidden');
+            document.querySelector('.add-mfa-error-msg').textContent = '';
+            const webauthn_configuration = await(await fetch('/user_settings/mfa/get_challenge/')).json();
+            
+            const newAssertion = await navigator.credentials.create({
+                publicKey: transformCredentialCreateOptions(webauthn_configuration)
+            });            
+            
+            const attObj = new Uint8Array(
+                newAssertion.response.attestationObject);
+            const clientDataJSON = new Uint8Array(
+                newAssertion.response.clientDataJSON);
+            const rawId = new Uint8Array(
+                newAssertion.rawId);
+            
+            const registrationClientExtensions = newAssertion.getClientExtensionResults();
+
+            const formData = {
+                id: newAssertion.id,
+                rawId: b64enc(rawId),
+                type: newAssertion.type,
+                attObj: b64enc(attObj),
+                clientData: b64enc(clientDataJSON),
+                registrationClientExtensions: JSON.stringify(registrationClientExtensions)
+            };
+
+            const result = await fetch("{% url 'user_settings_register_mfa_key' %}", {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': window.django_csrf_token
+                },
+                body: JSON.stringify({
+                    assertion: formData,
+                    nickname: nicknameField.value
+                })
+            });
+            const data = await result.json();
+            if(data.success) {
+                location.href = "{% url 'user_settings' %}"
+            } else {
+                document.querySelector('.add-mfa-error').classList.remove('hidden');
+                document.querySelector('.add-mfa-error-msg').textContent = data.error;
+            }
+        } catch (e) {
+            console.error(e);
+            document.querySelector('.add-mfa-error').classList.remove('hidden');
+        }
+    });
+</script>
+{% endblock %}

--- a/backend/cms/templates/settings/mfa/authenticate.html
+++ b/backend/cms/templates/settings/mfa/authenticate.html
@@ -1,0 +1,40 @@
+{% extends "_raw.html" %}
+{% load i18n %}
+{% block raw_content %}
+{% load static %}
+{% load widget_tweaks %}
+<div id="no-session" class="flex flex-wrap flex-col justify-center px-3 py-10">
+    <div class="mx-auto w-full max-w-xs">
+        <div class="mb-3" style="padding: 0 50px;">
+            <a href="/">
+                <img src="{% static 'images/integreat-logo.png' %}" alt="{% trans 'Integreat Logo' %}" class="w-full" />
+            </a>
+        </div>
+        <div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+            <form method="post">
+                {% csrf_token %}
+                {% if form.errors %}
+                <div class="bg-red-lightest border-l-4 border-red text-red-dark px-4 py-3 mb-5" role="alert">
+                    <p>{% trans 'The password is incorrect.' %} {% trans 'Please try again.' %}</p>
+                </div>
+                {% endif %}
+                <div class="mb-6">
+                    <p>{% trans 'Please authenticate to change security related settings' %}</p>
+                </div>
+                <div class="mb-4">
+                    <label class="block text-grey-darker text-sm font-bold mb-2" for="password">
+	                    {% trans 'Password' %}
+                    </label>
+	                {% trans 'Password' as password_placeholder%}
+                    {% render_field form.password id="password" placeholder=password_placeholder class="shadow appearance-none border rounded w-full py-2 px-3 text-grey-darker leading-tight focus:outline-none focus:shadow-outline" %}
+                </div>
+                <div class="flex items-center justify-between">
+                    <button type="submit" class="bg-integreat hover:bg-grey-dark hover:text-white text-grey-darkest font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
+	                    {% trans 'Log in' %}
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/backend/cms/templates/settings/mfa/delete.html
+++ b/backend/cms/templates/settings/mfa/delete.html
@@ -1,0 +1,42 @@
+{% extends "_raw.html" %}
+{% load i18n %}
+{% block raw_content %}
+{% load static %}
+{% load widget_tweaks %}
+<div id="no-session" class="flex flex-wrap flex-col justify-center px-3 py-10">
+    <div class="mx-auto w-full max-w-xs">
+        <div class="mb-3" style="padding: 0 50px;">
+            <a href="/">
+                <img src="{% static 'images/integreat-logo.png' %}" alt="{% trans 'Integreat Logo' %}" class="w-full" />
+            </a>
+        </div>
+        <div class="add-mfa bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+            <form method="POST">
+                {% csrf_token %}
+                <div class="mb-6">
+                    {% if last_key %}
+                        <h2 class="mb-4">{% trans 'Remove the last key' %}</h2>
+                        <p>{% trans 'This is your last key, once removed you will be able to log in without a second factor' %}</p>
+                    {% else %}
+                        <h2 class="mb-4">{% trans 'Remove key' %}</h2>
+                        <p>{% trans 'Once you remove the key you will need to use one of the other available keys to log into your account. PLease make sure that you have at least one extra key available to log in before removing this key.' %}</p>
+                    {% endif %}
+                </div>
+                <div class="my-4">
+                    <p><b>Nickname: </b>{{ key.name }}</p>
+                </div>
+                <div class="flex items-center justify-between">
+                    <button type="submit" class="bg-red hover:bg-red-dark text-white text-grey-darkest font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
+	                    {% trans 'Delete 2FA key' %}
+                    </button>
+                </div>
+            </form>
+        </div>
+        <div class="mfa-not-supported bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4 hidden">
+            <div class="mb-6">
+                <p>{% trans 'It seems like your browser does not support webauthn' %}</p>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/backend/cms/templates/settings/mfa/delete.html
+++ b/backend/cms/templates/settings/mfa/delete.html
@@ -19,7 +19,7 @@
                         <p>{% trans 'This is your last key, once removed you will be able to log in without a second factor' %}</p>
                     {% else %}
                         <h2 class="mb-4">{% trans 'Remove key' %}</h2>
-                        <p>{% trans 'Once you remove the key you will need to use one of the other available keys to log into your account. PLease make sure that you have at least one extra key available to log in before removing this key.' %}</p>
+                        <p>{% trans 'Once you remove the key you will need to use one of the other available keys to log into your account. Please make sure that you have at least one extra key available to log in before removing this key.' %}</p>
                     {% endif %}
                 </div>
                 <div class="my-4">

--- a/backend/cms/templates/settings/user.html
+++ b/backend/cms/templates/settings/user.html
@@ -1,0 +1,37 @@
+{% extends "_base.html" %}
+{% load i18n %}
+
+{% block content %}
+{% load static %}
+
+
+<h2 class="heading font-normal mb-2">{% trans 'User settings' %}</h2>
+<h3>{% trans 'Registered 2FA key' %}</h3>
+<table class="w-full mt-4 rounded border border-solid border-grey-light shadow bg-white">
+    <thead>
+        <tr class="border-b border-solid border-grey-light">
+            <th class="text-sm text-left uppercase py-3 pl-4 pr-2">{% trans 'Key name' %}</th>
+            <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Last usage' %}</th>
+            <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Date added' %}</th>
+            <th class="text-sm text-left uppercase py-3 pl-2 pr-4" style="width: 50px;">{% trans 'Actions' %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for key in keys %}
+        <tr>
+            <td class="pl-4">{{ key.name }}</td>
+            <td class="pl-2">123</td>
+            <td class="pl-2">123</td>
+            <td class="pr-4 p-2 text-right"><a class="button" href="{% url 'user_settings_delete_mfa_key' key_id=key.id %}"><i data-feather="trash" class="text-grey-darkest"></i></a></td>
+        </tr>
+    {% empty %}
+        <tr>
+            <td colspan="6" class="px-4 py-3">
+                {% trans 'No 2FA keys have been added yet.' %}
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+<p><a class="bg-blue hover:bg-blue-dark text-white font-bold py-2 px-4 rounded inline-block my-4" href="{% url 'user_settings_add_new_mfa_key' %}">{% trans 'Add a new 2FA key' %}</a></p>
+{% endblock %}

--- a/backend/cms/templates/settings/user.html
+++ b/backend/cms/templates/settings/user.html
@@ -7,31 +7,42 @@
 
 <h2 class="heading font-normal mb-2">{% trans 'User settings' %}</h2>
 <h3>{% trans 'Registered 2FA key' %}</h3>
-<table class="w-full mt-4 rounded border border-solid border-grey-light shadow bg-white">
-    <thead>
-        <tr class="border-b border-solid border-grey-light">
-            <th class="text-sm text-left uppercase py-3 pl-4 pr-2">{% trans 'Key name' %}</th>
-            <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Last usage' %}</th>
-            <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Date added' %}</th>
-            <th class="text-sm text-left uppercase py-3 pl-2 pr-4" style="width: 50px;">{% trans 'Actions' %}</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for key in keys %}
-        <tr>
-            <td class="pl-4">{{ key.name }}</td>
-            <td class="pl-2">123</td>
-            <td class="pl-2">123</td>
-            <td class="pr-4 p-2 text-right"><a class="button" href="{% url 'user_settings_delete_mfa_key' key_id=key.id %}"><i data-feather="trash" class="text-grey-darkest"></i></a></td>
-        </tr>
-    {% empty %}
-        <tr>
-            <td colspan="6" class="px-4 py-3">
-                {% trans 'No 2FA keys have been added yet.' %}
-            </td>
-        </tr>
-    {% endfor %}
-    </tbody>
-</table>
-<p><a class="bg-blue hover:bg-blue-dark text-white font-bold py-2 px-4 rounded inline-block my-4" href="{% url 'user_settings_add_new_mfa_key' %}">{% trans 'Add a new 2FA key' %}</a></p>
+<div class="flex flex-wrap mt-4">
+    <div class="w-2/3 pr-2">
+        <table class="w-full rounded border border-solid border-grey-light shadow bg-white">
+            <thead>
+                <tr class="border-b border-solid border-grey-light">
+                    <th class="text-sm text-left uppercase py-3 pl-4 pr-2">{% trans 'Key name' %}</th>
+                    <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Last usage' %}</th>
+                    <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Date added' %}</th>
+                    <th class="text-sm text-left uppercase py-3 pl-2 pr-4" style="width: 50px;">{% trans 'Actions' %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for key in keys %}
+                <tr>
+                    <td class="pl-4">{{ key.name }}</td>
+                    <td class="pl-2">123</td>
+                    <td class="pl-2">123</td>
+                    <td class="pr-4 p-2 text-right"><a class="button" href="{% url 'user_settings_delete_mfa_key' key_id=key.id %}"><i data-feather="trash" class="text-grey-darkest"></i></a></td>
+                </tr>
+            {% empty %}
+                <tr>
+                    <td colspan="6" class="px-4 py-3">
+                        {% trans 'No 2FA keys have been added yet.' %}
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        <p><a class="bg-blue hover:bg-blue-dark text-white font-bold py-2 px-4 rounded inline-block my-4" href="{% url 'user_settings_add_new_mfa_key' %}">{% trans 'Add a new 2FA key' %}</a></p>
+    </div>
+    <div class="w-1/3 pl-2">
+        <div class="w-full p-4 mb-4 rounded border border-solid border-grey-light shadow bg-white">
+                {% trans "You can use your FIDO2 keys to secure your account. Once you added a key to your account you won't be able to log in without using the key." %}<br>
+                {% trans "To make sure that you don't loose access to your account when you loose your FIDO2 key it is recommended to add multiple keys. Just make sure to keep at least one key at a secure place." %}
+        </div>
+    </div>
+</div>
+
 {% endblock %}

--- a/backend/cms/templates/settings/user.html
+++ b/backend/cms/templates/settings/user.html
@@ -22,8 +22,8 @@
                 {% for key in keys %}
                 <tr>
                     <td class="pl-4">{{ key.name }}</td>
-                    <td class="pl-2">123</td>
-                    <td class="pl-2">123</td>
+                    <td class="pl-2">{{ key.last_usage }}</td>
+                    <td class="pl-2">{{ key.created_at }}</td>
                     <td class="pr-4 p-2 text-right"><a class="button" href="{% url 'user_settings_delete_mfa_key' key_id=key.id %}"><i data-feather="trash" class="text-grey-darkest"></i></a></td>
                 </tr>
             {% empty %}

--- a/backend/cms/urls.py
+++ b/backend/cms/urls.py
@@ -17,6 +17,7 @@ from .views import organizations
 from .views import extras
 from .views import extra_templates
 from .views import settings
+from .views.settings import mfa
 from .views import statistics
 from .views import regions
 from .views import registration
@@ -125,7 +126,16 @@ urlpatterns = [
     ])),
 
     url(r'^settings/$', settings.AdminSettingsView.as_view(), name='admin_settings'),
+    url(r'^user_settings/$', settings.UserSettingsView.as_view(), name='user_settings'),
+    url(r'^user_settings/mfa/register/$', mfa.register_mfa_key, name='user_settings_register_mfa_key'),
+    url(r'^user_settings/mfa/delete/(?P<key_id>\d+)$', mfa.DeleteMfaKey.as_view(), name='user_settings_delete_mfa_key'),
+    url(r'^user_settings/mfa/get_challenge/$', mfa.GetChallengeView.as_view(), name='user_settings_mfa_get_challenge'),
+    url(r'^user_settings/add_new_mfa_key/$', mfa.AddMfaKeyView.as_view(), name='user_settings_add_new_mfa_key'),
+    url(r'^user_settings/authenticate_modify_mfa/$', mfa.AuthenticateModifyMfaView.as_view(), name='user_settings_auth_modify_mfa'),
     url(r'^login/$', registration.login, name='login'),
+    url(r'^login/mfa/$', registration.mfa, name='login_mfa'),
+    url(r'^login/mfa/assert$', registration.mfaAssert, name='login_mfa_assert'),
+    url(r'^login/mfa/verify$', registration.mfaVerify, name='login_mfa_verify'),
     url(r'^logout/$', registration.logout, name='logout'),
     url(r'^password_reset/', include([
         url(

--- a/backend/cms/views/registration/__init__.py
+++ b/backend/cms/views/registration/__init__.py
@@ -2,5 +2,5 @@
 Python standard Init-File
 """
 from .registration import login, logout
-from .registration import password_reset_done, password_reset_confirm, password_reset_complete
+from .registration import password_reset_done, password_reset_confirm, password_reset_complete, mfa, mfaAssert, mfaVerify
 from .forms import PasswordResetConfirmForm

--- a/backend/cms/views/registration/registration.py
+++ b/backend/cms/views/registration/registration.py
@@ -1,8 +1,6 @@
 """
 Handling of login, logout and password reset functionality.
 """
-import random
-import string
 import json
 
 from django.contrib import messages
@@ -18,12 +16,7 @@ from django.http import JsonResponse
 import webauthn
 
 from backend import settings
-
-def generate_challenge(challenge_len):
-    return ''.join([
-        random.SystemRandom().choice(string.ascii_letters + string.digits)
-        for i in range(challenge_len)
-    ])
+from cms.views.utils.mfa_utils import generate_challenge
 
 class MfaEnableAuthentication(auth_views.LoginView):
     def form_valid(self, form):

--- a/backend/cms/views/registration/registration.py
+++ b/backend/cms/views/registration/registration.py
@@ -2,6 +2,7 @@
 Handling of login, logout and password reset functionality.
 """
 import json
+import datetime
 
 from django.contrib import messages
 from django.contrib.auth import logout as django_logout
@@ -110,6 +111,7 @@ def mfaVerify(request):
 
     # Update counter.
     key.sign_count = sign_count
+    key.last_usage = datetime.datetime.now()
     key.save()
 
     auth_login(request, user, backend='django.contrib.auth.backends.ModelBackend')

--- a/backend/cms/views/settings/__init__.py
+++ b/backend/cms/views/settings/__init__.py
@@ -1,2 +1,3 @@
 from .settings import SettingsView
 from .settings import AdminSettingsView
+from .settings import UserSettingsView

--- a/backend/cms/views/settings/mfa/__init__.py
+++ b/backend/cms/views/settings/mfa/__init__.py
@@ -1,0 +1,5 @@
+from .mfa import register_mfa_key
+from .mfa import GetChallengeView
+from .mfa import AuthenticateModifyMfaView
+from .mfa import AddMfaKeyView
+from .mfa import DeleteMfaKey

--- a/backend/cms/views/settings/mfa/mfa.py
+++ b/backend/cms/views/settings/mfa/mfa.py
@@ -1,0 +1,124 @@
+import time
+import random
+import string
+import json
+
+import webauthn
+from django.http import JsonResponse
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView, View
+from django.contrib.auth.decorators import login_required
+from django import forms
+from django.views.generic.edit import FormView
+from django.contrib.auth.hashers import check_password
+from django.utils.translation import ugettext as _
+from django.shortcuts import render, redirect
+from cms.models import UserMfa
+from backend import settings
+
+from ....decorators import modify_mfa_authenticated
+
+
+def generate_challenge(challenge_len):
+    return ''.join([
+        random.SystemRandom().choice(string.ascii_letters + string.digits)
+        for i in range(challenge_len)
+    ])
+
+
+class AddMfaKeyForm(forms.Form):
+    nickname = forms.CharField(max_length=255, required=True)
+
+
+@method_decorator(login_required, name='dispatch')
+@method_decorator(modify_mfa_authenticated, name='dispatch')
+class AddMfaKeyView(FormView):
+    template_name = 'settings/mfa/add_key.html'
+    form_class = AddMfaKeyForm
+
+
+class AuthenticationForm(forms.Form):
+    attrs = {
+        "type": "password",
+        "required": True
+    }
+    password = forms.CharField(widget=forms.TextInput(attrs=attrs))
+
+@method_decorator(login_required, name='dispatch')
+class AuthenticateModifyMfaView(FormView):
+    template_name = 'settings/mfa/authenticate.html'
+    form_class = AuthenticationForm
+    success_url = '/user_settings/add_new_mfa_key/'
+
+    def form_valid(self, form):
+        if check_password(form.cleaned_data['password'], self.request.user.password):
+            self.request.session['modify_mfa_authentication_time'] = time.time()
+            if 'mfa_redirect_url' in self.request.session:
+                return redirect(self.request.session['mfa_redirect_url'])
+            return super().form_valid(form)
+        form.add_error('password', _('The provided password is not correct'))
+        return super().form_invalid(form)
+
+@method_decorator(login_required, name='dispatch')
+@method_decorator(modify_mfa_authenticated, name='dispatch')
+class GetChallengeView(View):
+    def get(self, request):
+        challenge = generate_challenge(32)
+        request.session['mfa_registration_challenge'] = challenge
+
+        user = request.user
+
+        make_credential_options = webauthn.WebAuthnMakeCredentialOptions(
+            challenge,
+            'Integreat',
+            settings.HOSTNAME,
+            user.id,
+            user.username,
+            user.first_name + " " + user.last_name,
+            '')
+        return JsonResponse(make_credential_options.registration_dict)
+
+@method_decorator(login_required, name='dispatch')
+@method_decorator(modify_mfa_authenticated, name='dispatch')
+class DeleteMfaKey(TemplateView):
+    template_name = 'settings/mfa/delete.html'
+
+    def get(self, request, *args, **kwargs):
+        key = request.user.mfa_keys.get(id=kwargs['key_id'])
+        return render(request,
+                      self.template_name,
+                      {'key': key,
+                       'last_key': request.user.mfa_keys.count() == 1})
+
+    def post(self, request, **kwargs):
+        key = request.user.mfa_keys.get(id=kwargs['key_id'])
+        key.delete()
+        return redirect('user_settings')
+
+
+def register_mfa_key(request):
+    webauthn_registration_response = webauthn.WebAuthnRegistrationResponse(
+        settings.HOSTNAME,
+        settings.BASE_URL,
+        json.loads(request.body)['assertion'],
+        request.session['mfa_registration_challenge'])
+
+    webauthn_credential = webauthn_registration_response.verify()
+
+    existing_key = request.user.mfa_keys.filter(name=json.loads(request.body)['nickname'])
+    if len(existing_key) > 0:
+        return JsonResponse({'success': False, 'error': _('This nickname has already been used')})
+
+    existing_key = request.user.mfa_keys.filter(key_id=webauthn_credential.credential_id)
+    if len(existing_key) > 0:
+        return JsonResponse({'success': False, 'error': _('You already registered this key')})
+
+    new_key = UserMfa(
+        user=request.user,
+        name=json.loads(request.body)['nickname'],
+        key_id=webauthn_credential.credential_id,
+        public_key=webauthn_credential.public_key,
+        sign_count=webauthn_credential.sign_count
+    )
+    new_key.save()
+    return JsonResponse({'success': True})

--- a/backend/cms/views/settings/settings.py
+++ b/backend/cms/views/settings/settings.py
@@ -2,6 +2,7 @@ from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 from django.shortcuts import render
+from django.views.decorators.cache import never_cache
 
 from ...decorators import staff_required, region_permission_required
 
@@ -32,3 +33,15 @@ class AdminSettingsView(TemplateView):
                       self.template_name,
                       {**self.base_context,
                        'settings': settings})
+
+@method_decorator(login_required, name='dispatch')
+class UserSettingsView(TemplateView):
+    template_name = 'settings/user.html'
+
+    @never_cache
+    def get(self, request, *args, **kwargs):
+        user = request.user
+
+        return render(request,
+                      self.template_name,
+                      {'keys': user.mfa_keys.all()})

--- a/backend/cms/views/utils/mfa_utils.py
+++ b/backend/cms/views/utils/mfa_utils.py
@@ -1,0 +1,8 @@
+import random
+import string
+
+def generate_challenge(challenge_len):
+    return ''.join([
+        random.SystemRandom().choice(string.ascii_letters + string.digits)
+        for i in range(challenge_len)
+    ])

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "postcss-cli": "^6.1.3"
   },
   "dependencies": {
+    "base64-js": "^1.3.1",
     "chart.js": "^2.9.3",
     "feather-icons": "^4.24.1",
     "tinymce": "^5.1.2",

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "requests",
         "rules",
         "six",
+        "webauthn",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Add a settings view, allowing a user to register multiple keys and remove those.
Changing MFA settings is only possible if the user (re-)verified his identity (using a password) within the last 5 minutes.
Question is: Should 2FA be checked before changes are allowed to be made?
I don't see a thread model where this would help. The user already proved his identity by logging in in the first place and the password check is only there if someone gains access to the already logged in session. Asking for the password again makes sure that the attacker could not gain persistent access. If the password was leaked he would need the key to log in in the first place.
Asking for 2FA to edit 2FA settings would only help against an attacker that has the valid password and got access to a valid session somehow.

Add a new login step in case there is a key to verify.

Fixes #131 

This is my first PR, so there is most likely a lot of things that don't align with your standards and as this is a quite large PR as well I expect a lot of comments on this :P
I did not fix lining errors yet, as pylint_runner shows me a ton on unrelated files as well