### PR TITLE
Improve readonly forms

### DIFF
--- a/backend/cms/templates/events/event_form.html
+++ b/backend/cms/templates/events/event_form.html
@@ -59,15 +59,15 @@
         </div>
         {% has_perm 'cms.edit_events' request.user as can_edit_event %}
         {% if not event_form.instance.id or not event_form.instance.archived %}
-        <div class="w-1/5 flex justify-end mb-6">
-        {% if can_edit_event %}
-            <input type="submit" name="submit_draft" class="bg-gray-500 hover:bg-gray-600 cursor-pointer text-white font-bold py-3 px-4 rounded mr-2" value="{% trans 'Save as draft' %}" />
-        {% has_perm 'cms.publish_events' request.user as can_publish_event %}
-        {% if can_publish_event %}
-            <input type="submit" name="submit_public" class="cursor-pointer bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded" value="{% trans 'Publish' %}" />
-        {% else %}
-            <input type="submit" name="submit_review" class="cursor-pointer bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded" value="{% trans 'Submit for review' %}" />
-        {% endif %}
+            <div class="w-1/5 flex justify-end mb-6">
+            {% if can_edit_event %}
+                <input type="submit" name="submit_draft" class="bg-gray-500 hover:bg-gray-600 cursor-pointer text-white font-bold py-3 px-4 rounded mr-2" value="{% trans 'Save as draft' %}" />
+            {% has_perm 'cms.publish_events' request.user as can_publish_event %}
+            {% if can_publish_event %}
+                <input type="submit" name="submit_public" class="cursor-pointer bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded" value="{% trans 'Publish' %}" />
+            {% else %}
+                <input type="submit" name="submit_review" class="cursor-pointer bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded" value="{% trans 'Submit for review' %}" />
+            {% endif %}
         {% endif %}
         </div>
         {% endif %}

--- a/backend/cms/templates/events/event_form.html
+++ b/backend/cms/templates/events/event_form.html
@@ -433,7 +433,8 @@ document.addEventListener('DOMContentLoaded', function(){
                     editor.insertContent('<img src="{% static "svg/idea.svg" %}" style="width:1.5em">');
                 }
             });
-        }
+        }{% has_perm 'cms.edit_events' request.user as can_edit_event %}{% if not can_edit_event or event_form.instance.id and event_form.instance.archived %},
+            readonly : 1{% endif %}
     });
 
     custom_file_field();

--- a/backend/cms/templates/pages/page_form.html
+++ b/backend/cms/templates/pages/page_form.html
@@ -61,14 +61,16 @@
         </div>
         <div class="w-1/5 flex justify-end mb-6">
         {% has_perm 'cms.edit_page' request.user page as can_edit_page %}
-        {% if can_edit_page %}
-            <input type="submit" name="submit_draft" class="bg-gray-500 hover:bg-gray-600 cursor-pointer text-white font-bold py-3 px-4 rounded mr-2" value="{% trans 'Save as draft' %}" />
-        {% endif %}
-        {% has_perm 'cms.publish_page' request.user page as can_publish_page %}
-        {% if can_publish_page %}
-            <input type="submit" name="submit_public" class="cursor-pointer bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded" value="{% trans 'Publish' %}" />
-        {% else %}
-            <input type="submit" name="submit_review" class="cursor-pointer bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded" value="{% trans 'Submit for review' %}" />
+        {% if not page_form.instance.id or not page_form.instance.archived %}
+            {% if can_edit_page %}
+                <input type="submit" name="submit_draft" class="bg-gray-500 hover:bg-gray-600 cursor-pointer text-white font-bold py-3 px-4 rounded mr-2" value="{% trans 'Save as draft' %}" />
+            {% endif %}
+            {% has_perm 'cms.publish_page' request.user page as can_publish_page %}
+            {% if can_publish_page %}
+                <input type="submit" name="submit_public" class="cursor-pointer bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded" value="{% trans 'Publish' %}" />
+            {% else %}
+                <input type="submit" name="submit_review" class="cursor-pointer bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded" value="{% trans 'Submit for review' %}" />
+            {% endif %}
         {% endif %}
         </div>
         <div class="w-2/3 flex flex-wrap flex-col pr-2">

--- a/backend/cms/templates/pages/page_form.html
+++ b/backend/cms/templates/pages/page_form.html
@@ -344,7 +344,8 @@ document.addEventListener('DOMContentLoaded', function(){
                     editor.insertContent('<img src="{% static "svg/idea.svg" %}" style="width:1.5em">');
                 }
             });
-        }
+        }{% has_perm 'cms.edit_page' request.user page as can_edit_page %}{% if not can_edit_page or page_form.instance.id and page_form.instance.archived %},
+        readonly : 1{% endif %}
     });
 
     custom_file_field();

--- a/backend/cms/views/pages/page_view.py
+++ b/backend/cms/views/pages/page_view.py
@@ -48,9 +48,14 @@ class PageView(PermissionRequiredMixin, TemplateView):
         ).first()
 
         # Make form disabled if user has no permission to edit the page
-        disabled = not request.user.has_perm('cms.edit_page', page)
-        if disabled:
+        if not request.user.has_perm('cms.edit_page', page):
+            disabled = True
             messages.warning(request, _("You don't have the permission to edit this page."))
+        elif page and page.archived:
+            disabled = True
+            messages.warning(request, _("You cannot edit this page because it is archived."))
+        else:
+            disabled = False
 
         page_form = PageForm(
             instance=page,


### PR DESCRIPTION
- Make TinyMCE textarea readonly when form is disabled (fixes #277)
- Disable submitting forms of archived pages/events (fixes #278)