### PR TITLE
Add new translation icons

### DIFF
--- a/backend/cms/locale/de/LC_MESSAGES/django.po
+++ b/backend/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-02 14:14+0000\n"
+"POT-Creation-Date: 2020-03-02 14:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -18,8 +18,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: constants/administrative_division.py:20 templates/events/event_form.html:228
-#: templates/pois/poi_form.html:143 templates/pois/poi_list.html:67
+#: constants/administrative_division.py:20 templates/events/event_form.html:271
+#: templates/pois/poi_form.html:186 templates/pois/poi_list.html:67
 #: templates/pois/poi_list_archived.html:41
 msgid "City"
 msgstr "Stadt"
@@ -471,9 +471,13 @@ msgid "Translations up-to-date"
 msgstr "Aktuelle Übersetzungen"
 
 #: templates/analytics/translation_coverage.html:46
-#: templates/pages/page_form.html:93 templates/pages/page_form.html:117
+#: templates/events/event_form.html:90 templates/events/event_form.html:119
+#: templates/events/event_list_archived_row.html:50
+#: templates/events/event_list_row.html:50 templates/pages/page_form.html:94
+#: templates/pages/page_form.html:123
 #: templates/pages/page_tree_archived_node.html:56
-#: templates/pages/page_tree_node.html:57
+#: templates/pages/page_tree_node.html:57 templates/pois/poi_form.html:83
+#: templates/pois/poi_form.html:112 templates/pois/poi_list_row.html:50
 msgid "Currently in translation"
 msgstr "Wird derzeit übersetzt"
 
@@ -725,233 +729,268 @@ msgstr "Veröffentlichen"
 msgid "Submit for review"
 msgstr "Zur Überprüfung vorlegen"
 
-#: templates/events/event_form.html:100 templates/events/event_list.html:47
+#: templates/events/event_form.html:86 templates/events/event_form.html:115
+#: templates/events/event_list_archived_row.html:54
+#: templates/events/event_list_row.html:54 templates/pages/page_form.html:90
+#: templates/pages/page_form.html:119
+#: templates/pages/page_tree_archived_node.html:60
+#: templates/pages/page_tree_node.html:61 templates/pois/poi_form.html:79
+#: templates/pois/poi_form.html:108 templates/pois/poi_list_row.html:54
+msgid "Translation outdated"
+msgstr "Übersetzung ist veraltet"
+
+#: templates/events/event_form.html:94 templates/events/event_form.html:123
+#: templates/events/event_list_archived_row.html:58
+#: templates/events/event_list_row.html:58 templates/pages/page_form.html:98
+#: templates/pages/page_form.html:127
+#: templates/pages/page_tree_archived_node.html:64
+#: templates/pages/page_tree_node.html:65 templates/pois/poi_form.html:87
+#: templates/pois/poi_form.html:116 templates/pois/poi_list_row.html:58
+msgid "Translation up-to-date"
+msgstr "Übersetzung ist aktuell"
+
+#: templates/events/event_form.html:99 templates/events/event_form.html:128
+#: templates/events/event_list_archived_row.html:63
+#: templates/events/event_list_row.html:63 templates/pages/page_form.html:103
+#: templates/pages/page_form.html:132
+#: templates/pages/page_tree_archived_node.html:69
+#: templates/pages/page_tree_node.html:70 templates/pois/poi_form.html:92
+#: templates/pois/poi_form.html:121 templates/pois/poi_list_row.html:63
+msgid "Translation missing"
+msgstr "Übersetzung fehlt"
+
+#: templates/events/event_form.html:104 templates/pages/page_form.html:108
+#: templates/pois/poi_form.html:97
+msgid "Create Translation"
+msgstr "Übersetzung erstellen"
+
+#: templates/events/event_form.html:143 templates/events/event_list.html:47
 #: templates/events/event_list_archived.html:23
-#: templates/pages/page_form.html:141 templates/pages/page_tree.html:75
-#: templates/pages/page_tree_archived.html:31 templates/pois/poi_form.html:93
+#: templates/pages/page_form.html:147 templates/pages/page_tree.html:75
+#: templates/pages/page_tree_archived.html:31 templates/pois/poi_form.html:136
 #: templates/pois/poi_list.html:48 templates/pois/poi_list_archived.html:31
 msgid "Version"
 msgstr "Version"
 
-#: templates/events/event_form.html:102 templates/events/event_list.html:48
+#: templates/events/event_form.html:145 templates/events/event_list.html:48
 #: templates/events/event_list_archived.html:24
-#: templates/pages/page_form.html:143 templates/pages/page_tree.html:76
-#: templates/pages/page_tree_archived.html:32 templates/pois/poi_form.html:95
+#: templates/pages/page_form.html:149 templates/pages/page_tree.html:76
+#: templates/pages/page_tree_archived.html:32 templates/pois/poi_form.html:138
 #: templates/pois/poi_list.html:49 templates/pois/poi_list_archived.html:32
 #: templates/regions/region_form.html:96 templates/regions/region_list.html:34
 msgid "Status"
 msgstr "Status"
 
-#: templates/events/event_form.html:105 templates/pages/page_form.html:146
-#: templates/pois/poi_form.html:98 templates/regions/region_form.html:53
+#: templates/events/event_form.html:148 templates/pages/page_form.html:152
+#: templates/pois/poi_form.html:141 templates/regions/region_form.html:53
 msgid "Permalink"
 msgstr ""
 
