### PR TITLE
Refactor generate_unique_slug

### DIFF
--- a/backend/cms/locale/de/LC_MESSAGES/django.po
+++ b/backend/cms/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-17 18:56+0000\n"
+"POT-Creation-Date: 2019-12-19 19:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Timo Ludwig <ludwig@integreat-app.de>\n"
 "Language-Team:\n"
@@ -1171,7 +1171,7 @@ msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
-#: templates/pages/page.html:310
+#: templates/pages/page.html:311
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
@@ -2053,35 +2053,35 @@ msgid "You cannot edit this event because it is archived."
 msgstr ""
 "Sie können diese Veranstaltung nicht bearbeiten, weil sie archiviert ist."
 
-#: views/events/event_view.py:130 views/pages/page.py:131
-#: views/pages/sbs_page.py:107 views/pois/poi.py:113
+#: views/events/event_view.py:132 views/pages/page.py:131
+#: views/pages/sbs_page.py:107 views/pois/poi.py:114
 #: views/regions/regions.py:90 views/users/region_users.py:113
 #: views/users/users.py:90
 msgid "No changes detected."
 msgstr "Keine Änderungen vorgenommen."
 
-#: views/events/event_view.py:156
+#: views/events/event_view.py:157
 msgid "Event was successfully created and published."
 msgstr "Veranstaltung wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/events/event_view.py:158
+#: views/events/event_view.py:159
 msgid "Event was successfully created."
 msgstr "Veranstaltung wurde erfolgreich erstellt."
 
-#: views/events/event_view.py:166
+#: views/events/event_view.py:167
 msgid "Event translation was successfully created and published."
 msgstr ""
 "Veranstaltungsübersetzung wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/events/event_view.py:168
+#: views/events/event_view.py:169
 msgid "Event translation was successfully created."
 msgstr "Veranstaltungsübersetzung wurde erfolgreich erstellt."
 
-#: views/events/event_view.py:171
+#: views/events/event_view.py:172
 msgid "Event was successfully published."
 msgstr "Veranstaltung wurde erfolgreich veröffentlicht."
 
-#: views/events/event_view.py:173
+#: views/events/event_view.py:174
 msgid "Event was successfully saved."
 msgstr "Veranstaltung wurde erfolgreich gespeichert."
 
@@ -2138,7 +2138,7 @@ msgstr "Extra-Vorlage wurde erfolgreich erstellt."
 #: views/extra_templates/extra_templates.py:74
 #: views/language_tree/language_tree_node.py:69
 #: views/organizations/organizations.py:72 views/pages/page.py:119
-#: views/pages/sbs_page.py:109 views/pois/poi.py:121
+#: views/pages/sbs_page.py:109 views/pois/poi.py:122
 #: views/push_notifications/push_notifications.py:169
 #: views/regions/regions.py:79 views/roles/roles.py:71
 #: views/users/region_users.py:116 views/users/users.py:93
@@ -2303,7 +2303,7 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um Seiten zu bearbeiten oder zu "
 "erstellen."
 
-#: views/pois/poi.py:96 views/pois/poi.py:143
+#: views/pois/poi.py:96 views/pois/poi.py:144
 msgid "POI was successfully archived."
 msgstr "POI wurde erfolgreich archiviert."
 
@@ -2331,7 +2331,7 @@ msgstr "POI Übersetzung wurde erfolgreich veröffentlich."
 msgid "POI Translation was successfully saved."
 msgstr "POI Übersetzung wurde erfolgreich gespeichert."
 
-#: views/pois/poi.py:160
+#: views/pois/poi.py:161
 msgid "POI was successfully restored."
 msgstr "POI wurde erfolgreich wiederhergestellt."
 

--- a/backend/cms/models/event.py
+++ b/backend/cms/models/event.py
@@ -172,10 +172,17 @@ class EventTranslation(models.Model):
     last_updated = models.DateTimeField(auto_now=True)
 
     @property
+    def foreign_object(self):
+        return self.event
+
+    @property
     def permalink(self):
-        return self.event.region.slug + '/' \
-               + self.language.code + '/' \
-               + self.slug + '/'
+        return '/'.join([
+            self.event.region.slug,
+            self.language.code,
+            'events',
+            self.slug
+        ])
 
     def __str__(self):
         return self.title

--- a/backend/cms/models/poi.py
+++ b/backend/cms/models/poi.py
@@ -76,7 +76,6 @@ class POITranslation(models.Model):
     slug = models.SlugField(max_length=200, blank=True, allow_unicode=True)
     poi = models.ForeignKey(POI, related_name='translations', null=True,
                             on_delete=models.SET_NULL)
-    permalink = models.CharField(max_length=60)
     status = models.CharField(max_length=6, choices=status.CHOICES, default=status.DRAFT)
     short_description = models.CharField(max_length=250)
     description = models.TextField()
@@ -87,6 +86,19 @@ class POITranslation(models.Model):
     created_date = models.DateTimeField(default=timezone.now)
     last_updated = models.DateTimeField(auto_now=True)
     creator = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, on_delete=models.SET_NULL)
+
+    @property
+    def foreign_object(self):
+        return self.poi
+
+    @property
+    def permalink(self):
+        return '/'.join([
+            self.poi.region.slug,
+            self.language.code,
+            'pois',
+            self.slug
+        ])
 
     class Meta:
         default_permissions = ()