-#: templates/events/event_form.html:107 templates/pages/page_form.html:148
+#: templates/events/event_form.html:150 templates/pages/page_form.html:154
 #: templates/regions/region_form.html:55
 msgid " Leave blank to generate unique permalink from title"
 msgstr ""
 " Dieses Feld freilassen, um eine eindeutigen Permalink aus dem Titel zu "
 "generieren"
 
-#: templates/events/event_form.html:118 templates/pages/page_form.html:159
-#: templates/pois/poi_form.html:108
+#: templates/events/event_form.html:161 templates/pages/page_form.html:165
+#: templates/pois/poi_form.html:151
 #: templates/push_notifications/push_notification_form.html:49
 #: templates/push_notifications/push_notification_list.html:24
 msgid "Title"
 msgstr "Titel"
 
-#: templates/events/event_form.html:119 templates/pages/page_form.html:160
-#: templates/pages/page_sbs.html:30 templates/pois/poi_form.html:109
+#: templates/events/event_form.html:162 templates/pages/page_form.html:166
+#: templates/pages/page_sbs.html:30 templates/pois/poi_form.html:152
 msgid "Insert title here"
 msgstr "Titel hier eingeben"
 
-#: templates/events/event_form.html:121 templates/pois/poi_form.html:114
+#: templates/events/event_form.html:164 templates/pois/poi_form.html:157
 msgid "Description"
 msgstr "Beschreibung"
 
-#: templates/events/event_form.html:122
+#: templates/events/event_form.html:165
 msgid "Insert description here"
 msgstr "Beschreibung hier eingeben"
 
-#: templates/events/event_form.html:124 templates/pages/page_form.html:165
-#: templates/pois/poi_form.html:116
+#: templates/events/event_form.html:167 templates/pages/page_form.html:171
+#: templates/pois/poi_form.html:159
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
 
-#: templates/events/event_form.html:126 templates/pages/page_form.html:167
-#: templates/pois/poi_form.html:118
+#: templates/events/event_form.html:169 templates/pages/page_form.html:173
+#: templates/pois/poi_form.html:161
 msgid "This change does not require an update of the translations"
 msgstr "Diese Änderung erfordert keine angepasste Übersetzung"
 
-#: templates/events/event_form.html:136 templates/pages/page_form.html:208
-#: templates/pois/poi_form.html:128
+#: templates/events/event_form.html:179 templates/pages/page_form.html:214
+#: templates/pois/poi_form.html:171
 msgid "Settings for all translations"
 msgstr "Einstellungen für alle Übersetzungen"
 
-#: templates/events/event_form.html:143 templates/media/media_list.html:23
+#: templates/events/event_form.html:186 templates/media/media_list.html:23
 msgid "Date"
 msgstr "Datum"
 
-#: templates/events/event_form.html:146 templates/events/event_form.html:160
+#: templates/events/event_form.html:189 templates/events/event_form.html:203
 #: templates/events/event_list.html:65
 #: templates/events/event_list_archived.html:41
 msgid "Start"
 msgstr "Beginn"
 
-#: templates/events/event_form.html:150 templates/events/event_form.html:164
+#: templates/events/event_form.html:193 templates/events/event_form.html:207
 #: templates/events/event_list.html:66
 #: templates/events/event_list_archived.html:42
 msgid "End"
 msgstr "Ende"
 
-#: templates/events/event_form.html:154
+#: templates/events/event_form.html:197
 msgid "Time"
 msgstr "Uhrzeit"
 
-#: templates/events/event_form.html:156
+#: templates/events/event_form.html:199
 msgid "All-day"
 msgstr "Ganztägig"
 
-#: templates/events/event_form.html:168
+#: templates/events/event_form.html:211
 msgid "Recurrence"
 msgstr "Wiederholung"
 
-#: templates/events/event_form.html:171
+#: templates/events/event_form.html:214
 msgid "Recurring"
 msgstr "Wiederholend"
 
-#: templates/events/event_form.html:174
+#: templates/events/event_form.html:217
 msgid "Frequency"
 msgstr "Häufigkeit"
 
-#: templates/events/event_form.html:182 templates/events/event_form.html:196
+#: templates/events/event_form.html:225 templates/events/event_form.html:239
 msgid "Weekday"
 msgstr "Wochentag"
 
-#: templates/events/event_form.html:194
+#: templates/events/event_form.html:237
 msgid "Week"
 msgstr "Woche"
 
-#: templates/events/event_form.html:199
+#: templates/events/event_form.html:242
 msgid "Interval"
 msgstr "Intervall"
 
-#: templates/events/event_form.html:202
+#: templates/events/event_form.html:245
 msgid "Recurrence ends"
 msgstr "Wiederholung endet"
 
-#: templates/events/event_form.html:209
+#: templates/events/event_form.html:252
 msgid "Recurrence end date"
 msgstr "Wiederholung Enddatum"
 
-#: templates/events/event_form.html:213
+#: templates/events/event_form.html:256
 msgid "Where"
 msgstr "Wo"
 
-#: templates/events/event_form.html:216
+#: templates/events/event_form.html:259
 msgid "This event does not have a physical location"
 msgstr "Diese Veranstaltung hat keinen Veranstaltungsort"
 
-#: templates/events/event_form.html:219 templates/pois/poi_form.html:136
+#: templates/events/event_form.html:262 templates/pois/poi_form.html:179
 msgid "Address"
 msgstr "Adresse"
 
-#: templates/events/event_form.html:221
+#: templates/events/event_form.html:264
 msgid "Name of event location"
 msgstr "Name des Veranstaltungsortes"
 
-#: templates/events/event_form.html:223
+#: templates/events/event_form.html:266
 msgid ""
 "Create an event location or start typing the name of an existing location"
 msgstr ""
 "Erstelle einen Veranstaltungsort oder beginne den Namen eines bestehenden "
 "Veranstaltungsortes einzutippen"
 
-#: templates/events/event_form.html:226 templates/pois/poi_form.html:137
+#: templates/events/event_form.html:269 templates/pois/poi_form.html:180
 #: templates/pois/poi_list.html:65 templates/pois/poi_list_archived.html:39
 msgid "Street"
 msgstr "Straße"
 
-#: templates/events/event_form.html:231
+#: templates/events/event_form.html:274
 msgid "Germany"
 msgstr "Deutschland"
 
-#: templates/events/event_form.html:241
+#: templates/events/event_form.html:284
 msgid "Map"
 msgstr "Karte"
 
-#: templates/events/event_form.html:244 templates/pages/page_form.html:256
-#: templates/pois/poi_form.html:160 templates/regions/region_form.html:80
+#: templates/events/event_form.html:287 templates/pages/page_form.html:262
+#: templates/pois/poi_form.html:203 templates/regions/region_form.html:80
 msgid "Icon"
 msgstr "Icon"
 
-#: templates/events/event_form.html:248
+#: templates/events/event_form.html:291
 #: templates/organizations/organization_form.html:65
-#: templates/pages/page_form.html:260 templates/pois/poi_form.html:164
+#: templates/pages/page_form.html:266 templates/pois/poi_form.html:207
 #: templates/regions/region_form.html:89
 msgid "Set icon"
 msgstr "Icon festlegen"
 
-#: templates/events/event_form.html:255
-#: templates/events/event_list_archived_row.html:74
+#: templates/events/event_form.html:298
+#: templates/events/event_list_archived_row.html:93
 msgid "Restore event"
 msgstr "Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:258
+#: templates/events/event_form.html:301
 msgid "Restore this event"
 msgstr "Diese Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:261 templates/events/event_list_row.html:77
+#: templates/events/event_form.html:304 templates/events/event_list_row.html:96
 msgid "Archive event"
 msgstr "Veranstaltung archivieren"
 
-#: templates/events/event_form.html:264
+#: templates/events/event_form.html:307
 msgid "Archive this event"
 msgstr "Diese Veranstaltung archivieren"
 
-#: templates/events/event_form.html:270
-#: templates/events/event_list_archived_row.html:79
-#: templates/events/event_list_row.html:82
+#: templates/events/event_form.html:313
+#: templates/events/event_list_archived_row.html:98
+#: templates/events/event_list_row.html:101
 msgid "Delete event"
 msgstr "Veranstaltung löschen"
 
-#: templates/events/event_form.html:273
+#: templates/events/event_form.html:316
 msgid "Delete this event"
 msgstr "Diese Veranstaltung löschen"
 
-#: templates/events/event_form.html:377 templates/pages/page_form.html:353
-#: templates/pois/poi_form.html:228
+#: templates/events/event_form.html:420 templates/pages/page_form.html:359
+#: templates/pois/poi_form.html:271
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
-#: templates/events/event_form.html:396 templates/pages/page_form.html:372
-#: templates/pois/poi_form.html:247
+#: templates/events/event_form.html:439 templates/pages/page_form.html:378
+#: templates/pois/poi_form.html:290
 msgid "Location"
 msgstr "Ort"
 
-#: templates/events/event_form.html:403 templates/pages/page_form.html:379
-#: templates/pois/poi_form.html:254
+#: templates/events/event_form.html:446 templates/pages/page_form.html:385
+#: templates/pois/poi_form.html:297
 msgid "Link"
 msgstr "Link"
 
-#: templates/events/event_form.html:410 templates/pages/page_form.html:386
-#: templates/pois/poi_form.html:261
+#: templates/events/event_form.html:453 templates/pages/page_form.html:392
+#: templates/pois/poi_form.html:304
 msgid "Phone"
 msgstr "Telefon"
 
-#: templates/events/event_form.html:417 templates/pages/page_form.html:393
-#: templates/pois/poi_form.html:268
+#: templates/events/event_form.html:460 templates/pages/page_form.html:399
+#: templates/pois/poi_form.html:311
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
-#: templates/events/event_form.html:424 templates/pages/page_form.html:400
-#: templates/pois/poi_form.html:275
+#: templates/events/event_form.html:467 templates/pages/page_form.html:406
+#: templates/pois/poi_form.html:318
 msgid "Email"
 msgstr "Email"
 
-#: templates/events/event_form.html:431 templates/pages/page_form.html:407
-#: templates/pois/poi_form.html:282
+#: templates/events/event_form.html:474 templates/pages/page_form.html:413
+#: templates/pois/poi_form.html:325
 msgid "Hint"
 msgstr "Tipp"
 
@@ -1009,12 +1048,12 @@ msgstr "Noch keine Veranstaltungen archiviert."
 msgid "Translation not available"
 msgstr "Übersetzung nicht verfügbar"
 
-#: templates/events/event_list_archived_row.html:58
-#: templates/events/event_list_row.html:58
+#: templates/events/event_list_archived_row.html:77
+#: templates/events/event_list_row.html:77
 msgid "Not specified"
 msgstr "Nicht festgelegt"
 
-#: templates/events/event_list_row.html:74
+#: templates/events/event_list_row.html:93
 msgid "Edit event"
 msgstr "Veranstaltung bearbeiten"
 
@@ -1189,7 +1228,7 @@ msgid "Add language"
 msgstr "Sprache hinzufügen"
 
 #: templates/language_tree/language_tree_node_form.html:37