--- a/backend/cms/templates/pois/poi.html
+++ b/backend/cms/templates/pois/poi.html
@@ -75,7 +75,7 @@
                     {% trans ' Leave blank to generate unique permalink from title' as slug_placeholder%}
                     {% spaceless %}
                         <div style="display: table; white-space: nowrap;">
-                            <span style="display: table-cell;">https://integreat.app/{{ region.slug }}/{{ language.code }}/</span>
+                            <span style="display: table-cell;">https://integreat.app/{{ region.slug }}/{{ language.code }}/pois/</span>
                             {% if poi_translation_form.instance.ancestor_path %}
                                 <span style="display: table-cell;">{{ poi_translation_form.instance.ancestor_path }}/</span>
                             {% endif %}

--- a/backend/cms/views/events/event_view.py
+++ b/backend/cms/views/events/event_view.py
@@ -97,6 +97,8 @@ class EventView(PermissionRequiredMixin, TemplateView):
         event_translation_form = EventTranslationForm(
             data=request.POST,
             instance=event_translation_instance,
+            region=region,
+            language=language,
         )
 
         if (
@@ -146,7 +148,6 @@ class EventView(PermissionRequiredMixin, TemplateView):
             )
             event_translation = event_translation_form.save(
                 event=event,
-                language=language,
                 user=request.user
             )
 

--- a/backend/cms/views/pois/poi.py
+++ b/backend/cms/views/pois/poi.py
@@ -110,6 +110,7 @@ class POIView(PermissionRequiredMixin, TemplateView):
                     else:
                         messages.success(request, _('POI Translation was successfully saved.'))
             else:
+                poi = poi_instance
                 messages.info(request, _('No changes detected.'))
 
             return redirect('edit_poi', **{

--- a/backend/cms/views/utils/slug_utils.py
+++ b/backend/cms/views/utils/slug_utils.py
@@ -1,9 +1,18 @@
+import logging
+
 from django.utils.text import slugify
 
-from ...models import Page, Event
+
+logger = logging.getLogger(__name__)
 
 
 def generate_unique_slug(form_object, foreign_model=None):
+
+    logger.info('generate_unique_slug()')
+    if foreign_model:
+        logger.info('foreign_model: "%s"', foreign_model)
+        logger.info('region: "%s"', form_object.region)
+        logger.info('language: "%s"', form_object.language)
 
     slug = form_object.cleaned_data['slug']
 
@@ -24,37 +33,31 @@ def generate_unique_slug(form_object, foreign_model=None):
     i = 1
     pre_filtered_objects = form_object.Meta.model.objects
 
-    # if the foreign model is a content type (e.g. page or event), make sure slug is unique per region and language
+    # if the foreign model is a content type (e.g. page, event or poi), make sure slug is unique per region and language
     if foreign_model:
-        try:
-            foreign_instance = getattr(form_object.instance, foreign_model)
-        except (Page.DoesNotExist, Event.DoesNotExist):
-            return slug
         pre_filtered_objects = pre_filtered_objects.filter(**{
-            foreign_model + '__region': foreign_instance.region,
-            'language': form_object.instance.language
+            foreign_model + '__region': form_object.region,
+            'language': form_object.language
         })
 
     # generate new slug while it is not unique
     while True:
         # get other objects with same slug
-        other_object = pre_filtered_objects.filter(
-            slug=unique_slug
-        )
-        if foreign_model:
-            # other objects which are just other versions of this object are allowed to have the same slug
-            other_object = other_object.exclude(**{
-                foreign_model: foreign_instance,
-                'language': form_object.instance.language
-            })
-        else:
-            # the current object is also allowed to have the same slug
-            other_object = other_object.exclude(
-                id=form_object.instance.id,
-            )
-        if not other_object.exists():
+        other_objects = pre_filtered_objects.filter(slug=unique_slug)
+        if form_object.instance.id:
+            if foreign_model:
+                # other objects which are just other versions of this object are allowed to have the same slug
+                other_objects = other_objects.exclude(**{
+                    foreign_model: form_object.instance.foreign_object,
+                    'language': form_object.language
+                })
+            else:
+                # the current object is also allowed to have the same slug
+                other_objects = other_objects.exclude(id=form_object.instance.id)
+        if not other_objects.exists():
             break
         i += 1
         unique_slug = '{}-{}'.format(slug, i)
 
+    logger.info('unique slug: %s', unique_slug)
     return unique_slug

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "base64-js": "^1.3.1",
     "chart.js": "^2.9.3",
-    "feather-icons": "^4.24.1",
-    "tinymce": "^5.1.2",
+    "feather-icons": "^4.25.0",
+    "tinymce": "^5.1.5",
     "tinymce-i18n": "^19.9.17",
     "umbrellajs": "^3.1.0"
   }


### PR DESCRIPTION
I refactored the clean slug method because it was buggy for new objects.
The main changes include:
    - the region and language parameter for checking for existing slugs come from the form object now instead of the form object instance
    - the new property `translation.foreign_object` allows us to get the meta object for different content types, e.g. `page_translation.page` or `event_translation.event`
This changes also fixed the issue that POIs could not be created.

Fixes #262
Fixes #260