-#: templates/pages/page_form.html:185
+#: templates/pages/page_form.html:191
 msgid "Source Language"
 msgstr "Quell-Sprache"
 
@@ -1389,7 +1428,6 @@ msgid "Edit page \"%(page_title)s\""
 msgstr "Seite \"%(page_title)s\" bearbeiten"
 
 #: templates/pages/page_form.html:56
-#: templates/pages/page_tree_archived_node.html:69
 msgid "Create new translation"
 msgstr "Neue Übersetzung erstellen"
 
@@ -1397,60 +1435,44 @@ msgstr "Neue Übersetzung erstellen"
 msgid "Create new page"
 msgstr "Neue Seite erstellen"
 
-#: templates/pages/page_form.html:89 templates/pages/page_form.html:113
-#: templates/pages/page_tree_archived_node.html:60
-#: templates/pages/page_tree_node.html:61
-msgid "Translation outdated"
-msgstr "Übersetzung ist veraltet"
-
-#: templates/pages/page_form.html:97 templates/pages/page_form.html:121
-#: templates/pages/page_tree_node.html:65
-msgid "Translation up-to-date"
-msgstr "Übersetzung ist aktuell"
-
-#: templates/pages/page_form.html:102 templates/pages/page_form.html:126
-#: templates/pages/page_tree_node.html:70
-msgid "Translation missing"
-msgstr "Übersetzung fehlt"
-
-#: templates/pages/page_form.html:162
+#: templates/pages/page_form.html:168
 #: templates/push_notifications/push_notification_form.html:54
 msgid "Content"
 msgstr "Inhalt"
 
-#: templates/pages/page_form.html:163 templates/pages/page_sbs.html:33
+#: templates/pages/page_form.html:169 templates/pages/page_sbs.html:33
 msgid "Insert content here"
 msgstr "Inhalt hier eingeben"
 
-#: templates/pages/page_form.html:178
+#: templates/pages/page_form.html:184
 msgid "Side-by-Side view"
 msgstr "Side-by-Side-Ansicht"
 
-#: templates/pages/page_form.html:198
+#: templates/pages/page_form.html:204
 msgid "Show translations side by side"
 msgstr "Übersetzungen nebeneinander anzeigen"
 
-#: templates/pages/page_form.html:215
+#: templates/pages/page_form.html:221
 msgid "Positioning"
 msgstr "Anordnung"
 
-#: templates/pages/page_form.html:216
+#: templates/pages/page_form.html:222
 msgid "Relationship"
 msgstr "Verhältnis"
 
-#: templates/pages/page_form.html:220
+#: templates/pages/page_form.html:226
 msgid "Page"
 msgstr "Seite"
 
-#: templates/pages/page_form.html:228
+#: templates/pages/page_form.html:234
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: templates/pages/page_form.html:249
+#: templates/pages/page_form.html:255
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: templates/pages/page_form.html:250
+#: templates/pages/page_form.html:256
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -1458,37 +1480,37 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: templates/pages/page_form.html:267 templates/pages/page_form.html:268
+#: templates/pages/page_form.html:273 templates/pages/page_form.html:274
 #: templates/pages/page_tree_archived_node.html:85
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
-#: templates/pages/page_form.html:269
+#: templates/pages/page_form.html:275
 msgid "Restore this page"
 msgstr "Diese Seite wiederherstellen"
 
-#: templates/pages/page_form.html:272 templates/pages/page_form.html:273
+#: templates/pages/page_form.html:278 templates/pages/page_form.html:279
 #: templates/pages/page_tree_node.html:95
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: templates/pages/page_form.html:275
+#: templates/pages/page_form.html:281
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: templates/pages/page_form.html:281 templates/pages/page_form.html:285
+#: templates/pages/page_form.html:287 templates/pages/page_form.html:291
 #: templates/pages/page_tree_archived_node.html:94
 #: templates/pages/page_tree_node.html:104
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: templates/pages/page_form.html:283
+#: templates/pages/page_form.html:289
 #: templates/pages/page_tree_archived_node.html:90
 #: templates/pages/page_tree_node.html:100 views/pages/page_actions.py:93
 msgid "You cannot delete a page which has children."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: templates/pages/page_form.html:287
+#: templates/pages/page_form.html:293
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
@@ -1530,10 +1552,6 @@ msgstr "Archivierte Seiten"
 #: templates/pages/page_tree_archived.html:64
 msgid "No pages archived yet."
 msgstr "Noch keine Seiten archiviert."
-
-#: templates/pages/page_tree_archived_node.html:64
-msgid "Edit translation"
-msgstr "Diese Übersetzung bearbeiten"
 
 #: templates/pages/page_tree_archived_node.html:82
 #: templates/pages/page_tree_node.html:88
@@ -1598,89 +1616,89 @@ msgstr "Neue POI Übersetzung erstellen"
 msgid "Create new POI"
 msgstr "POI erstellen"
 
-#: templates/pois/poi_form.html:100
+#: templates/pois/poi_form.html:143
 msgid " Leave blank to derive from title"
 msgstr " Freilassen, um vom Titel abzuleiten"
 
-#: templates/pois/poi_form.html:111
+#: templates/pois/poi_form.html:154
 msgid "Short description"
 msgstr "Kurzbeschreibung"
 
-#: templates/pois/poi_form.html:112
+#: templates/pois/poi_form.html:155
 msgid "Insert short description here"
 msgstr "Kurzbeschreibung hier eingeben"
 
-#: templates/pois/poi_form.html:138
+#: templates/pois/poi_form.html:181
 msgid "Insert street here"
 msgstr "Straße hier eingeben"
 
-#: templates/pois/poi_form.html:140 templates/pois/poi_list.html:66
+#: templates/pois/poi_form.html:183 templates/pois/poi_list.html:66
 #: templates/pois/poi_list_archived.html:40
 msgid "Postal Code"
 msgstr "Postleitzahl"
 
-#: templates/pois/poi_form.html:141
+#: templates/pois/poi_form.html:184
 msgid "Insert postal code here"
 msgstr "Postleitzahl hier eingeben"
 
-#: templates/pois/poi_form.html:144
+#: templates/pois/poi_form.html:187
 msgid "Insert city here"
 msgstr "Stadt hier eingeben"
 
-#: templates/pois/poi_form.html:146 templates/pois/poi_list.html:68
+#: templates/pois/poi_form.html:189 templates/pois/poi_list.html:68
 #: templates/pois/poi_list_archived.html:42
 msgid "Country"
 msgstr "Land"
 
-#: templates/pois/poi_form.html:147
+#: templates/pois/poi_form.html:190
 msgid "Insert country here"
 msgstr "Land hier eingeben"
 
-#: templates/pois/poi_form.html:151
+#: templates/pois/poi_form.html:194
 msgid "Position"
 msgstr "Position"
 
-#: templates/pois/poi_form.html:152 templates/regions/region_form.html:75
+#: templates/pois/poi_form.html:195 templates/regions/region_form.html:75
 msgid "Longitude"
 msgstr "Geographische Länge"
 
-#: templates/pois/poi_form.html:153
+#: templates/pois/poi_form.html:196
 msgid "Insert longitude here"
 msgstr "Geographische Länge hier eingeben"
 
-#: templates/pois/poi_form.html:155 templates/regions/region_form.html:72
+#: templates/pois/poi_form.html:198 templates/regions/region_form.html:72
 msgid "Latitude"
 msgstr "Geographische Breite"
 
-#: templates/pois/poi_form.html:156
+#: templates/pois/poi_form.html:199
 msgid "Insert latitude here"
 msgstr "Geographische Breite hier eingeben"
 
-#: templates/pois/poi_form.html:171 templates/pois/poi_form.html:172
+#: templates/pois/poi_form.html:214 templates/pois/poi_form.html:215
 #: templates/pois/poi_list_archived_row.html:55
 msgid "Restore POI"
 msgstr "POI Wiederherstellen"
 
-#: templates/pois/poi_form.html:173
+#: templates/pois/poi_form.html:216
 msgid "Restore this POI"
 msgstr "Diesen POI wiederherstellen"
 
-#: templates/pois/poi_form.html:176 templates/pois/poi_form.html:177
-#: templates/pois/poi_list_row.html:70
+#: templates/pois/poi_form.html:219 templates/pois/poi_form.html:220
+#: templates/pois/poi_list_row.html:89
 msgid "Archive POI"
 msgstr "POI archivieren"
 
-#: templates/pois/poi_form.html:178
+#: templates/pois/poi_form.html:221
 msgid "Archive this POI"
 msgstr "Diesen POI archivieren"
 
-#: templates/pois/poi_form.html:184 templates/pois/poi_form.html:185
+#: templates/pois/poi_form.html:227 templates/pois/poi_form.html:228
 #: templates/pois/poi_list_archived_row.html:59
-#: templates/pois/poi_list_row.html:74
+#: templates/pois/poi_list_row.html:93
 msgid "Delete POI"
 msgstr "POI löschen"
 
-#: templates/pois/poi_form.html:186
+#: templates/pois/poi_form.html:229
 msgid "Delete this POI"
 msgstr "Diesen POI löschen"
 
@@ -2679,6 +2697,9 @@ msgstr "Benutzer wurde erfolgreich erstellt."
 #: views/users/user_view.py:108
 msgid "User was successfully deleted."
 msgstr "Benutzer wurde erfolgreich gelöscht."
+
+#~ msgid "Edit translation"
+#~ msgstr "Diese Übersetzung bearbeiten"
 
 #~ msgid "Restore"
 #~ msgstr "Wiederherstellen"

--- a/backend/cms/models/events/event.py
+++ b/backend/cms/models/events/event.py
@@ -11,7 +11,7 @@ from django.db import models
 from .recurrence_rule import RecurrenceRule
 from ..pois.poi import POI
 from ..regions.region import Region
-from ...constants import frequency
+from ...constants import frequency, status
 
 
 class Event(models.Model):
@@ -116,6 +116,12 @@ class Event(models.Model):
                                     until=until)
             return [x for x in occurrences if start <= x <= end or start <= x + event_span <= end]
         return [event_start] if start <= event_start <= end or start <= event_end <= end else []
+
+    def get_public_translation(self, language_code):
+        return self.translations.filter(
+            language__code=language_code,
+            status=status.PUBLIC,
+        ).first()
 
     class Meta:
         ordering = ['start_date', 'start_time']

--- a/backend/cms/models/events/event_translation.py
+++ b/backend/cms/models/events/event_translation.py
@@ -47,6 +47,80 @@ class EventTranslation(models.Model):
             self.slug
         ])
 
+    @property
+    def available_languages(self):
+        languages = self.event.languages
+        languages.remove(self.language)
+        available_languages = {}
+        for language in languages:
+            other_translation = self.event.get_public_translation(language.code)
+            if other_translation:
+                available_languages[language.code] = {
+                    'id': other_translation.id,
+                    'url': other_translation.permalink
+                }
+        return available_languages
+
+    @property
+    def source_translation(self):
+        source_language_tree_node = self.event.region.language_tree_nodes.get(language=self.language).parent
+        if source_language_tree_node:
+            return self.event.get_translation(source_language_tree_node.code)
+        return None
+
+    @property
+    def latest_public_revision(self):
+        return self.event.translations.filter(
+            language=self.language,
+            status=status.PUBLIC,
+        ).first()
+
+    @property
+    def latest_major_revision(self):
+        return self.event.translations.filter(
+            language=self.language,
+            minor_edit=False,
+        ).first()
+
+    @property
+    def latest_major_public_revision(self):
+        return self.event.translations.filter(
+            language=self.language,
+            status=status.PUBLIC,
+            minor_edit=False,
+        ).first()
+
+    @property
+    def previous_revision(self):
+        version = self.version - 1
+        return self.event.translations.filter(
+            language=self.language,
+            version=version,
+        ).first()
+
+    @property
+    def is_outdated(self):
+        # If the event translation is currently in translation, it is defined as not outdated
+        if self.currently_in_translation:
+            return False
+        source_translation = self.source_translation
+        # If self.language is the root language, this translation can never be outdated
+        if not source_translation:
+            return False
+        # If the source translation is outdated, this translation can not be up to date
+        if source_translation.is_outdated:
+            return True
+        self_revision = self.latest_major_public_revision
+        source_revision = source_translation.latest_major_public_revision
+        # If one of the translations has no major public revision, it cannot be outdated
+        if not self_revision or not source_revision:
+            return False
+        return self_revision.last_updated < source_revision.last_updated
+
+    @property
+    def is_up_to_date(self):
+        return not self.currently_in_translation and not self.is_outdated
+
     def __str__(self):
         return self.title
 

--- a/backend/cms/models/pois/poi.py
+++ b/backend/cms/models/pois/poi.py
@@ -1,10 +1,10 @@
 """Model for Point of Interests
 
 """
-from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 
 from ..regions.region import Region
+from ...constants import status
 
 
 class POI(models.Model):
@@ -52,8 +52,12 @@ class POI(models.Model):
         return languages
 
     def get_translation(self, language_code):
-        try:
-            poi_translation = self.translations.get(language__code=language_code)
-        except ObjectDoesNotExist:
-            poi_translation = None
-        return poi_translation
+        return self.translations.filter(
+            language__code=language_code
+        ).first()
+
+    def get_public_translation(self, language_code):
+        return self.translations.filter(
+            language__code=language_code,
+            status=status.PUBLIC,
+        ).first()

--- a/backend/cms/templates/events/event_form.html
+++ b/backend/cms/templates/events/event_form.html
@@ -80,12 +80,55 @@
                             <div class="border-b-2 border-white">
                             {% if other_language == language %}
                                 <div class="p-4">
-                                    <i data-feather="{% if event_translation_form.instance.id %}edit-2{% else %}plus{% endif %}" class="inline-block"></i>
+                                    {% if event_form.instance %}
+                                        {% if other_language in event_form.instance.languages %}
+                                            {% if event_translation_form.instance.is_outdated %}
+                                                <span title="{% trans 'Translation outdated' %}">
+                                                    <i data-feather="alert-triangle" class="inline-block"></i>
+                                                </span>
+                                            {% elif event_translation_form.instance.currently_in_translation %}
+                                                <span title="{% trans 'Currently in translation' %}">
+                                                    <i data-feather="clock" class="inline-block"></i>
+                                                </span>
+                                            {% else %}
+                                                <span title="{% trans 'Translation up-to-date' %}">
+                                                    <i data-feather="check" class="inline-block"></i>
+                                                </span>
+                                            {% endif %}
+                                        {% else %}
+                                            <span title="{% trans 'Translation missing' %}">
+                                                <i data-feather="x" class="inline-block"></i>
+                                            </span>
+                                        {% endif %}
+                                    {% else %}
+                                        <span title="{% trans 'Create Translation' %}">
+                                            <i data-feather="plus" class="inline-block"></i>
+                                        </span>
+                                    {% endif %}
                                     {{ other_language.translated_name }}
                                 </div>
                             {% else %}
                                 <a class="block p-4" style="color: inherit;" href="{% url 'edit_event' event_id=event_form.instance.id region_slug=region.slug language_code=other_language.code %}">
-                                    <i data-feather="{% if other_language in event_form.instance.languages %}edit-2{% else %}plus{% endif %}" class="inline-block"></i>
+                                    {% if other_language in event_form.instance.languages %}
+                                        {% get_translation event_form.instance other_language.code as other_event_translation %}
+                                        {% if other_event_translation.is_outdated %}
+                                            <span title="{% trans 'Translation outdated' %}">
+                                                <i data-feather="alert-triangle" class="inline-block"></i>
+                                            </span>
+                                        {% elif other_event_translation.currently_in_translation %}
+                                            <span title="{% trans 'Currently in translation' %}">
+                                                <i data-feather="clock" class="inline-block"></i>
+                                            </span>
+                                        {% else %}
+                                            <span title="{% trans 'Translation up-to-date' %}">
+                                                <i data-feather="check" class="inline-block"></i>
+                                            </span>
+                                        {% endif %}
+                                    {% else %}
+                                        <span title="{% trans 'Translation missing' %}">
+                                            <i data-feather="x" class="inline-block"></i>
+                                        </span>
+                                    {% endif %}
                                     {{ other_language.translated_name }}
                                 </a>
                             {% endif %}

--- a/backend/cms/templates/events/event_list_archived_row.html
+++ b/backend/cms/templates/events/event_list_archived_row.html
@@ -44,7 +44,26 @@
             <div class="lang-grid">
                 {% for other_language in languages %}
                     <a href="{% url 'edit_event' event_id=event.id region_slug=region.slug language_code=other_language.code%}">
-                        <i data-feather="{% if other_language in event.languages %}edit-2{% else %}plus{% endif %}" class="text-gray-800"></i>
+                        {% get_translation event other_language.code as other_translation %}
+                        {% if other_translation %}
+                            {% if other_translation.currently_in_translation %}
+                                <span title="{% trans 'Currently in translation' %}">
+                                    <i data-feather="clock" class="text-gray-800"></i>
+                                </span>
+                            {% elif other_translation.is_outdated %}
+                                <span title="{% trans 'Translation outdated' %}">
+                                    <i data-feather="alert-triangle" class="text-gray-800"></i>
+                                </span>
+                            {% else %}
+                                <span title="{% trans 'Translation up-to-date' %}">
+                                    <i data-feather="check" class="text-gray-800"></i>
+                                </span>
+                            {% endif %}
+                        {% else %}
+                            <span title="{% trans 'Translation missing' %}">
+                                <i data-feather="x" class="text-gray-800"></i>
+                            </span>
+                        {% endif %}
                     </a>
                 {% endfor %}
             </div>

--- a/backend/cms/templates/events/event_list_row.html
+++ b/backend/cms/templates/events/event_list_row.html
@@ -44,7 +44,26 @@
             <div class="lang-grid">
                 {% for other_language in languages %}
                     <a href="{% url 'edit_event' event_id=event.id region_slug=region.slug language_code=other_language.code%}">
-                        <i data-feather="{% if other_language in event.languages %}edit-2{% else %}plus{% endif %}" class="text-gray-800"></i>
+                        {% get_translation event other_language.code as other_translation %}
+                        {% if other_translation %}
+                            {% if other_translation.currently_in_translation %}
+                                <span title="{% trans 'Currently in translation' %}">
+                                    <i data-feather="clock" class="text-gray-800"></i>
+                                </span>
+                            {% elif other_translation.is_outdated %}
+                                <span title="{% trans 'Translation outdated' %}">
+                                    <i data-feather="alert-triangle" class="text-gray-800"></i>
+                                </span>
+                            {% else %}
+                                <span title="{% trans 'Translation up-to-date' %}">
+                                    <i data-feather="check" class="text-gray-800"></i>
+                                </span>
+                            {% endif %}
+                        {% else %}
+                            <span title="{% trans 'Translation missing' %}">
+                                <i data-feather="x" class="text-gray-800"></i>
+                            </span>
+                        {% endif %}
                     </a>
                 {% endfor %}
             </div>

--- a/backend/cms/templates/pages/page_form.html
+++ b/backend/cms/templates/pages/page_form.html
@@ -84,23 +84,29 @@
                             <div class="border-b-2 border-white">
                         {% if other_language == language %}
                             <div class="p-4">
-                                {% if other_language in page.languages %}
-                                    {% if page_translation_form.instance.is_outdated %}
-                                        <span title="{% trans 'Translation outdated' %}">
-                                            <i data-feather="alert-triangle" class="inline-block"></i>
-                                        </span>
-                                    {% elif page_translation_form.instance.currently_in_translation %}
-                                        <span title="{% trans 'Currently in translation' %}">
-                                            <i data-feather="clock" class="inline-block"></i>
-                                        </span>
+                                {% if page %}
+                                    {% if other_language in page.languages %}
+                                        {% if page_translation_form.instance.is_outdated %}
+                                            <span title="{% trans 'Translation outdated' %}">
+                                                <i data-feather="alert-triangle" class="inline-block"></i>
+                                            </span>
+                                        {% elif page_translation_form.instance.currently_in_translation %}
+                                            <span title="{% trans 'Currently in translation' %}">
+                                                <i data-feather="clock" class="inline-block"></i>
+                                            </span>
+                                        {% else %}
+                                            <span title="{% trans 'Translation up-to-date' %}">
+                                                <i data-feather="check" class="inline-block"></i>
+                                            </span>
+                                        {% endif %}
                                     {% else %}
-                                        <span title="{% trans 'Translation up-to-date' %}">
-                                            <i data-feather="check" class="inline-block"></i>
+                                        <span title="{% trans 'Translation missing' %}">
+                                            <i data-feather="x" class="inline-block"></i>
                                         </span>
                                     {% endif %}
                                 {% else %}
-                                    <span title="{% trans 'Translation missing' %}">
-                                        <i data-feather="x" class="inline-block"></i>
+                                    <span title="{% trans 'Create Translation' %}">
+                                        <i data-feather="plus" class="inline-block"></i>
                                     </span>
                                 {% endif %}
                                 {{ other_language.translated_name }}

--- a/backend/cms/templates/pages/page_tree_archived_node.html
+++ b/backend/cms/templates/pages/page_tree_archived_node.html
@@ -61,13 +61,13 @@
                                     <i data-feather="alert-triangle" class="text-gray-800"></i>
                                 </span>
                             {% else %}
-                                <span title="{% trans 'Edit translation' %}">
-                                    <i data-feather="edit-2" class="text-gray-800"></i>
+                                <span title="{% trans 'Translation up-to-date' %}">
+                                    <i data-feather="check" class="text-gray-800"></i>
                                 </span>
                             {% endif %}
                         {% else %}
-                            <span title="{% trans 'Create new translation' %}">
-                                <i data-feather="plus" class="text-gray-800"></i>
+                            <span title="{% trans 'Translation missing' %}">
+                                <i data-feather="x" class="text-gray-800"></i>
                             </span>
                         {% endif %}
                     </a>

--- a/backend/cms/templates/pois/poi_form.html
+++ b/backend/cms/templates/pois/poi_form.html
@@ -73,12 +73,55 @@
                             <div class="border-b-2 border-white">
                         {% if other_language == language %}
                             <div class="p-4">
-                                <i data-feather="{% if other_language in poi_form.instance.languages %}edit-2{% else %}plus{% endif %}" class="inline-block"></i>
+                                {% if poi_form.instance %}
+                                    {% if other_language in poi_form.instance.languages %}
+                                        {% if poi_translation_form.instance.is_outdated %}
+                                            <span title="{% trans 'Translation outdated' %}">
+                                                <i data-feather="alert-triangle" class="inline-block"></i>
+                                            </span>
+                                        {% elif poi_translation_form.instance.currently_in_translation %}
+                                            <span title="{% trans 'Currently in translation' %}">
+                                                <i data-feather="clock" class="inline-block"></i>
+                                            </span>
+                                        {% else %}
+                                            <span title="{% trans 'Translation up-to-date' %}">
+                                                <i data-feather="check" class="inline-block"></i>
+                                            </span>
+                                        {% endif %}
+                                    {% else %}
+                                        <span title="{% trans 'Translation missing' %}">
+                                            <i data-feather="x" class="inline-block"></i>
+                                        </span>
+                                    {% endif %}
+                                {% else %}
+                                    <span title="{% trans 'Create Translation' %}">
+                                        <i data-feather="plus" class="inline-block"></i>
+                                    </span>
+                                {% endif %}
                                 {{ other_language.translated_name }}
                             </div>
                         {% else %}
                             <a class="block p-4" style="color: inherit;" href="{% url 'edit_poi' poi_id=poi_form.instance.id region_slug=region.slug language_code=other_language.code %}">
-                                <i data-feather="{% if other_language in poi_form.instance.languages %}edit-2{% else %}plus{% endif %}" class="inline-block"></i>
+                                {% if other_language in poi_form.instance.languages %}
+                                    {% get_translation poi_form.instance other_language.code as other_poi_translation %}
+                                    {% if other_poi_translation.is_outdated %}
+                                        <span title="{% trans 'Translation outdated' %}">
+                                            <i data-feather="alert-triangle" class="inline-block"></i>
+                                        </span>
+                                    {% elif other_poi_translation.currently_in_translation %}
+                                        <span title="{% trans 'Currently in translation' %}">
+                                            <i data-feather="clock" class="inline-block"></i>
+                                        </span>
+                                    {% else %}
+                                        <span title="{% trans 'Translation up-to-date' %}">
+                                            <i data-feather="check" class="inline-block"></i>
+                                        </span>
+                                    {% endif %}
+                                {% else %}
+                                    <span title="{% trans 'Translation missing' %}">
+                                        <i data-feather="x" class="inline-block"></i>
+                                    </span>
+                                {% endif %}
                                 {{ other_language.translated_name }}
                             </a>
                         {% endif %}

--- a/backend/cms/templates/pois/poi_list.html
+++ b/backend/cms/templates/pois/poi_list.html
@@ -53,7 +53,7 @@
                 {% if LANGUAGE_CODE != language.code %}
                     <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {% translated_language_name LANGUAGE_CODE %}</th>
                 {% endif %}
-                <th class="text-sm text-left uppercase py-3">
+                <th class="text-sm text-left uppercase py-3 px-2">
                     <div class="lang-grid flags" style="white-space: nowrap;">
 	                    {% for lang in languages %}
 		                    <a href="{% url 'pois' region_slug=region.slug language_code=lang.code %}">

--- a/backend/cms/templates/pois/poi_list_row.html
+++ b/backend/cms/templates/pois/poi_list_row.html
@@ -44,8 +44,27 @@
 			<div class="lang-grid">
 				{% for other_language in languages %}
 					<a href="{% url 'edit_poi' poi_id=poi.id region_slug=region.slug language_code=other_language.code %}">
-						<i data-feather="{% if other_language in poi.languages %}edit-2{% else %}plus{% endif %}" class="text-gray-800"></i>
-					</a>
+                        {% get_translation poi other_language.code as other_translation %}
+                        {% if other_translation %}
+                            {% if other_translation.currently_in_translation %}
+                                <span title="{% trans 'Currently in translation' %}">
+                                    <i data-feather="clock" class="text-gray-800"></i>
+                                </span>
+                            {% elif other_translation.is_outdated %}
+                                <span title="{% trans 'Translation outdated' %}">
+                                    <i data-feather="alert-triangle" class="text-gray-800"></i>
+                                </span>
+                            {% else %}
+                                <span title="{% trans 'Translation up-to-date' %}">
+                                    <i data-feather="check" class="text-gray-800"></i>
+                                </span>
+                            {% endif %}
+                        {% else %}
+                            <span title="{% trans 'Translation missing' %}">
+                                <i data-feather="x" class="text-gray-800"></i>
+                            </span>
+                        {% endif %}
+                    </a>
 				{% endfor %}
 			</div>
 		</div>


### PR DESCRIPTION
Adapt the new translation icons for:
- Events
- POIs
- Archived Pages

This also copies the translation helper functions from pages to events and pois.

Fixes #305