### PR TITLE
Add POI selection to event form

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "homepage": "https://github.com/Integreat/cms-django#readme",
   "devDependencies": {
-    "autoprefixer": "^9.7.4",
+    "autoprefixer": "^9.7.5",
     "babel-preset-es2015": "^6.24.1",
     "babelify": "^10.0.0",
-    "browserify": "^16.5.0",
+    "browserify": "^16.5.1",
     "less": "^3.11.1",
     "less-plugin-clean-css": "^1.5.1",
     "node-sass": "^4.13.1",

--- a/src/cms/forms/events/event_form.py
+++ b/src/cms/forms/events/event_form.py
@@ -45,6 +45,7 @@ class EventForm(forms.ModelForm):
             self.fields['is_recurring'].initial = self.instance.is_recurring
 
         # If form is disabled because the user has no permissions to edit the page, disable all form fields
+        self.disabled = disabled
         if disabled:
             for _, field in self.fields.items():
                 field.disabled = True

--- a/src/cms/forms/events/event_form.py
+++ b/src/cms/forms/events/event_form.py
@@ -50,7 +50,7 @@ class EventForm(forms.ModelForm):
                 field.disabled = True
 
     #pylint: disable=arguments-differ
-    def save(self, region=None, recurrence_rule=None):
+    def save(self, region=None, recurrence_rule=None, location=None):
         logger.info('EventForm saved with cleaned data %s and changed data %s', self.cleaned_data, self.changed_data)
 
         # Disable instant commit on saving because missing information would cause errors
@@ -64,6 +64,8 @@ class EventForm(forms.ModelForm):
             # Delete old recurrence rule from database in order to not spam the database with unused objects
             event.recurrence_rule.delete()
         event.recurrence_rule = recurrence_rule
+
+        event.location = location
 
         event.save()
         return event

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-23 16:06+0000\n"
+"POT-Creation-Date: 2020-03-24 17:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: constants/administrative_division.py:52 templates/events/event_form.html:275
+#: constants/administrative_division.py:52 templates/events/event_form.html:278
 #: templates/pois/poi_form.html:186 templates/pois/poi_list.html:67
 #: templates/pois/poi_list_archived.html:41
 msgid "City"
@@ -243,19 +243,19 @@ msgstr "Vierte Woche"
 msgid "The passwords do not match."
 msgstr "Die Passwörter stimmen nicht überein."
 
-#: forms/events/event_form.py:87
+#: forms/events/event_form.py:89
 msgid "If the event is not all-day, the start time is required"
 msgstr ""
 "Wenn die Veranstaltung nicht ganztägig ist, muss eine Start-Uhrzeit "
 "angegeben werden"
 
-#: forms/events/event_form.py:89
+#: forms/events/event_form.py:91
 msgid "If the event is not all-day, the end time is required"
 msgstr ""
 "Wenn die Veranstaltung nicht ganztägig ist, muss eine End-Uhrzeit angegeben "
 "werden"
 
-#: forms/events/event_form.py:96 forms/events/event_form.py:102
+#: forms/events/event_form.py:98 forms/events/event_form.py:104
 msgid "The end of the event can't be before the start of the event"
 msgstr "Das Ende der Veranstaltung kann nicht vor seinem Beginn sein"
 
@@ -478,7 +478,7 @@ msgid "Translations up-to-date"
 msgstr "Aktuelle Übersetzungen"
 
 #: templates/analytics/translation_coverage.html:46
-#: templates/events/event_form.html:90 templates/events/event_form.html:119
+#: templates/events/event_form.html:91 templates/events/event_form.html:120
 #: templates/events/event_list_archived_row.html:50
 #: templates/events/event_list_row.html:50 templates/pages/page_form.html:94
 #: templates/pages/page_form.html:123
@@ -644,7 +644,7 @@ msgstr "Zurück zur Startseite"
 msgid "Error"
 msgstr "Fehler"
 
-#: templates/events/_poi_query_result.html:4
+#: templates/events/_poi_query_result.html:5
 #, python-format
 msgid "Create POI with title \"%(poi_query)s\""
 msgstr "POI mit Titel \"%(poi_query)s\" erstellen"
@@ -701,12 +701,12 @@ msgstr "Alle Übersetzungen dieser Veranstaltung werden wiederhergestellt."
 msgid "Yes, restore this event now."
 msgstr "Ja, diese Veranstaltung wiederherstellen."
 
-#: templates/events/event_form.html:43
+#: templates/events/event_form.html:46
 #, python-format
 msgid "Edit event \"%(event_title)s\""
 msgstr "Event \"%(event_title)s\" bearbeiten"
 
-#: templates/events/event_form.html:50 templates/events/event_list.html:49
+#: templates/events/event_form.html:51 templates/events/event_list.html:49
 #: templates/events/event_list.html:53
 #: templates/events/event_list_archived.html:25
 #: templates/events/event_list_archived.html:29
@@ -719,29 +719,29 @@ msgstr "Event \"%(event_title)s\" bearbeiten"
 msgid "Title in"
 msgstr "Titel auf"
 
-#: templates/events/event_form.html:54
+#: templates/events/event_form.html:55
 msgid "Create new event translation"
 msgstr "Neue Event-Übersetzung erstellen"
 
-#: templates/events/event_form.html:57
+#: templates/events/event_form.html:58
 msgid "Create new event"
 msgstr "Veranstaltung erstellen"
 
-#: templates/events/event_form.html:65 templates/pages/page_form.html:67
+#: templates/events/event_form.html:66 templates/pages/page_form.html:67
 #: templates/pois/poi_form.html:64
 msgid "Save as draft"
 msgstr "Als Entwurf speichern"
 
-#: templates/events/event_form.html:68 templates/pages/page_form.html:71
+#: templates/events/event_form.html:69 templates/pages/page_form.html:71
 #: templates/pois/poi_form.html:65
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: templates/events/event_form.html:70 templates/pages/page_form.html:73
+#: templates/events/event_form.html:71 templates/pages/page_form.html:73
 msgid "Submit for review"
 msgstr "Zur Überprüfung vorlegen"
 
-#: templates/events/event_form.html:86 templates/events/event_form.html:115
+#: templates/events/event_form.html:87 templates/events/event_form.html:116
 #: templates/events/event_list_archived_row.html:54
 #: templates/events/event_list_row.html:54 templates/pages/page_form.html:90
 #: templates/pages/page_form.html:119
@@ -751,7 +751,7 @@ msgstr "Zur Überprüfung vorlegen"
 msgid "Translation outdated"
 msgstr "Übersetzung ist veraltet"
 
-#: templates/events/event_form.html:94 templates/events/event_form.html:123
+#: templates/events/event_form.html:95 templates/events/event_form.html:124
 #: templates/events/event_list_archived_row.html:58
 #: templates/events/event_list_row.html:58 templates/pages/page_form.html:98
 #: templates/pages/page_form.html:127
@@ -761,7 +761,7 @@ msgstr "Übersetzung ist veraltet"
 msgid "Translation up-to-date"
 msgstr "Übersetzung ist aktuell"
 
-#: templates/events/event_form.html:99 templates/events/event_form.html:128
+#: templates/events/event_form.html:100 templates/events/event_form.html:129
 #: templates/events/event_list_archived_row.html:63
 #: templates/events/event_list_row.html:63 templates/pages/page_form.html:103
 #: templates/pages/page_form.html:132
@@ -771,12 +771,12 @@ msgstr "Übersetzung ist aktuell"
 msgid "Translation missing"
 msgstr "Übersetzung fehlt"
 
-#: templates/events/event_form.html:104 templates/pages/page_form.html:108
+#: templates/events/event_form.html:105 templates/pages/page_form.html:108
 #: templates/pois/poi_form.html:97
 msgid "Create Translation"
 msgstr "Übersetzung erstellen"
 
-#: templates/events/event_form.html:143 templates/events/event_list.html:47
+#: templates/events/event_form.html:144 templates/events/event_list.html:47
 #: templates/events/event_list_archived.html:23
 #: templates/pages/page_form.html:147 templates/pages/page_tree.html:75
 #: templates/pages/page_tree_archived.html:31 templates/pois/poi_form.html:136
@@ -784,7 +784,7 @@ msgstr "Übersetzung erstellen"
 msgid "Version"
 msgstr "Version"
 
-#: templates/events/event_form.html:145 templates/events/event_list.html:48
+#: templates/events/event_form.html:146 templates/events/event_list.html:48
 #: templates/events/event_list_archived.html:24
 #: templates/pages/page_form.html:149 templates/pages/page_tree.html:76
 #: templates/pages/page_tree_archived.html:32 templates/pois/poi_form.html:138
@@ -793,216 +793,216 @@ msgstr "Version"
 msgid "Status"
 msgstr "Status"
 
-#: templates/events/event_form.html:148 templates/pages/page_form.html:152
+#: templates/events/event_form.html:149 templates/pages/page_form.html:152
 #: templates/pois/poi_form.html:141 templates/regions/region_form.html:53
 msgid "Permalink"
 msgstr ""
 
-#: templates/events/event_form.html:150 templates/pages/page_form.html:154
+#: templates/events/event_form.html:151 templates/pages/page_form.html:154
 #: templates/regions/region_form.html:55
 msgid " Leave blank to generate unique permalink from title"
 msgstr ""
 " Dieses Feld freilassen, um eine eindeutigen Permalink aus dem Titel zu "
 "generieren"
 
-#: templates/events/event_form.html:161 templates/pages/page_form.html:165
+#: templates/events/event_form.html:162 templates/pages/page_form.html:165
 #: templates/pois/poi_form.html:151
 #: templates/push_notifications/push_notification_form.html:49
 #: templates/push_notifications/push_notification_list.html:24
 msgid "Title"
 msgstr "Titel"
 
-#: templates/events/event_form.html:162 templates/pages/page_form.html:166
+#: templates/events/event_form.html:163 templates/pages/page_form.html:166
 #: templates/pages/page_sbs.html:30 templates/pois/poi_form.html:152
 msgid "Insert title here"
 msgstr "Titel hier eingeben"
 
-#: templates/events/event_form.html:164 templates/pois/poi_form.html:157
+#: templates/events/event_form.html:165 templates/pois/poi_form.html:157
 msgid "Description"
 msgstr "Beschreibung"
 
-#: templates/events/event_form.html:165
+#: templates/events/event_form.html:166
 msgid "Insert description here"
 msgstr "Beschreibung hier eingeben"
 
-#: templates/events/event_form.html:167 templates/pages/page_form.html:171
+#: templates/events/event_form.html:168 templates/pages/page_form.html:171
 #: templates/pois/poi_form.html:159
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
 
-#: templates/events/event_form.html:169 templates/pages/page_form.html:173
+#: templates/events/event_form.html:170 templates/pages/page_form.html:173
 #: templates/pois/poi_form.html:161
 msgid "This change does not require an update of the translations"
 msgstr "Diese Änderung erfordert keine angepasste Übersetzung"
 
-#: templates/events/event_form.html:179 templates/pages/page_form.html:214
+#: templates/events/event_form.html:180 templates/pages/page_form.html:214
 #: templates/pois/poi_form.html:171
 msgid "Settings for all translations"
 msgstr "Einstellungen für alle Übersetzungen"
 
-#: templates/events/event_form.html:186 templates/media/media_list.html:23
+#: templates/events/event_form.html:187 templates/media/media_list.html:23
 msgid "Date"
 msgstr "Datum"
 
-#: templates/events/event_form.html:189 templates/events/event_form.html:203
+#: templates/events/event_form.html:190 templates/events/event_form.html:204
 #: templates/events/event_list.html:65
 #: templates/events/event_list_archived.html:41
 msgid "Start"
 msgstr "Beginn"
 
-#: templates/events/event_form.html:193 templates/events/event_form.html:207
+#: templates/events/event_form.html:194 templates/events/event_form.html:208
 #: templates/events/event_list.html:66
 #: templates/events/event_list_archived.html:42
 msgid "End"
 msgstr "Ende"
 
-#: templates/events/event_form.html:197
+#: templates/events/event_form.html:198
 msgid "Time"
 msgstr "Uhrzeit"
 
-#: templates/events/event_form.html:199
+#: templates/events/event_form.html:200
 msgid "All-day"
 msgstr "Ganztägig"
 
-#: templates/events/event_form.html:211
+#: templates/events/event_form.html:212
 msgid "Recurrence"
 msgstr "Wiederholung"
 
-#: templates/events/event_form.html:214
+#: templates/events/event_form.html:215
 msgid "Recurring"
 msgstr "Wiederholend"
 
-#: templates/events/event_form.html:217
+#: templates/events/event_form.html:218
 msgid "Frequency"
 msgstr "Häufigkeit"
 
-#: templates/events/event_form.html:225 templates/events/event_form.html:239
+#: templates/events/event_form.html:226 templates/events/event_form.html:240
 msgid "Weekday"
 msgstr "Wochentag"
 
-#: templates/events/event_form.html:237
+#: templates/events/event_form.html:238
 msgid "Week"
 msgstr "Woche"
 
-#: templates/events/event_form.html:242
+#: templates/events/event_form.html:243
 msgid "Interval"
 msgstr "Intervall"
 
-#: templates/events/event_form.html:245
+#: templates/events/event_form.html:246
 msgid "Recurrence ends"
 msgstr "Wiederholung endet"
 
-#: templates/events/event_form.html:252
+#: templates/events/event_form.html:253
 msgid "Recurrence end date"
 msgstr "Wiederholung Enddatum"
 
-#: templates/events/event_form.html:256
+#: templates/events/event_form.html:257
 msgid "Where"
 msgstr "Wo"
 
-#: templates/events/event_form.html:259
-msgid "This event does not have a physical location"
-msgstr "Diese Veranstaltung hat keinen Veranstaltungsort"
-
-#: templates/events/event_form.html:262 templates/pois/poi_form.html:179
+#: templates/events/event_form.html:259 templates/pois/poi_form.html:179
 msgid "Address"
 msgstr "Adresse"
 
-#: templates/events/event_form.html:263
+#: templates/events/event_form.html:260
 msgid "Name of event location"
 msgstr "Name des Veranstaltungsortes"
 
-#: templates/events/event_form.html:271
+#: templates/events/event_form.html:264
+msgid "Remove location from event"
+msgstr "Veranstaltungsort von Veranstaltung entfernen"
+
+#: templates/events/event_form.html:273
 msgid ""
 "Create an event location or start typing the name of an existing location"
 msgstr ""
 "Erstelle einen Veranstaltungsort oder beginne den Namen eines bestehenden "
 "Veranstaltungsortes einzutippen"
 
-#: templates/events/event_form.html:273 templates/pois/poi_form.html:180
+#: templates/events/event_form.html:276 templates/pois/poi_form.html:180
 #: templates/pois/poi_list.html:65 templates/pois/poi_list_archived.html:39
 msgid "Street"
 msgstr "Straße"
 
-#: templates/events/event_form.html:277 templates/pois/poi_form.html:189
+#: templates/events/event_form.html:280 templates/pois/poi_form.html:189
 #: templates/pois/poi_list.html:68 templates/pois/poi_list_archived.html:42
 msgid "Country"
 msgstr "Land"
 
-#: templates/events/event_form.html:280
+#: templates/events/event_form.html:283
 msgid "Map"
 msgstr "Karte"
 
-#: templates/events/event_form.html:283 templates/pages/page_form.html:262
+#: templates/events/event_form.html:286 templates/pages/page_form.html:262
 #: templates/pois/poi_form.html:203 templates/regions/region_form.html:80
 msgid "Icon"
 msgstr "Icon"
 
-#: templates/events/event_form.html:287
+#: templates/events/event_form.html:290
 #: templates/organizations/organization_form.html:65
 #: templates/pages/page_form.html:266 templates/pois/poi_form.html:207
 #: templates/regions/region_form.html:89
 msgid "Set icon"
 msgstr "Icon festlegen"
 
-#: templates/events/event_form.html:294
+#: templates/events/event_form.html:297
 #: templates/events/event_list_archived_row.html:93
 msgid "Restore event"
 msgstr "Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:297
+#: templates/events/event_form.html:300
 msgid "Restore this event"
 msgstr "Diese Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:300 templates/events/event_list_row.html:99
+#: templates/events/event_form.html:303 templates/events/event_list_row.html:99
 msgid "Archive event"
 msgstr "Veranstaltung archivieren"
 
-#: templates/events/event_form.html:303
+#: templates/events/event_form.html:306
 msgid "Archive this event"
 msgstr "Diese Veranstaltung archivieren"
 
-#: templates/events/event_form.html:309
+#: templates/events/event_form.html:312
 #: templates/events/event_list_archived_row.html:98
 #: templates/events/event_list_row.html:104
 msgid "Delete event"
 msgstr "Veranstaltung löschen"
 
-#: templates/events/event_form.html:312
+#: templates/events/event_form.html:315
 msgid "Delete this event"
 msgstr "Diese Veranstaltung löschen"
 
-#: templates/events/event_form.html:418 templates/pages/page_form.html:359
+#: templates/events/event_form.html:421 templates/pages/page_form.html:359
 #: templates/pois/poi_form.html:271
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
-#: templates/events/event_form.html:437 templates/pages/page_form.html:378
+#: templates/events/event_form.html:440 templates/pages/page_form.html:378
 #: templates/pois/poi_form.html:290
 msgid "Location"
 msgstr "Ort"
 
-#: templates/events/event_form.html:444 templates/pages/page_form.html:385
+#: templates/events/event_form.html:447 templates/pages/page_form.html:385
 #: templates/pois/poi_form.html:297
 msgid "Link"
 msgstr "Link"
 
-#: templates/events/event_form.html:451 templates/pages/page_form.html:392
+#: templates/events/event_form.html:454 templates/pages/page_form.html:392
 #: templates/pois/poi_form.html:304
 msgid "Phone"
 msgstr "Telefon"
 
-#: templates/events/event_form.html:458 templates/pages/page_form.html:399
+#: templates/events/event_form.html:461 templates/pages/page_form.html:399
 #: templates/pois/poi_form.html:311
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
-#: templates/events/event_form.html:465 templates/pages/page_form.html:406
+#: templates/events/event_form.html:468 templates/pages/page_form.html:406
 #: templates/pois/poi_form.html:318
 msgid "Email"
 msgstr "Email"
 
-#: templates/events/event_form.html:472 templates/pages/page_form.html:413
+#: templates/events/event_form.html:475 templates/pages/page_form.html:413
 #: templates/pois/poi_form.html:325
 msgid "Hint"
 msgstr "Tipp"
@@ -2399,18 +2399,18 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um Veranstaltungen zu bearbeiten "
 "oder zu erstellen."
 
-#: views/events/event_view.py:49
+#: views/events/event_view.py:44
 msgid "You don't have the permission to edit this event."
 msgstr ""
 "Sie haben nicht die nötige Berechtigung, um diese Veranstaltung zu "
 "bearbeiten."
 
-#: views/events/event_view.py:52
+#: views/events/event_view.py:47
 msgid "You cannot edit this event because it is archived."
 msgstr ""
 "Sie können diese Veranstaltung nicht bearbeiten, weil sie archiviert ist."
 
-#: views/events/event_view.py:147 views/pages/page_sbs_view.py:107
+#: views/events/event_view.py:137 views/pages/page_sbs_view.py:107
 #: views/pages/page_view.py:127 views/pois/poi_view.py:106
 #: views/regions/region_view.py:67 views/settings/user_settings_view.py:54
 #: views/settings/user_settings_view.py:74
@@ -2421,28 +2421,28 @@ msgstr ""
 msgid "No changes detected."
 msgstr "Keine Änderungen vorgenommen."
 
-#: views/events/event_view.py:172
+#: views/events/event_view.py:163
 msgid "Event was successfully created and published."
 msgstr "Veranstaltung wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/events/event_view.py:174
+#: views/events/event_view.py:165
 msgid "Event was successfully created."
 msgstr "Veranstaltung wurde erfolgreich erstellt."
 
-#: views/events/event_view.py:182
+#: views/events/event_view.py:173
 msgid "Event translation was successfully created and published."
 msgstr ""
 "Veranstaltungsübersetzung wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/events/event_view.py:184
+#: views/events/event_view.py:175
 msgid "Event translation was successfully created."
 msgstr "Veranstaltungsübersetzung wurde erfolgreich erstellt."
 
-#: views/events/event_view.py:187
+#: views/events/event_view.py:178
 msgid "Event was successfully published."
 msgstr "Veranstaltung wurde erfolgreich veröffentlicht."
 
-#: views/events/event_view.py:189
+#: views/events/event_view.py:180
 msgid "Event was successfully saved."
 msgstr "Veranstaltung wurde erfolgreich gespeichert."
 
@@ -2760,6 +2760,9 @@ msgstr "Benutzer wurde erfolgreich erstellt."
 #: views/users/user_view.py:108
 msgid "User was successfully deleted."
 msgstr "Benutzer wurde erfolgreich gelöscht."
+
+#~ msgid "This event does not have a physical location"
+#~ msgstr "Diese Veranstaltung hat keinen Veranstaltungsort"
 
 #~ msgid "No POI found"
 #~ msgstr "Kein POI gefunden"

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-24 17:39+0000\n"
+"POT-Creation-Date: 2020-04-04 12:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: constants/administrative_division.py:52 templates/events/event_form.html:278
+#: constants/administrative_division.py:52 templates/events/event_form.html:279
 #: templates/pois/poi_form.html:186 templates/pois/poi_list.html:67
 #: templates/pois/poi_list_archived.html:41
 msgid "City"
@@ -243,19 +243,19 @@ msgstr "Vierte Woche"
 msgid "The passwords do not match."
 msgstr "Die Passwörter stimmen nicht überein."
 
-#: forms/events/event_form.py:89
+#: forms/events/event_form.py:90
 msgid "If the event is not all-day, the start time is required"
 msgstr ""
 "Wenn die Veranstaltung nicht ganztägig ist, muss eine Start-Uhrzeit "
 "angegeben werden"
 
-#: forms/events/event_form.py:91
+#: forms/events/event_form.py:92
 msgid "If the event is not all-day, the end time is required"
 msgstr ""
 "Wenn die Veranstaltung nicht ganztägig ist, muss eine End-Uhrzeit angegeben "
 "werden"
 
-#: forms/events/event_form.py:98 forms/events/event_form.py:104
+#: forms/events/event_form.py:99 forms/events/event_form.py:105
 msgid "The end of the event can't be before the start of the event"
 msgstr "Das Ende der Veranstaltung kann nicht vor seinem Beginn sein"
 
@@ -478,9 +478,9 @@ msgid "Translations up-to-date"
 msgstr "Aktuelle Übersetzungen"
 
 #: templates/analytics/translation_coverage.html:46
-#: templates/events/event_form.html:91 templates/events/event_form.html:120
-#: templates/events/event_list_archived_row.html:50
-#: templates/events/event_list_row.html:50 templates/pages/page_form.html:94
+#: templates/events/event_form.html:92 templates/events/event_form.html:121
+#: templates/events/event_list_archived_row.html:51
+#: templates/events/event_list_row.html:51 templates/pages/page_form.html:94
 #: templates/pages/page_form.html:123
 #: templates/pages/page_tree_archived_node.html:56
 #: templates/pages/page_tree_node.html:57 templates/pois/poi_form.html:83
@@ -644,7 +644,7 @@ msgstr "Zurück zur Startseite"
 msgid "Error"
 msgstr "Fehler"
 
-#: templates/events/_poi_query_result.html:5
+#: templates/events/_poi_query_result.html:10
 #, python-format
 msgid "Create POI with title \"%(poi_query)s\""
 msgstr "POI mit Titel \"%(poi_query)s\" erstellen"
@@ -701,12 +701,12 @@ msgstr "Alle Übersetzungen dieser Veranstaltung werden wiederhergestellt."
 msgid "Yes, restore this event now."
 msgstr "Ja, diese Veranstaltung wiederherstellen."
 
-#: templates/events/event_form.html:46
+#: templates/events/event_form.html:47
 #, python-format
 msgid "Edit event \"%(event_title)s\""
 msgstr "Event \"%(event_title)s\" bearbeiten"
 
-#: templates/events/event_form.html:51 templates/events/event_list.html:49
+#: templates/events/event_form.html:52 templates/events/event_list.html:49
 #: templates/events/event_list.html:53
 #: templates/events/event_list_archived.html:25
 #: templates/events/event_list_archived.html:29
@@ -719,31 +719,31 @@ msgstr "Event \"%(event_title)s\" bearbeiten"
 msgid "Title in"
 msgstr "Titel auf"
 
-#: templates/events/event_form.html:55
+#: templates/events/event_form.html:56
 msgid "Create new event translation"
 msgstr "Neue Event-Übersetzung erstellen"
 
-#: templates/events/event_form.html:58
+#: templates/events/event_form.html:59
 msgid "Create new event"
 msgstr "Veranstaltung erstellen"
 
-#: templates/events/event_form.html:66 templates/pages/page_form.html:67
+#: templates/events/event_form.html:67 templates/pages/page_form.html:67
 #: templates/pois/poi_form.html:64
 msgid "Save as draft"
 msgstr "Als Entwurf speichern"
 
-#: templates/events/event_form.html:69 templates/pages/page_form.html:71
+#: templates/events/event_form.html:70 templates/pages/page_form.html:71
 #: templates/pois/poi_form.html:65
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: templates/events/event_form.html:71 templates/pages/page_form.html:73
+#: templates/events/event_form.html:72 templates/pages/page_form.html:73
 msgid "Submit for review"
 msgstr "Zur Überprüfung vorlegen"
 
-#: templates/events/event_form.html:87 templates/events/event_form.html:116
-#: templates/events/event_list_archived_row.html:54
-#: templates/events/event_list_row.html:54 templates/pages/page_form.html:90
+#: templates/events/event_form.html:88 templates/events/event_form.html:117
+#: templates/events/event_list_archived_row.html:55
+#: templates/events/event_list_row.html:55 templates/pages/page_form.html:90
 #: templates/pages/page_form.html:119
 #: templates/pages/page_tree_archived_node.html:60
 #: templates/pages/page_tree_node.html:61 templates/pois/poi_form.html:79
@@ -751,9 +751,9 @@ msgstr "Zur Überprüfung vorlegen"
 msgid "Translation outdated"
 msgstr "Übersetzung ist veraltet"
 
-#: templates/events/event_form.html:95 templates/events/event_form.html:124
-#: templates/events/event_list_archived_row.html:58
-#: templates/events/event_list_row.html:58 templates/pages/page_form.html:98
+#: templates/events/event_form.html:96 templates/events/event_form.html:125
+#: templates/events/event_list_archived_row.html:59
+#: templates/events/event_list_row.html:59 templates/pages/page_form.html:98
 #: templates/pages/page_form.html:127
 #: templates/pages/page_tree_archived_node.html:64
 #: templates/pages/page_tree_node.html:65 templates/pois/poi_form.html:87
@@ -761,9 +761,9 @@ msgstr "Übersetzung ist veraltet"
 msgid "Translation up-to-date"
 msgstr "Übersetzung ist aktuell"
 
-#: templates/events/event_form.html:100 templates/events/event_form.html:129
-#: templates/events/event_list_archived_row.html:63
-#: templates/events/event_list_row.html:63 templates/pages/page_form.html:103
+#: templates/events/event_form.html:101 templates/events/event_form.html:130
+#: templates/events/event_list_archived_row.html:64
+#: templates/events/event_list_row.html:64 templates/pages/page_form.html:103
 #: templates/pages/page_form.html:132
 #: templates/pages/page_tree_archived_node.html:69
 #: templates/pages/page_tree_node.html:70 templates/pois/poi_form.html:92
@@ -771,12 +771,12 @@ msgstr "Übersetzung ist aktuell"
 msgid "Translation missing"
 msgstr "Übersetzung fehlt"
 
-#: templates/events/event_form.html:105 templates/pages/page_form.html:108
+#: templates/events/event_form.html:106 templates/pages/page_form.html:108
 #: templates/pois/poi_form.html:97
 msgid "Create Translation"
 msgstr "Übersetzung erstellen"
 
-#: templates/events/event_form.html:144 templates/events/event_list.html:47
+#: templates/events/event_form.html:145 templates/events/event_list.html:47
 #: templates/events/event_list_archived.html:23
 #: templates/pages/page_form.html:147 templates/pages/page_tree.html:75
 #: templates/pages/page_tree_archived.html:31 templates/pois/poi_form.html:136
@@ -784,7 +784,7 @@ msgstr "Übersetzung erstellen"
 msgid "Version"
 msgstr "Version"
 
-#: templates/events/event_form.html:146 templates/events/event_list.html:48
+#: templates/events/event_form.html:147 templates/events/event_list.html:48
 #: templates/events/event_list_archived.html:24
 #: templates/pages/page_form.html:149 templates/pages/page_tree.html:76
 #: templates/pages/page_tree_archived.html:32 templates/pois/poi_form.html:138
@@ -793,216 +793,216 @@ msgstr "Version"
 msgid "Status"
 msgstr "Status"
 
-#: templates/events/event_form.html:149 templates/pages/page_form.html:152
+#: templates/events/event_form.html:150 templates/pages/page_form.html:152
 #: templates/pois/poi_form.html:141 templates/regions/region_form.html:53
 msgid "Permalink"
 msgstr ""
 
-#: templates/events/event_form.html:151 templates/pages/page_form.html:154
+#: templates/events/event_form.html:152 templates/pages/page_form.html:154
 #: templates/regions/region_form.html:55
 msgid " Leave blank to generate unique permalink from title"
 msgstr ""
 " Dieses Feld freilassen, um eine eindeutigen Permalink aus dem Titel zu "
 "generieren"
 
-#: templates/events/event_form.html:162 templates/pages/page_form.html:165
+#: templates/events/event_form.html:163 templates/pages/page_form.html:165
 #: templates/pois/poi_form.html:151
 #: templates/push_notifications/push_notification_form.html:49
 #: templates/push_notifications/push_notification_list.html:24
 msgid "Title"
 msgstr "Titel"
 
-#: templates/events/event_form.html:163 templates/pages/page_form.html:166
+#: templates/events/event_form.html:164 templates/pages/page_form.html:166
 #: templates/pages/page_sbs.html:30 templates/pois/poi_form.html:152
 msgid "Insert title here"
 msgstr "Titel hier eingeben"
 
-#: templates/events/event_form.html:165 templates/pois/poi_form.html:157
+#: templates/events/event_form.html:166 templates/pois/poi_form.html:157
 msgid "Description"
 msgstr "Beschreibung"
 
-#: templates/events/event_form.html:166
+#: templates/events/event_form.html:167
 msgid "Insert description here"
 msgstr "Beschreibung hier eingeben"
 
-#: templates/events/event_form.html:168 templates/pages/page_form.html:171
+#: templates/events/event_form.html:169 templates/pages/page_form.html:171
 #: templates/pois/poi_form.html:159
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
 
-#: templates/events/event_form.html:170 templates/pages/page_form.html:173
+#: templates/events/event_form.html:171 templates/pages/page_form.html:173
 #: templates/pois/poi_form.html:161
 msgid "This change does not require an update of the translations"
 msgstr "Diese Änderung erfordert keine angepasste Übersetzung"
 
-#: templates/events/event_form.html:180 templates/pages/page_form.html:214
+#: templates/events/event_form.html:181 templates/pages/page_form.html:214
 #: templates/pois/poi_form.html:171
 msgid "Settings for all translations"
 msgstr "Einstellungen für alle Übersetzungen"
 
-#: templates/events/event_form.html:187 templates/media/media_list.html:23
+#: templates/events/event_form.html:188 templates/media/media_list.html:23
 msgid "Date"
 msgstr "Datum"
 
-#: templates/events/event_form.html:190 templates/events/event_form.html:204
+#: templates/events/event_form.html:191 templates/events/event_form.html:205
 #: templates/events/event_list.html:65
 #: templates/events/event_list_archived.html:41
 msgid "Start"
 msgstr "Beginn"
 
-#: templates/events/event_form.html:194 templates/events/event_form.html:208
+#: templates/events/event_form.html:195 templates/events/event_form.html:209
 #: templates/events/event_list.html:66
 #: templates/events/event_list_archived.html:42
 msgid "End"
 msgstr "Ende"
 
-#: templates/events/event_form.html:198
+#: templates/events/event_form.html:199
 msgid "Time"
 msgstr "Uhrzeit"
 
-#: templates/events/event_form.html:200
+#: templates/events/event_form.html:201
 msgid "All-day"
 msgstr "Ganztägig"
 
-#: templates/events/event_form.html:212
+#: templates/events/event_form.html:213
 msgid "Recurrence"
 msgstr "Wiederholung"
 
-#: templates/events/event_form.html:215
+#: templates/events/event_form.html:216
 msgid "Recurring"
 msgstr "Wiederholend"
 
-#: templates/events/event_form.html:218
+#: templates/events/event_form.html:219
 msgid "Frequency"
 msgstr "Häufigkeit"
 
-#: templates/events/event_form.html:226 templates/events/event_form.html:240
+#: templates/events/event_form.html:227 templates/events/event_form.html:241
 msgid "Weekday"
 msgstr "Wochentag"
 
-#: templates/events/event_form.html:238
+#: templates/events/event_form.html:239
 msgid "Week"
 msgstr "Woche"
 
-#: templates/events/event_form.html:243
+#: templates/events/event_form.html:244
 msgid "Interval"
 msgstr "Intervall"
 
-#: templates/events/event_form.html:246
+#: templates/events/event_form.html:247
 msgid "Recurrence ends"
 msgstr "Wiederholung endet"
 
-#: templates/events/event_form.html:253
+#: templates/events/event_form.html:254
 msgid "Recurrence end date"
 msgstr "Wiederholung Enddatum"
 
-#: templates/events/event_form.html:257
+#: templates/events/event_form.html:258
 msgid "Where"
 msgstr "Wo"
 
-#: templates/events/event_form.html:259 templates/pois/poi_form.html:179
+#: templates/events/event_form.html:260 templates/pois/poi_form.html:179
 msgid "Address"
 msgstr "Adresse"
 
-#: templates/events/event_form.html:260
+#: templates/events/event_form.html:261
 msgid "Name of event location"
 msgstr "Name des Veranstaltungsortes"
 
-#: templates/events/event_form.html:264
+#: templates/events/event_form.html:265
 msgid "Remove location from event"
 msgstr "Veranstaltungsort von Veranstaltung entfernen"
 
-#: templates/events/event_form.html:273
+#: templates/events/event_form.html:274
 msgid ""
 "Create an event location or start typing the name of an existing location"
 msgstr ""
 "Erstelle einen Veranstaltungsort oder beginne den Namen eines bestehenden "
 "Veranstaltungsortes einzutippen"
 
-#: templates/events/event_form.html:276 templates/pois/poi_form.html:180
+#: templates/events/event_form.html:277 templates/pois/poi_form.html:180
 #: templates/pois/poi_list.html:65 templates/pois/poi_list_archived.html:39
 msgid "Street"
 msgstr "Straße"
 
-#: templates/events/event_form.html:280 templates/pois/poi_form.html:189
+#: templates/events/event_form.html:281 templates/pois/poi_form.html:189
 #: templates/pois/poi_list.html:68 templates/pois/poi_list_archived.html:42
 msgid "Country"
 msgstr "Land"
 
-#: templates/events/event_form.html:283
+#: templates/events/event_form.html:284
 msgid "Map"
 msgstr "Karte"
 
-#: templates/events/event_form.html:286 templates/pages/page_form.html:262
+#: templates/events/event_form.html:287 templates/pages/page_form.html:262
 #: templates/pois/poi_form.html:203 templates/regions/region_form.html:80
 msgid "Icon"
 msgstr "Icon"
 
-#: templates/events/event_form.html:290
+#: templates/events/event_form.html:291
 #: templates/organizations/organization_form.html:65
 #: templates/pages/page_form.html:266 templates/pois/poi_form.html:207
 #: templates/regions/region_form.html:89
 msgid "Set icon"
 msgstr "Icon festlegen"
 
-#: templates/events/event_form.html:297
-#: templates/events/event_list_archived_row.html:93
+#: templates/events/event_form.html:298
+#: templates/events/event_list_archived_row.html:94
 msgid "Restore event"
 msgstr "Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:300
+#: templates/events/event_form.html:301
 msgid "Restore this event"
 msgstr "Diese Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:303 templates/events/event_list_row.html:99
+#: templates/events/event_form.html:304 templates/events/event_list_row.html:97
 msgid "Archive event"
 msgstr "Veranstaltung archivieren"
 
-#: templates/events/event_form.html:306
+#: templates/events/event_form.html:307
 msgid "Archive this event"
 msgstr "Diese Veranstaltung archivieren"
 
-#: templates/events/event_form.html:312
-#: templates/events/event_list_archived_row.html:98
-#: templates/events/event_list_row.html:104
+#: templates/events/event_form.html:313
+#: templates/events/event_list_archived_row.html:99
+#: templates/events/event_list_row.html:102
 msgid "Delete event"
 msgstr "Veranstaltung löschen"
 
-#: templates/events/event_form.html:315
+#: templates/events/event_form.html:316
 msgid "Delete this event"
 msgstr "Diese Veranstaltung löschen"
 
-#: templates/events/event_form.html:421 templates/pages/page_form.html:359
+#: templates/events/event_form.html:423 templates/pages/page_form.html:359
 #: templates/pois/poi_form.html:271
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
-#: templates/events/event_form.html:440 templates/pages/page_form.html:378
+#: templates/events/event_form.html:442 templates/pages/page_form.html:378
 #: templates/pois/poi_form.html:290
 msgid "Location"
 msgstr "Ort"
 
-#: templates/events/event_form.html:447 templates/pages/page_form.html:385
+#: templates/events/event_form.html:449 templates/pages/page_form.html:385
 #: templates/pois/poi_form.html:297
 msgid "Link"
 msgstr "Link"
 
-#: templates/events/event_form.html:454 templates/pages/page_form.html:392
+#: templates/events/event_form.html:456 templates/pages/page_form.html:392
 #: templates/pois/poi_form.html:304
 msgid "Phone"
 msgstr "Telefon"
 
-#: templates/events/event_form.html:461 templates/pages/page_form.html:399
+#: templates/events/event_form.html:463 templates/pages/page_form.html:399
 #: templates/pois/poi_form.html:311
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
-#: templates/events/event_form.html:468 templates/pages/page_form.html:406
+#: templates/events/event_form.html:470 templates/pages/page_form.html:406
 #: templates/pois/poi_form.html:318
 msgid "Email"
 msgstr "Email"
 
-#: templates/events/event_form.html:475 templates/pages/page_form.html:413
+#: templates/events/event_form.html:477 templates/pages/page_form.html:413
 #: templates/pois/poi_form.html:325
 msgid "Hint"
 msgstr "Tipp"
@@ -1047,10 +1047,10 @@ msgstr "Noch keine Veranstaltungen vorhanden."
 msgid "No events archived yet."
 msgstr "Noch keine Veranstaltungen archiviert."
 
-#: templates/events/event_list_archived_row.html:24
-#: templates/events/event_list_archived_row.html:37
-#: templates/events/event_list_row.html:24
-#: templates/events/event_list_row.html:37
+#: templates/events/event_list_archived_row.html:25
+#: templates/events/event_list_archived_row.html:38
+#: templates/events/event_list_row.html:25
+#: templates/events/event_list_row.html:38
 #: templates/pages/page_tree_archived_node.html:30
 #: templates/pages/page_tree_archived_node.html:43
 #: templates/pages/page_tree_node.html:31
@@ -1061,12 +1061,12 @@ msgstr "Noch keine Veranstaltungen archiviert."
 msgid "Translation not available"
 msgstr "Übersetzung nicht verfügbar"
 
-#: templates/events/event_list_archived_row.html:77
-#: templates/events/event_list_row.html:80
+#: templates/events/event_list_archived_row.html:78
+#: templates/events/event_list_row.html:78
 msgid "Not specified"
 msgstr "Nicht festgelegt"
 
-#: templates/events/event_list_row.html:96
+#: templates/events/event_list_row.html:94
 msgid "Edit event"
 msgstr "Veranstaltung bearbeiten"
 
@@ -2375,15 +2375,15 @@ msgstr "Interner Server-Fehler"
 msgid "An unexpected error has occurred."
 msgstr "Es ist ein unerwarteter Fehler aufgetreten."
 
-#: views/events/event_actions.py:27
+#: views/events/event_actions.py:29
 msgid "Event was successfully archived."
 msgstr "Veranstaltung wurde erfolgreich archiviert."
 
-#: views/events/event_actions.py:46
+#: views/events/event_actions.py:48
 msgid "Event was successfully restored."
 msgstr "Veranstaltung wurde erfolgreich wiederhergestellt."
 
-#: views/events/event_actions.py:61
+#: views/events/event_actions.py:63
 msgid "Event was successfully deleted."
 msgstr "Veranstaltung wurde erfolgreich gelöscht."
 

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-03 13:04+0000\n"
+"POT-Creation-Date: 2020-03-20 13:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: constants/administrative_division.py:52 templates/events/event_form.html:271
+#: constants/administrative_division.py:52 templates/events/event_form.html:270
 #: templates/pois/poi_form.html:186 templates/pois/poi_list.html:67
 #: templates/pois/poi_list_archived.html:41
 msgid "City"
@@ -903,7 +903,7 @@ msgstr "Diese Veranstaltung hat keinen Veranstaltungsort"
 msgid "Address"
 msgstr "Adresse"
 
-#: templates/events/event_form.html:264
+#: templates/events/event_form.html:263
 msgid "Name of event location"
 msgstr "Name des Veranstaltungsortes"
 
@@ -914,89 +914,90 @@ msgstr ""
 "Erstelle einen Veranstaltungsort oder beginne den Namen eines bestehenden "
 "Veranstaltungsortes einzutippen"
 
-#: templates/events/event_form.html:269 templates/pois/poi_form.html:180
+#: templates/events/event_form.html:268 templates/pois/poi_form.html:180
 #: templates/pois/poi_list.html:65 templates/pois/poi_list_archived.html:39
 msgid "Street"
 msgstr "Straße"
 
-#: templates/events/event_form.html:274
-msgid "Germany"
-msgstr "Deutschland"
+#: templates/events/event_form.html:272 templates/pois/poi_form.html:189
+#: templates/pois/poi_list.html:68 templates/pois/poi_list_archived.html:42
+msgid "Country"
+msgstr "Land"
 
-#: templates/events/event_form.html:284
+#: templates/events/event_form.html:275
 msgid "Map"
 msgstr "Karte"
 
-#: templates/events/event_form.html:287 templates/pages/page_form.html:262
+#: templates/events/event_form.html:278 templates/pages/page_form.html:262
 #: templates/pois/poi_form.html:203 templates/regions/region_form.html:80
 msgid "Icon"
 msgstr "Icon"
 
-#: templates/events/event_form.html:291
+#: templates/events/event_form.html:282
 #: templates/organizations/organization_form.html:65
 #: templates/pages/page_form.html:266 templates/pois/poi_form.html:207
 #: templates/regions/region_form.html:89
 msgid "Set icon"
 msgstr "Icon festlegen"
 
-#: templates/events/event_form.html:298
+#: templates/events/event_form.html:289
 #: templates/events/event_list_archived_row.html:93
 msgid "Restore event"
 msgstr "Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:301
+#: templates/events/event_form.html:292
 msgid "Restore this event"
 msgstr "Diese Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:304 templates/events/event_list_row.html:96
+#: templates/events/event_form.html:295 templates/events/event_list_row.html:99
 msgid "Archive event"
 msgstr "Veranstaltung archivieren"
 
-#: templates/events/event_form.html:307
+#: templates/events/event_form.html:298
 msgid "Archive this event"
 msgstr "Diese Veranstaltung archivieren"
 
-#: templates/events/event_form.html:313
+#: templates/events/event_form.html:304
 #: templates/events/event_list_archived_row.html:98
-#: templates/events/event_list_row.html:101
+#: templates/events/event_list_row.html:104
 msgid "Delete event"
 msgstr "Veranstaltung löschen"
 
-#: templates/events/event_form.html:316
+#: templates/events/event_form.html:307
 msgid "Delete this event"
 msgstr "Diese Veranstaltung löschen"
 
-#: templates/events/event_form.html:420 templates/pages/page_form.html:359
+#: templates/events/event_form.html:411 templates/pages/page_form.html:359
 #: templates/pois/poi_form.html:271
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
-#: templates/events/event_form.html:439 templates/pages/page_form.html:378
+#: templates/events/event_form.html:430 templates/pages/page_form.html:378
 #: templates/pois/poi_form.html:290
 msgid "Location"
 msgstr "Ort"
 
-#: templates/events/event_form.html:446 templates/pages/page_form.html:385
+#: templates/events/event_form.html:437 templates/pages/page_form.html:385
 #: templates/pois/poi_form.html:297
 msgid "Link"
 msgstr "Link"
 
-#: templates/events/event_form.html:453 templates/pages/page_form.html:392
+#: templates/events/event_form.html:444 templates/pages/page_form.html:392
 #: templates/pois/poi_form.html:304
 msgid "Phone"
 msgstr "Telefon"
 
-#: templates/events/event_form.html:460 templates/pages/page_form.html:399
+#: templates/events/event_form.html:451 templates/pages/page_form.html:399
 #: templates/pois/poi_form.html:311
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
-#: templates/events/event_form.html:467 templates/pages/page_form.html:406
+#: templates/events/event_form.html:458 templates/pages/page_form.html:406
 #: templates/pois/poi_form.html:318
 msgid "Email"
 msgstr "Email"
 
-#: templates/events/event_form.html:474 templates/pages/page_form.html:413
+#: templates/events/event_form.html:465 templates/pages/page_form.html:413
 #: templates/pois/poi_form.html:325
 msgid "Hint"
 msgstr "Tipp"
@@ -1056,11 +1057,11 @@ msgid "Translation not available"
 msgstr "Übersetzung nicht verfügbar"
 
 #: templates/events/event_list_archived_row.html:77
-#: templates/events/event_list_row.html:77
+#: templates/events/event_list_row.html:80
 msgid "Not specified"
 msgstr "Nicht festgelegt"
 
-#: templates/events/event_list_row.html:93
+#: templates/events/event_list_row.html:96
 msgid "Edit event"
 msgstr "Veranstaltung bearbeiten"
 
@@ -1652,11 +1653,6 @@ msgstr "Postleitzahl hier eingeben"
 #: templates/pois/poi_form.html:187
 msgid "Insert city here"
 msgstr "Stadt hier eingeben"
-
-#: templates/pois/poi_form.html:189 templates/pois/poi_list.html:68
-#: templates/pois/poi_list_archived.html:42
-msgid "Country"
-msgstr "Land"
 
 #: templates/pois/poi_form.html:190
 msgid "Insert country here"
@@ -2398,18 +2394,18 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um Veranstaltungen zu bearbeiten "
 "oder zu erstellen."
 
-#: views/events/event_view.py:42
+#: views/events/event_view.py:49
 msgid "You don't have the permission to edit this event."
 msgstr ""
 "Sie haben nicht die nötige Berechtigung, um diese Veranstaltung zu "
 "bearbeiten."
 
-#: views/events/event_view.py:45
+#: views/events/event_view.py:52
 msgid "You cannot edit this event because it is archived."
 msgstr ""
 "Sie können diese Veranstaltung nicht bearbeiten, weil sie archiviert ist."
 
-#: views/events/event_view.py:132 views/pages/page_sbs_view.py:107
+#: views/events/event_view.py:149 views/pages/page_sbs_view.py:107
 #: views/pages/page_view.py:127 views/pois/poi_view.py:106
 #: views/regions/region_view.py:67 views/settings/user_settings_view.py:54
 #: views/settings/user_settings_view.py:74
@@ -2420,28 +2416,28 @@ msgstr ""
 msgid "No changes detected."
 msgstr "Keine Änderungen vorgenommen."
 
-#: views/events/event_view.py:157
+#: views/events/event_view.py:174
 msgid "Event was successfully created and published."
 msgstr "Veranstaltung wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/events/event_view.py:159
+#: views/events/event_view.py:176
 msgid "Event was successfully created."
 msgstr "Veranstaltung wurde erfolgreich erstellt."
 
-#: views/events/event_view.py:167
+#: views/events/event_view.py:184
 msgid "Event translation was successfully created and published."
 msgstr ""
 "Veranstaltungsübersetzung wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/events/event_view.py:169
+#: views/events/event_view.py:186
 msgid "Event translation was successfully created."
 msgstr "Veranstaltungsübersetzung wurde erfolgreich erstellt."
 
-#: views/events/event_view.py:172
+#: views/events/event_view.py:189
 msgid "Event was successfully published."
 msgstr "Veranstaltung wurde erfolgreich veröffentlicht."
 
-#: views/events/event_view.py:174
+#: views/events/event_view.py:191
 msgid "Event was successfully saved."
 msgstr "Veranstaltung wurde erfolgreich gespeichert."
 
@@ -2759,6 +2755,9 @@ msgstr "Benutzer wurde erfolgreich erstellt."
 #: views/users/user_view.py:108
 msgid "User was successfully deleted."
 msgstr "Benutzer wurde erfolgreich gelöscht."
+
+#~ msgid "Germany"
+#~ msgstr "Deutschland"
 
 #~ msgid "Save e-mail-address"
 #~ msgstr "E-Mail Adresse speichern"

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-20 13:35+0000\n"
+"POT-Creation-Date: 2020-03-23 16:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: constants/administrative_division.py:52 templates/events/event_form.html:270
+#: constants/administrative_division.py:52 templates/events/event_form.html:275
 #: templates/pois/poi_form.html:186 templates/pois/poi_list.html:67
 #: templates/pois/poi_list_archived.html:41
 msgid "City"
@@ -644,6 +644,11 @@ msgstr "Zurück zur Startseite"
 msgid "Error"
 msgstr "Fehler"
 
+#: templates/events/_poi_query_result.html:4
+#, python-format
+msgid "Create POI with title \"%(poi_query)s\""
+msgstr "POI mit Titel \"%(poi_query)s\" erstellen"
+
 #: templates/events/confirmation_popups/archive_event.html:5
 msgid "Please confirm that you really want to archive this event"
 msgstr "Bitte bestätigen Sie, dass dieses Event archiviert werden soll."
@@ -907,97 +912,97 @@ msgstr "Adresse"
 msgid "Name of event location"
 msgstr "Name des Veranstaltungsortes"
 
-#: templates/events/event_form.html:266
+#: templates/events/event_form.html:271
 msgid ""
 "Create an event location or start typing the name of an existing location"
 msgstr ""
 "Erstelle einen Veranstaltungsort oder beginne den Namen eines bestehenden "
 "Veranstaltungsortes einzutippen"
 
-#: templates/events/event_form.html:268 templates/pois/poi_form.html:180
+#: templates/events/event_form.html:273 templates/pois/poi_form.html:180
 #: templates/pois/poi_list.html:65 templates/pois/poi_list_archived.html:39
 msgid "Street"
 msgstr "Straße"
 
-#: templates/events/event_form.html:272 templates/pois/poi_form.html:189
+#: templates/events/event_form.html:277 templates/pois/poi_form.html:189
 #: templates/pois/poi_list.html:68 templates/pois/poi_list_archived.html:42
 msgid "Country"
 msgstr "Land"
 
-#: templates/events/event_form.html:275
+#: templates/events/event_form.html:280
 msgid "Map"
 msgstr "Karte"
 
-#: templates/events/event_form.html:278 templates/pages/page_form.html:262
+#: templates/events/event_form.html:283 templates/pages/page_form.html:262
 #: templates/pois/poi_form.html:203 templates/regions/region_form.html:80
 msgid "Icon"
 msgstr "Icon"
 
-#: templates/events/event_form.html:282
+#: templates/events/event_form.html:287
 #: templates/organizations/organization_form.html:65
 #: templates/pages/page_form.html:266 templates/pois/poi_form.html:207
 #: templates/regions/region_form.html:89
 msgid "Set icon"
 msgstr "Icon festlegen"
 
-#: templates/events/event_form.html:289
+#: templates/events/event_form.html:294
 #: templates/events/event_list_archived_row.html:93
 msgid "Restore event"
 msgstr "Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:292
+#: templates/events/event_form.html:297
 msgid "Restore this event"
 msgstr "Diese Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:295 templates/events/event_list_row.html:99
+#: templates/events/event_form.html:300 templates/events/event_list_row.html:99
 msgid "Archive event"
 msgstr "Veranstaltung archivieren"
 
-#: templates/events/event_form.html:298
+#: templates/events/event_form.html:303
 msgid "Archive this event"
 msgstr "Diese Veranstaltung archivieren"
 
-#: templates/events/event_form.html:304
+#: templates/events/event_form.html:309
 #: templates/events/event_list_archived_row.html:98
 #: templates/events/event_list_row.html:104
 msgid "Delete event"
 msgstr "Veranstaltung löschen"
 
-#: templates/events/event_form.html:307
+#: templates/events/event_form.html:312
 msgid "Delete this event"
 msgstr "Diese Veranstaltung löschen"
 
-#: templates/events/event_form.html:411 templates/pages/page_form.html:359
+#: templates/events/event_form.html:418 templates/pages/page_form.html:359
 #: templates/pois/poi_form.html:271
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
-#: templates/events/event_form.html:430 templates/pages/page_form.html:378
+#: templates/events/event_form.html:437 templates/pages/page_form.html:378
 #: templates/pois/poi_form.html:290
 msgid "Location"
 msgstr "Ort"
 
-#: templates/events/event_form.html:437 templates/pages/page_form.html:385
+#: templates/events/event_form.html:444 templates/pages/page_form.html:385
 #: templates/pois/poi_form.html:297
 msgid "Link"
 msgstr "Link"
 
-#: templates/events/event_form.html:444 templates/pages/page_form.html:392
+#: templates/events/event_form.html:451 templates/pages/page_form.html:392
 #: templates/pois/poi_form.html:304
 msgid "Phone"
 msgstr "Telefon"
 
-#: templates/events/event_form.html:451 templates/pages/page_form.html:399
+#: templates/events/event_form.html:458 templates/pages/page_form.html:399
 #: templates/pois/poi_form.html:311
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
-#: templates/events/event_form.html:458 templates/pages/page_form.html:406
+#: templates/events/event_form.html:465 templates/pages/page_form.html:406
 #: templates/pois/poi_form.html:318
 msgid "Email"
 msgstr "Email"
 
-#: templates/events/event_form.html:465 templates/pages/page_form.html:413
+#: templates/events/event_form.html:472 templates/pages/page_form.html:413
 #: templates/pois/poi_form.html:325
 msgid "Hint"
 msgstr "Tipp"
@@ -2370,15 +2375,15 @@ msgstr "Interner Server-Fehler"
 msgid "An unexpected error has occurred."
 msgstr "Es ist ein unerwarteter Fehler aufgetreten."
 
-#: views/events/event_actions.py:22
+#: views/events/event_actions.py:27
 msgid "Event was successfully archived."
 msgstr "Veranstaltung wurde erfolgreich archiviert."
 
-#: views/events/event_actions.py:41
+#: views/events/event_actions.py:46
 msgid "Event was successfully restored."
 msgstr "Veranstaltung wurde erfolgreich wiederhergestellt."
 
-#: views/events/event_actions.py:57
+#: views/events/event_actions.py:61
 msgid "Event was successfully deleted."
 msgstr "Veranstaltung wurde erfolgreich gelöscht."
 
@@ -2405,7 +2410,7 @@ msgid "You cannot edit this event because it is archived."
 msgstr ""
 "Sie können diese Veranstaltung nicht bearbeiten, weil sie archiviert ist."
 
-#: views/events/event_view.py:149 views/pages/page_sbs_view.py:107
+#: views/events/event_view.py:147 views/pages/page_sbs_view.py:107
 #: views/pages/page_view.py:127 views/pois/poi_view.py:106
 #: views/regions/region_view.py:67 views/settings/user_settings_view.py:54
 #: views/settings/user_settings_view.py:74
@@ -2416,28 +2421,28 @@ msgstr ""
 msgid "No changes detected."
 msgstr "Keine Änderungen vorgenommen."
 
-#: views/events/event_view.py:174
+#: views/events/event_view.py:172
 msgid "Event was successfully created and published."
 msgstr "Veranstaltung wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/events/event_view.py:176
+#: views/events/event_view.py:174
 msgid "Event was successfully created."
 msgstr "Veranstaltung wurde erfolgreich erstellt."
 
-#: views/events/event_view.py:184
+#: views/events/event_view.py:182
 msgid "Event translation was successfully created and published."
 msgstr ""
 "Veranstaltungsübersetzung wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/events/event_view.py:186
+#: views/events/event_view.py:184
 msgid "Event translation was successfully created."
 msgstr "Veranstaltungsübersetzung wurde erfolgreich erstellt."
 
-#: views/events/event_view.py:189
+#: views/events/event_view.py:187
 msgid "Event was successfully published."
 msgstr "Veranstaltung wurde erfolgreich veröffentlicht."
 
-#: views/events/event_view.py:191
+#: views/events/event_view.py:189
 msgid "Event was successfully saved."
 msgstr "Veranstaltung wurde erfolgreich gespeichert."
 
@@ -2755,6 +2760,9 @@ msgstr "Benutzer wurde erfolgreich erstellt."
 #: views/users/user_view.py:108
 msgid "User was successfully deleted."
 msgstr "Benutzer wurde erfolgreich gelöscht."
+
+#~ msgid "No POI found"
+#~ msgstr "Kein POI gefunden"
 
 #~ msgid "Germany"
 #~ msgstr "Deutschland"

--- a/src/cms/models/events/event.py
+++ b/src/cms/models/events/event.py
@@ -52,6 +52,10 @@ class Event(models.Model):
     def is_all_day(self):
         return self.start_time == time.min and self.end_time == time.max.replace(second=0, microsecond=0)
 
+    @property
+    def has_location(self):
+        return bool(self.location)
+
     def get_translation(self, language_code):
         return self.translations.filter(language__code=language_code).first()
 

--- a/src/cms/static/js/event.js
+++ b/src/cms/static/js/event.js
@@ -1,0 +1,66 @@
+const query_input = u('#poi-query-input');
+const query_result = u('#poi-query-result');
+const delay_in_ms = 700;
+let scheduled_function = false;
+
+u(document).handle('DOMContentLoaded', set_poi_query_event_listeners);
+
+async function query_pois(url, query_string, region_slug, language_code) {
+    const data = await fetch(url, {
+        method: 'POST',
+        headers: {
+            'X-CSRFToken': u('[name=csrfmiddlewaretoken]').first().value
+        },
+        body: JSON.stringify({
+            'query_string': query_string,
+            'region_slug': region_slug,
+            'language_code': language_code
+        })
+    }).then(res => {
+        if (res.status != 200) {
+            // Invalid status => return empty result
+            return '';
+        } else {
+            // Return response text
+            return res.text();
+        }
+    });
+    if (data) {
+        // Set and display new data
+        query_result.first().classList.remove('hidden');
+        query_result.html(data);
+    }
+}
+
+function set_poi_query_event_listeners() {
+    // AJAX search
+    query_input.handle('keyup', function (event) {
+        let input_field = u(event.target).closest('input');
+
+        // Reschedule function execution on new input
+        if (scheduled_function) {
+            clearTimeout(scheduled_function);
+        }
+        // Schedule function execution
+        scheduled_function = setTimeout(
+            query_pois,
+            delay_in_ms,
+            input_field.data('url'),
+            input_field.first().value,
+            input_field.data('region-slug'),
+            input_field.data('language-code')
+        );
+    });
+
+    // Hide AJAX search results
+    u(document).handle('click', function (event) {
+        if (
+            u(event.target).closest('#poi-query-input').first() !== query_input.first() &&
+            u(event.target).closest('#poi-query-result').first() !== query_result.first()
+        ) {
+            // Neither clicking on input field nor on result to select it
+            query_result.first().classList.add('hidden');
+            query_input.first().value = '';
+        }
+    });
+}

--- a/src/cms/static/js/event.js
+++ b/src/cms/static/js/event.js
@@ -1,6 +1,6 @@
 u(document).handle('DOMContentLoaded', set_poi_query_event_listeners);
 
-async function query_pois(url, query_string, region_slug, language_code) {
+async function query_pois(url, query_string, region_slug) {
     const data = await fetch(url, {
         method: 'POST',
         headers: {
@@ -8,8 +8,7 @@ async function query_pois(url, query_string, region_slug, language_code) {
         },
         body: JSON.stringify({
             'query_string': query_string,
-            'region_slug': region_slug,
-            'language_code': language_code
+            'region_slug': region_slug
         })
     }).then(res => {
         if (res.status != 200) {
@@ -26,8 +25,8 @@ async function query_pois(url, query_string, region_slug, language_code) {
         u('#poi-query-result').html(data);
     }
 
-    u('.option-new-poi').each(function (node, i) {
-        u(node).handle('click', () => console.log('Clicked on new node ' + i));
+    u('.option-new-poi').each(function (node) {
+        u(node).handle('click', new_poi_window);
     });
 
     u('.option-existing-poi').each(function (node) {
@@ -36,7 +35,7 @@ async function query_pois(url, query_string, region_slug, language_code) {
 }
 
 function set_poi(event) {
-    let option = u(event.target).closest('option');
+    let option = u(event.target).closest('.option-existing-poi');
     render_poi_data(
         option.data('poi-title'),
         option.data('poi-id'),
@@ -54,6 +53,14 @@ function remove_poi() {
         '',
         ''
     );
+}
+
+function new_poi_window(event) {
+    let option = u(event.target).closest('.option-new-poi');
+    let new_window = window.open(option.data('url'), "_blank");
+    new_window.onload = function () {
+        u('#id_title', new_window.document).attr('value', option.data('poi-title'));
+    }
 }
 
 function render_poi_data(query_placeholder, id, address, city, country) {
@@ -83,8 +90,7 @@ function set_poi_query_event_listeners() {
             300,
             input_field.data('url'),
             input_field.first().value,
-            input_field.data('region-slug'),
-            input_field.data('language-code')
+            input_field.data('region-slug')
         );
     });
 
@@ -101,8 +107,5 @@ function set_poi_query_event_listeners() {
     });
 
     // Remove POI
-    u('#poi-remove').on('click', function (event) {
-        event.preventDefault();
-        remove_poi();
-    });
+    u('#poi-remove').handle('click', remove_poi);
 }

--- a/src/cms/static/js/event.js
+++ b/src/cms/static/js/event.js
@@ -1,8 +1,3 @@
-const query_input = u('#poi-query-input');
-const query_result = u('#poi-query-result');
-const delay_in_ms = 700;
-let scheduled_function = false;
-
 u(document).handle('DOMContentLoaded', set_poi_query_event_listeners);
 
 async function query_pois(url, query_string, region_slug, language_code) {
@@ -27,14 +22,55 @@ async function query_pois(url, query_string, region_slug, language_code) {
     });
     if (data) {
         // Set and display new data
-        query_result.first().classList.remove('hidden');
-        query_result.html(data);
+        u('#poi-query-result').first().classList.remove('hidden');
+        u('#poi-query-result').html(data);
     }
+
+    u('.option-new-poi').each(function (node, i) {
+        u(node).handle('click', () => console.log('Clicked on new node ' + i));
+    });
+
+    u('.option-existing-poi').each(function (node) {
+        u(node).handle('click', set_poi);
+    });
+}
+
+function set_poi(event) {
+    let option = u(event.target).closest('option');
+    render_poi_data(
+        option.data('poi-title'),
+        option.data('poi-id'),
+        option.data('poi-address'),
+        option.data('poi-city'),
+        option.data('poi-country')
+    );
+}
+
+function remove_poi() {
+    render_poi_data(
+        u('#poi-query-input').data('default-placeholder'),
+        -1,
+        '',
+        '',
+        ''
+    );
+}
+
+function render_poi_data(query_placeholder, id, address, city, country) {
+    u('#poi-query-input').attr('placeholder', query_placeholder);
+    u('#poi-id').attr('value', id);
+    u('#poi-address').attr('value', address);
+    u('#poi-city').attr('value', city);
+    u('#poi-country').attr('value', country);
+
+    u('#poi-query-result').first().classList.add('hidden');
+    u('#poi-query-input').first().value = '';
 }
 
 function set_poi_query_event_listeners() {
+    let scheduled_function = false;
     // AJAX search
-    query_input.handle('keyup', function (event) {
+    u('#poi-query-input').handle('keyup', function (event) {
         let input_field = u(event.target).closest('input');
 
         // Reschedule function execution on new input
@@ -44,7 +80,7 @@ function set_poi_query_event_listeners() {
         // Schedule function execution
         scheduled_function = setTimeout(
             query_pois,
-            delay_in_ms,
+            300,
             input_field.data('url'),
             input_field.first().value,
             input_field.data('region-slug'),
@@ -53,14 +89,20 @@ function set_poi_query_event_listeners() {
     });
 
     // Hide AJAX search results
-    u(document).handle('click', function (event) {
+    u(document).on('click', function (event) {
         if (
-            u(event.target).closest('#poi-query-input').first() !== query_input.first() &&
-            u(event.target).closest('#poi-query-result').first() !== query_result.first()
+            u(event.target).closest('#poi-query-input').first() !== u('#poi-query-input').first() &&
+            u(event.target).closest('#poi-query-result').first() !== u('#poi-query-result').first()
         ) {
             // Neither clicking on input field nor on result to select it
-            query_result.first().classList.add('hidden');
-            query_input.first().value = '';
+            u('#poi-query-result').first().classList.add('hidden');
+            u('#poi-query-input').first().value = '';
         }
+    });
+
+    // Remove POI
+    u('#poi-remove').on('click', function (event) {
+        event.preventDefault();
+        remove_poi();
     });
 }

--- a/src/cms/templates/events/_poi_query_result.html
+++ b/src/cms/templates/events/_poi_query_result.html
@@ -1,9 +1,10 @@
 {% load i18n %}
+{% load poi_filters %}
 {% if poi_query %}
     <select size="{% if poi_query_result|length > 5 %}5{% else %}{{ poi_query_result|length|add:"1" }}{% endif %}" class="appearance-none absolute block w-full bg-white text-gray-800 border border-gray-500 mb-2 py-2 px-2">
-        <option value="-1">{% blocktrans %}Create POI with title "{{ poi_query }}"{% endblocktrans %}</option>
+        <option class="option-new-poi" value="-1">{% blocktrans %}Create POI with title "{{ poi_query }}"{% endblocktrans %}</option>
         {% for poi in poi_query_result %}
-            <option value="{{ poi.foreign_object.id }}">{{ poi.title }}</option>
+            <option class="option-existing-poi" data-poi-title="{{ poi|poi_translation_title:language }}" data-poi-id="{{ poi.id }}" data-poi-address="{{ poi.address }}" data-poi-city="{{ poi.city }}" data-poi-country="{{ poi.country }}">{{ poi|poi_translation_title:language }}</option>
         {% endfor %}
     </select>
 {% endif %}

--- a/src/cms/templates/events/_poi_query_result.html
+++ b/src/cms/templates/events/_poi_query_result.html
@@ -1,0 +1,9 @@
+{% load i18n %}
+{% if poi_query %}
+    <select size="{% if poi_query_result|length > 5 %}5{% else %}{{ poi_query_result|length|add:"1" }}{% endif %}" class="appearance-none absolute block w-full bg-white text-gray-800 border border-gray-500 mb-2 py-2 px-2">
+        <option value="-1">{% blocktrans %}Create POI with title "{{ poi_query }}"{% endblocktrans %}</option>
+        {% for poi in poi_query_result %}
+            <option value="{{ poi.foreign_object.id }}">{{ poi.title }}</option>
+        {% endfor %}
+    </select>
+{% endif %}

--- a/src/cms/templates/events/_poi_query_result.html
+++ b/src/cms/templates/events/_poi_query_result.html
@@ -1,10 +1,18 @@
 {% load i18n %}
+{% load content_filters %}
 {% load poi_filters %}
-{% if poi_query %}
+{% if poi_query and region %}
+    {% get_current_language as LANGUAGE_CODE %}
+    {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
+    {% get_language LANGUAGE_CODE as current_language %}
     <select size="{% if poi_query_result|length > 5 %}5{% else %}{{ poi_query_result|length|add:"1" }}{% endif %}" class="appearance-none absolute block w-full bg-white text-gray-800 border border-gray-500 mb-2 py-2 px-2">
-        <option class="option-new-poi" value="-1">{% blocktrans %}Create POI with title "{{ poi_query }}"{% endblocktrans %}</option>
+        <option class="option-new-poi" data-url="{% url 'new_poi' region_slug=region.slug language_code=region.default_language.code %}" data-poi-title="{{ poi_query }}" value="-1">
+            {% blocktrans %}Create POI with title "{{ poi_query }}"{% endblocktrans %}
+        </option>
         {% for poi in poi_query_result %}
-            <option class="option-existing-poi" data-poi-title="{{ poi|poi_translation_title:language }}" data-poi-id="{{ poi.id }}" data-poi-address="{{ poi.address }}" data-poi-city="{{ poi.city }}" data-poi-country="{{ poi.country }}">{{ poi|poi_translation_title:language }}</option>
+            <option class="option-existing-poi" data-poi-title="{{ poi|poi_translation_title:current_language }}" data-poi-id="{{ poi.id }}" data-poi-address="{{ poi.address }}" data-poi-city="{{ poi.city }}" data-poi-country="{{ poi.country }}">
+                {{ poi|poi_translation_title:current_language }}
+            </option>
         {% endfor %}
     </select>
 {% endif %}

--- a/src/cms/templates/events/event_form.html
+++ b/src/cms/templates/events/event_form.html
@@ -260,26 +260,17 @@
                         </div>
 
                         <label class="mt-4 mb-2 block font-bold uppercase text-sm">{% trans 'Address' %}</label>
-                        <input class="appearance-none block w-full bg-gray-200 text-gray-600 border border-gray-200 rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400"
-                               type="text" placeholder="{% trans 'Name of event location' %}">
+                        {% trans 'Name of event location' as poi_title_placeholder %}
+                        {% render_field poi_translation_form.title|add_error_class:"border-red-500" placeholder=poi_title_placeholder class="appearance-none block w-full bg-grey-lighter text-grey-darker border border-grey-lighter rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
                         <small class="text-sm italic block mb-2">
                             {% trans 'Create an event location or start typing the name of an existing location' %}.
                         </small>
-                        <input class="appearance-none block w-full bg-gray-200 text-gray-600 border border-gray-200 rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400"
-                               type="text" placeholder="{% trans 'Street' %}">
-                        <input class="appearance-none block w-full bg-gray-200 text-gray-600 border border-gray-200 rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400"
-                               type="text" placeholder="{% trans 'City' %}">
-                        <div class="relative my-2">
-                            <select class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400">
-                                <option>{% trans 'Germany' %}</option>
-                            </select>
-                            <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
-                                <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg"
-                                     viewBox="0 0 20 20">
-                                    <path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/>
-                                </svg>
-                            </div>
-                        </div>
+                        {% trans 'Street' as street_placeholder %}
+                        {% render_field poi_form.address|add_error_class:"border-red-500" placeholder=street_placeholder class="appearance-none block w-full bg-grey-lighter text-grey-darker border border-grey-lighter rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
+                        {% trans 'City' as city_placeholder %}
+                        {% render_field poi_form.city|add_error_class:"border-red-500" placeholder=city_placeholder class="appearance-none block w-full bg-grey-lighter text-grey-darker border border-grey-lighter rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
+                        {% trans 'Country' as country_placeholder %}
+                        {% render_field poi_form.country|add_error_class:"border-red-500" placeholder=country_placeholder class="appearance-none block w-full bg-grey-lighter text-grey-darker border border-grey-lighter rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
 
                         <label class="mt-4 mb-2 block font-bold uppercase text-sm">{% trans 'Map' %}</label>
                         <i class="text-teal-500">Google Map vs. OSM</i>

--- a/src/cms/templates/events/event_form.html
+++ b/src/cms/templates/events/event_form.html
@@ -4,6 +4,7 @@
 {% load static %}
 {% load widget_tweaks %}
 {% load content_filters %}
+{% load poi_filters %}
 {% load rules %}
 {% load compress %}
 
@@ -34,6 +35,9 @@
 {% block content %}
 <form method="post">
     {% csrf_token %}
+    {% get_current_language as LANGUAGE_CODE %}
+    {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
+    {% get_language LANGUAGE_CODE as current_language %}
     <div class="flex flex-wrap">
         <div class="w-4/5 flex flex-wrap flex-col justify-center mb-6">
             <h2 class="heading font-normal">
@@ -42,8 +46,6 @@
                         {% with event_translation_form.instance.title as event_title %}
                         {% blocktrans %}Edit event "{{ event_title }}"{% endblocktrans %}
                         {% endwith %}
-                        {% get_current_language as LANGUAGE_CODE %}
-                        {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
                         {% if LANGUAGE_CODE != language.code %}
                             {% get_translation event_form.instance LANGUAGE_CODE as backend_translation %}
                             {% if backend_translation %}
@@ -254,28 +256,30 @@
                             </div>
                         </div>
                         <h3 class="font-bold my-3">{% trans 'Where' %}</h3>
-                        <div class="checkbox-wrap relative my-2 pl-5" style="padding-top:2px;padding-bottom:2px;">
-                            <input class="leading-tight block absolute" style="top:5px;left:0;" type="checkbox" id="ignore-end">
-                            <label for="ignore-end">{% trans 'This event does not have a physical location' %}</label>
-                        </div>
 
                         <label class="mt-4 mb-2 block font-bold uppercase text-sm">{% trans 'Address' %}</label>
                         {% trans 'Name of event location' as poi_title_placeholder %}
-                        {% get_current_language as LANGUAGE_CODE %}
-                        {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
-                        <input id="poi-query-input" type="search" autocomplete="off" class="appearance-none block w-full bg-white text-gray-800 placeholder-gray-800 border border-gray-400 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:placeholder-gray-600" placeholder="{% if poi_translation_form.title.value %}{{ poi_translation_form.title.value }}{% else %}{{ poi_title_placeholder }}{% endif %}" data-url="{% url 'search_poi_ajax' %}" data-region-slug="{{ region.slug }}" data-language-code="{{ LANGUAGE_CODE }}">
+                        <div class="relative my-2">
+                            <input id="poi-query-input" type="search" autocomplete="off" class="pr-8 appearance-none block w-full bg-white text-gray-800 placeholder-gray-800 border border-gray-400 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:placeholder-gray-600" placeholder="{% if poi %}{{ poi|poi_translation_title:current_language }}{% else %}{{ poi_title_placeholder }}{% endif %}" data-url="{% url 'search_poi_ajax' %}" data-event-id="{{ event_form.instance.id }}" data-region-slug="{{ region.slug }}" data-language-code="{{ LANGUAGE_CODE }}" data-default-placeholder="{{ poi_title_placeholder }}">
+                            <div class="absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
+                                <button id="poi-remove" title="{% trans 'Remove location from event' %}">
+                                    <i data-feather="trash-2" class="h-5 w-5"></i>
+                                </button>
+                            </div>
+                        </div>
                         <div class="relative" id="poi-query-result">
                             {% include 'events/_poi_query_result.html' %}
                         </div>
                         <small class="text-sm italic block mt-2 mb-2">
                             {% trans 'Create an event location or start typing the name of an existing location' %}.
                         </small>
+                        <input name="poi_id" id="poi-id" class="hidden" value="{% if poi %}{{ poi.id }}{% else %}-1{% endif %}" readonly>
                         {% trans 'Street' as street_placeholder %}
-                        <div class="appearance-none block w-full bg-white text-gray-800 border border-gray-400 rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey">{% if poi_form.address.value %}{{ poi_form.address.value }}{% else %}{{ street_placeholder }}{% endif %}</div>
+                        <input id="poi-address" disabled class="appearance-none block w-full bg-white text-gray-800 border border-gray-400 rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" placeholder="{{ street_placeholder }}" value="{% if poi %}{{ poi.address }}{% endif %}" />
                         {% trans 'City' as city_placeholder %}
-                        <div class="appearance-none block w-full bg-white text-gray-800 border border-gray-400 rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey">{% if poi_form.city.value %}{{ poi_form.city.value }}{% else %}{{ city_placeholder }}{% endif %}</div>
+                        <input id="poi-city" disabled class="appearance-none block w-full bg-white text-gray-800 border border-gray-400 rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" placeholder="{{ city_placeholder }}" value="{% if poi %}{{ poi.city }}{% endif %}" />
                         {% trans 'Country' as country_placeholder %}
-                        <div class="appearance-none block w-full bg-white text-gray-800 border border-gray-400 rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey">{% if poi_form.country.value %}{{ poi_form.country.value }}{% else %}{{ country_placeholder }}{% endif %}</div>
+                        <input id="poi-country" disabled class="appearance-none block w-full bg-white text-gray-800 border border-gray-400 rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" placeholder="{{ country_placeholder }}" value="{% if poi %}{{ poi.country }}{% endif %}" />
 
                         <label class="mt-4 mb-2 block font-bold uppercase text-sm">{% trans 'Map' %}</label>
                         <i class="text-teal-500">Google Map vs. OSM</i>

--- a/src/cms/templates/events/event_form.html
+++ b/src/cms/templates/events/event_form.html
@@ -261,16 +261,21 @@
 
                         <label class="mt-4 mb-2 block font-bold uppercase text-sm">{% trans 'Address' %}</label>
                         {% trans 'Name of event location' as poi_title_placeholder %}
-                        {% render_field poi_translation_form.title|add_error_class:"border-red-500" placeholder=poi_title_placeholder class="appearance-none block w-full bg-grey-lighter text-grey-darker border border-grey-lighter rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
-                        <small class="text-sm italic block mb-2">
+                        {% get_current_language as LANGUAGE_CODE %}
+                        {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
+                        <input id="poi-query-input" type="search" autocomplete="off" class="appearance-none block w-full bg-white text-gray-800 placeholder-gray-800 border border-gray-400 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:placeholder-gray-600" placeholder="{% if poi_translation_form.title.value %}{{ poi_translation_form.title.value }}{% else %}{{ poi_title_placeholder }}{% endif %}" data-url="{% url 'search_poi_ajax' %}" data-region-slug="{{ region.slug }}" data-language-code="{{ LANGUAGE_CODE }}">
+                        <div class="relative" id="poi-query-result">
+                            {% include 'events/_poi_query_result.html' %}
+                        </div>
+                        <small class="text-sm italic block mt-2 mb-2">
                             {% trans 'Create an event location or start typing the name of an existing location' %}.
                         </small>
                         {% trans 'Street' as street_placeholder %}
-                        {% render_field poi_form.address|add_error_class:"border-red-500" placeholder=street_placeholder class="appearance-none block w-full bg-grey-lighter text-grey-darker border border-grey-lighter rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
+                        <div class="appearance-none block w-full bg-white text-gray-800 border border-gray-400 rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey">{% if poi_form.address.value %}{{ poi_form.address.value }}{% else %}{{ street_placeholder }}{% endif %}</div>
                         {% trans 'City' as city_placeholder %}
-                        {% render_field poi_form.city|add_error_class:"border-red-500" placeholder=city_placeholder class="appearance-none block w-full bg-grey-lighter text-grey-darker border border-grey-lighter rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
+                        <div class="appearance-none block w-full bg-white text-gray-800 border border-gray-400 rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey">{% if poi_form.city.value %}{{ poi_form.city.value }}{% else %}{{ city_placeholder }}{% endif %}</div>
                         {% trans 'Country' as country_placeholder %}
-                        {% render_field poi_form.country|add_error_class:"border-red-500" placeholder=country_placeholder class="appearance-none block w-full bg-grey-lighter text-grey-darker border border-grey-lighter rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey" %}
+                        <div class="appearance-none block w-full bg-white text-gray-800 border border-gray-400 rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-grey">{% if poi_form.country.value %}{{ poi_form.country.value }}{% else %}{{ country_placeholder }}{% endif %}</div>
 
                         <label class="mt-4 mb-2 block font-bold uppercase text-sm">{% trans 'Map' %}</label>
                         <i class="text-teal-500">Google Map vs. OSM</i>
@@ -390,89 +395,91 @@
     </script>
 {% endblock %}
 {% block javascript_nocompress %}
-<script>
-{% get_current_language as LANGUAGE_CODE %}
-document.addEventListener('DOMContentLoaded', function(){
-    tinymce.init({
-        selector: '.tinymce_textarea',
-        menubar: "edit view insert format icon",
-        menu: {
-            icon: { title: "Icons", items: "pinicon wwwicon callicon clockicon aticon ideaicon"},
-            format: { title: 'Format', items: 'bold italic underline strikethrough superscript | formats | forecolor backcolor | removeformat' }
-        },
-        plugins: "code paste fullscreen autosave link preview media image lists directionality",
-        toolbar: 'bold italic underline forecolor | bullist numlist | styleselect | undo redo | ltr rtl notranslate removeformat | aligncenter indent outdent | link image',
-        min_height: 400,
-        content_css : '{% static "css/tinymce_custom.css" %}',
-        language: '{{LANGUAGE_CODE|slice:"0:2"}}',
-        setup: (editor) => {
-            editor.ui.registry.addButton('notranslate', 
-            {
-                tooltip: '{% trans 'Do not translate the selected text.' %}',
-                icon: 'permanent-pen',
-                    onAction: () => {
-                    editor.focus();
-                    val = tinymce.activeEditor.dom.getAttrib(tinyMCE.activeEditor.selection.getNode(), "translate", "yes");
-                    if(val == "no") {
-                        tinymce.activeEditor.dom.setAttrib(tinyMCE.activeEditor.selection.getNode(), "translate", null);
-                    } else if (editor.selection.getContent().length > 0) {
-                        editor.selection.setContent('<span class="notranslate" translate="no">' + editor.selection.getContent() + '</span>');
-                    }
-                }
-            });
-            editor.ui.registry.addIcon('pin_icon', '<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">		<path d="M256,0C161.896,0,85.333,76.563,85.333,170.667c0,28.25,7.063,56.26,20.49,81.104L246.667,506.5			c1.875,3.396,5.448,5.5,9.333,5.5s7.458-2.104,9.333-5.5l140.896-254.813c13.375-24.76,20.438-52.771,20.438-81.021			C426.667,76.563,350.104,0,256,0z M256,256c-47.052,0-85.333-38.281-85.333-85.333c0-47.052,38.281-85.333,85.333-85.333			s85.333,38.281,85.333,85.333C341.333,217.719,303.052,256,256,256z"/></svg>');
-            editor.ui.registry.addIcon('www_icon','<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 viewBox="0 0 26 26" style="enable-background:new 0 0 26 26;" xml:space="preserve">	<path style="fill:#030104;" d="M8.083,11.222L6.419,15c-0.041,0.094-0.144,0.154-0.257,0.154H5.31		c-0.113,0-0.216-0.061-0.256-0.154l-0.79-1.803c-0.077-0.178-0.147-0.348-0.213-0.517c-0.073,0.186-0.148,0.359-0.223,0.525		l-0.833,1.8c-0.042,0.091-0.144,0.149-0.255,0.149H1.888c-0.117,0-0.219-0.063-0.259-0.158l-1.557-3.779		c-0.03-0.074-0.018-0.156,0.034-0.221s0.135-0.103,0.225-0.103H1.29c0.121,0,0.227,0.069,0.263,0.169l0.684,1.92		c0.057,0.162,0.11,0.315,0.159,0.461c0.06-0.146,0.125-0.3,0.194-0.463l0.842-1.932c0.041-0.093,0.143-0.155,0.256-0.155H4.48		c0.115,0,0.217,0.063,0.258,0.157l0.798,1.89c0.072,0.17,0.136,0.329,0.195,0.479c0.049-0.142,0.106-0.296,0.171-0.465l0.737-1.898		c0.038-0.098,0.143-0.164,0.26-0.164h0.926c0.091,0,0.175,0.039,0.227,0.104C8.105,11.064,8.115,11.147,8.083,11.222z		 M17.005,11.222L15.341,15c-0.041,0.094-0.144,0.154-0.256,0.154h-0.854c-0.113,0-0.215-0.061-0.256-0.154l-0.789-1.803		c-0.078-0.178-0.148-0.348-0.214-0.517c-0.073,0.186-0.148,0.359-0.223,0.525l-0.833,1.8c-0.042,0.091-0.143,0.149-0.255,0.149		h-0.853c-0.116,0-0.219-0.063-0.259-0.158l-1.557-3.779c-0.03-0.074-0.018-0.156,0.034-0.221c0.052-0.064,0.136-0.103,0.225-0.103		h0.959c0.121,0,0.227,0.069,0.263,0.169l0.683,1.92c0.057,0.162,0.11,0.315,0.161,0.461c0.059-0.146,0.123-0.3,0.192-0.463		l0.843-1.932c0.04-0.093,0.142-0.155,0.256-0.155H13.4c0.115,0,0.218,0.063,0.258,0.157l0.799,1.89		c0.071,0.17,0.135,0.329,0.193,0.479c0.051-0.142,0.106-0.296,0.172-0.465l0.737-1.898c0.038-0.098,0.144-0.164,0.261-0.164h0.926		c0.092,0,0.177,0.039,0.227,0.104C17.026,11.064,17.038,11.147,17.005,11.222z M25.926,11.222L24.263,15		c-0.042,0.094-0.144,0.154-0.257,0.154h-0.853c-0.113,0-0.216-0.061-0.256-0.154l-0.789-1.803		c-0.078-0.178-0.148-0.348-0.214-0.517c-0.073,0.186-0.149,0.359-0.224,0.525l-0.833,1.8c-0.042,0.091-0.144,0.149-0.255,0.149		H19.73c-0.117,0-0.22-0.063-0.26-0.158l-1.557-3.779c-0.029-0.074-0.019-0.156,0.033-0.221s0.136-0.103,0.226-0.103h0.96		c0.121,0,0.227,0.069,0.262,0.169l0.684,1.92c0.057,0.162,0.11,0.315,0.16,0.461c0.059-0.146,0.123-0.3,0.192-0.463l0.843-1.932		c0.041-0.093,0.143-0.155,0.257-0.155h0.791c0.115,0,0.218,0.063,0.258,0.157l0.798,1.89c0.072,0.17,0.137,0.329,0.196,0.479		c0.049-0.142,0.106-0.296,0.171-0.465l0.738-1.898c0.037-0.098,0.142-0.164,0.26-0.164h0.926c0.092,0,0.176,0.039,0.227,0.104		C25.946,11.064,25.958,11.147,25.926,11.222z"/>		<path style="fill:#030104;" d="M2.71,9c0.283-0.718,0.637-1.401,1.057-2.037C3.829,6.975,3.887,7,3.952,7h1.88			c-0.199,0.634-0.355,1.309-0.49,2h2.055c0.155-0.699,0.335-1.376,0.562-2h9.986c0.227,0.624,0.407,1.301,0.562,2h2.055			c-0.135-0.691-0.291-1.366-0.49-2h1.88c0.065,0,0.123-0.025,0.186-0.037C22.556,7.599,22.911,8.282,23.194,9h2.121			c-1.691-5.216-6.591-9-12.363-9S2.28,3.784,0.588,9H2.71z M20.478,5H19.29c-0.258-0.543-0.542-1.05-0.851-1.519			C19.179,3.909,19.861,4.419,20.478,5z M12.952,2c1.551,0,2.983,1.154,4.062,3H8.89C9.969,3.154,11.401,2,12.952,2z M7.463,3.481			C7.155,3.95,6.871,4.457,6.613,5H5.426C6.043,4.419,6.725,3.909,7.463,3.481z"/>		<path style="fill:#030104;" d="M23.194,17c-0.283,0.719-0.638,1.4-1.057,2.037C22.075,19.025,22.017,19,21.952,19h-1.881			c0.199-0.634,0.355-1.309,0.49-2h-2.055c-0.154,0.699-0.335,1.377-0.562,2H7.959c-0.227-0.623-0.407-1.301-0.562-2H5.343			c0.135,0.691,0.291,1.366,0.49,2H3.952c-0.065,0-0.123,0.025-0.185,0.037C3.348,18.4,2.993,17.719,2.71,17H0.588			c1.692,5.216,6.592,9,12.364,9s10.672-3.784,12.363-9H23.194z M5.426,21h1.188c0.258,0.543,0.542,1.051,0.85,1.519			C6.725,22.091,6.043,21.581,5.426,21z M12.952,24c-1.551,0-2.983-1.154-4.062-3h8.123C15.935,22.846,14.503,24,12.952,24z			 M18.44,22.519c0.309-0.468,0.593-0.976,0.851-1.519h1.188C19.861,21.581,19.179,22.091,18.44,22.519z"/></svg>');
-            editor.ui.registry.addIcon('call_icon', '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 width="16" height="16" viewBox="0 0 348.077 348.077" style="enable-background:new 0 0 348.077 348.077;"	 xml:space="preserve">			<path d="M340.273,275.083l-53.755-53.761c-10.707-10.664-28.438-10.34-39.518,0.744l-27.082,27.076				c-1.711-0.943-3.482-1.928-5.344-2.973c-17.102-9.476-40.509-22.464-65.14-47.113c-24.704-24.701-37.704-48.144-47.209-65.257				c-1.003-1.813-1.964-3.561-2.913-5.221l18.176-18.149l8.936-8.947c11.097-11.1,11.403-28.826,0.721-39.521L73.39,8.194				C62.708-2.486,44.969-2.162,33.872,8.938l-15.15,15.237l0.414,0.411c-5.08,6.482-9.325,13.958-12.484,22.02				C3.74,54.28,1.927,61.603,1.098,68.941C-6,127.785,20.89,181.564,93.866,254.541c100.875,100.868,182.167,93.248,185.674,92.876				c7.638-0.913,14.958-2.738,22.397-5.627c7.992-3.122,15.463-7.361,21.941-12.43l0.331,0.294l15.348-15.029				C350.631,303.527,350.95,285.795,340.273,275.083z"/></svg>');
-            editor.ui.registry.addIcon('clock_icon', '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 width="16" height="16" viewBox="0 0 468.067 468.067" style="enable-background:new 0 0 468.067 468.067;"	 xml:space="preserve">	<path d="M431.38,0.225H36.685C16.458,0.225,0,16.674,0,36.898v394.268c0,20.221,16.458,36.677,36.685,36.677H431.38		c20.232,0,36.688-16.456,36.688-36.677V36.898C468.062,16.668,451.606,0.225,431.38,0.225z M406.519,41.969		c8.678,0,15.711,7.04,15.711,15.72c0,8.683-7.033,15.717-15.711,15.717c-8.688,0-15.723-7.04-15.723-15.717		C390.796,49.009,397.83,41.969,406.519,41.969z M350.189,41.969c8.688,0,15.723,7.04,15.723,15.72		c0,8.683-7.034,15.717-15.723,15.717c-8.684,0-15.711-7.04-15.711-15.717C334.479,49.009,341.513,41.969,350.189,41.969z		 M426.143,425.924H41.919V112.429h384.224V425.924z M234.031,385.902c66.212,0,120.095-53.871,120.095-120.096		c0-66.221-53.883-120.095-120.095-120.095c-66.215,0-120.095,53.874-120.095,120.095		C113.936,332.031,167.815,385.902,234.031,385.902z M234.031,169.923c52.866,0,95.884,43.016,95.884,95.884		c0,52.866-43.019,95.885-95.884,95.885c-52.869,0-95.884-43.019-95.884-95.885C138.146,212.938,181.162,169.923,234.031,169.923z		 M221.926,265.807v-60.526c0-6.682,5.423-12.105,12.105-12.105s12.105,5.423,12.105,12.105v48.42h49.935		c6.679,0,12.105,5.427,12.105,12.105c0,6.68-5.427,12.105-12.105,12.105h-62.04C227.349,277.912,221.926,272.486,221.926,265.807z"		/></svg>');
-            editor.ui.registry.addIcon('email_icon', '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 viewBox="0 0 490.2 490.2" style="enable-background:new 0 0 490.2 490.2;" xml:space="preserve"><g>	<path d="M420.95,61.8C376.25,20.6,320.65,0,254.25,0c-69.8,0-129.3,23.4-178.4,70.3s-73.7,105.2-73.7,175		c0,66.9,23.4,124.4,70.1,172.6c46.9,48.2,109.9,72.3,189.2,72.3c47.8,0,94.7-9.8,140.7-29.5c15-6.4,22.3-23.6,16.2-38.7l0,0		c-6.3-15.6-24.1-22.8-39.6-16.2c-40,17.2-79.2,25.8-117.4,25.8c-60.8,0-107.9-18.5-141.3-55.6c-33.3-37-50-80.5-50-130.4		c0-54.2,17.9-99.4,53.6-135.7c35.6-36.2,79.5-54.4,131.5-54.4c47.9,0,88.4,14.9,121.4,44.7s49.5,67.3,49.5,112.5		c0,30.9-7.6,56.7-22.7,77.2c-15.1,20.6-30.8,30.8-47.1,30.8c-8.8,0-13.2-4.7-13.2-14.2c0-7.7,0.6-16.7,1.7-27.1l18.6-152.1h-64		l-4.1,14.9c-16.3-13.3-34.2-20-53.6-20c-30.8,0-57.2,12.3-79.1,36.8c-22,24.5-32.9,56.1-32.9,94.7c0,37.7,9.7,68.2,29.2,91.3		c19.5,23.2,42.9,34.7,70.3,34.7c24.5,0,45.4-10.3,62.8-30.8c13.1,19.7,32.4,29.5,57.9,29.5c37.5,0,69.9-16.3,97.2-49		c27.3-32.6,41-72,41-118.1C488.05,152.9,465.75,103,420.95,61.8z M273.55,291.9c-11.3,15.2-24.8,22.9-40.5,22.9		c-10.7,0-19.3-5.6-25.8-16.8c-6.6-11.2-9.9-25.1-9.9-41.8c0-20.6,4.6-37.2,13.8-49.8s20.6-19,34.2-19c11.8,0,22.3,4.7,31.5,14.2		s13.8,22.1,13.8,37.9C290.55,259.2,284.85,276.6,273.55,291.9z"/></g></svg>');
-            editor.ui.registry.addIcon('idea_icon', '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16"><path fill="#444444" d="M11.7 1.9c-1-1.2-2.6-1.9-4.2-1.9s-3.2 0.7-4.2 1.9c-1 1.1-1.4 2.6-1.2 4 0.2 1.5 0.8 2.6 2.1 3.7 0.5 0.4 0.7 0.8 0.9 1.2 0 0.1 0.1 0.2 0.1 0.3-0.1 0.1-0.2 0.2-0.2 0.4 0 0.3 0.2 0.5 0.5 0.5-0.3 0-0.5 0.2-0.5 0.5s0.2 0.5 0.5 0.5c-0.3 0-0.5 0.2-0.5 0.5s0.2 0.5 0.5 0.5c-0.3 0-0.5 0.2-0.5 0.5s0.2 0.5 0.5 0.5h0.5c0 0.5 0.7 1 1.5 1s1.5-0.5 1.5-1h0.5c0.3 0 0.5-0.2 0.5-0.5s-0.2-0.5-0.5-0.5c0.3 0 0.5-0.2 0.5-0.5s-0.2-0.5-0.5-0.5c0.3 0 0.5-0.2 0.5-0.5s-0.2-0.5-0.5-0.5c0.3 0 0.5-0.2 0.5-0.5 0-0.2-0.1-0.3-0.2-0.4 0-0.1 0.1-0.1 0.1-0.2 0.2-0.4 0.4-0.8 0.9-1.2 1.3-1.1 1.9-2.2 2.1-3.8 0.2-1.4-0.2-2.8-1.2-4zM12 5.8c-0.2 1.3-0.7 2.2-1.8 3.2-0.6 0.5-0.9 1-1.2 1.4-0.2 0.5-0.3 0.6-0.5 0.6h-2c-0.2 0-0.3-0.1-0.5-0.6-0.2-0.4-0.5-1-1.1-1.6-1.3-1.1-1.6-2-1.8-3-0.2-1.1 0.2-2.3 0.9-3.2 0.9-1 2.2-1.6 3.5-1.6s2.6 0.6 3.5 1.6c0.7 0.9 1.1 2.1 1 3.2z"></path><path fill="#444444" d="M11 5h-1c0-0.7-0.8-2-2-2v-1c1.8 0 3 1.8 3 3z"></path></svg>');
-            editor.ui.registry.addMenuItem('pinicon', {
-                text: '{% trans 'Location' %}',
-                icon: 'pin_icon',
-                onAction: function () {
-                    editor.insertContent('<img src="{% static "svg/pin.svg" %}" style="width:1.5em">');
-                }
-            });
-            editor.ui.registry.addMenuItem('wwwicon', {
-                text: '{% trans 'Link' %}',
-                icon: 'www_icon',
-                onAction: function () {
-                    editor.insertContent('<img src="{% static "svg/world-wide-web.svg" %}" style="width:1.5em">');
-                }
-            });
-            editor.ui.registry.addMenuItem('callicon', {
-                text: '{% trans 'Phone' %}',
-                icon: 'call_icon',
-                onAction: function () {
-                    editor.insertContent('<img src="{% static "svg/call.svg" %}" style="width:1.5em">');
-                }
-            });
-            editor.ui.registry.addMenuItem('clockicon', {
-                text: '{% trans 'Opening Hours' %}',
-                icon: 'clock_icon',
-                onAction: function () {
-                    editor.insertContent('<img src="{% static "svg/clock.svg" %}" style="width:1.5em">');
-                }
-            });
-            editor.ui.registry.addMenuItem('aticon', {
-                text: '{% trans 'Email' %}',
-                icon: 'email_icon',
-                onAction: function () {
-                    editor.insertContent('<img src="{% static "svg/at.svg" %}" style="width:1.5em">');
-                }
-            });
-            editor.ui.registry.addMenuItem('ideaicon', {
-                text: '{% trans 'Hint' %}',
-                icon: 'idea_icon',
-                onAction: function () {
-                    editor.insertContent('<img src="{% static "svg/idea.svg" %}" style="width:1.5em">');
-                }
-            });
-        }{% has_perm 'cms.edit_events' request.user as can_edit_event %}{% if not can_edit_event or event_form.instance.id and event_form.instance.archived %},
+    {# TODO: move script to compressable part above when code is stable #}
+    <script src="{% static 'js/event.js' %}"></script>
+    <script>
+        {% get_current_language as LANGUAGE_CODE %}
+        document.addEventListener('DOMContentLoaded', function(){
+            tinymce.init({
+                selector: '.tinymce_textarea',
+                menubar: "edit view insert format icon",
+                menu: {
+                    icon: { title: "Icons", items: "pinicon wwwicon callicon clockicon aticon ideaicon"},
+                    format: { title: 'Format', items: 'bold italic underline strikethrough superscript | formats | forecolor backcolor | removeformat' }
+                },
+                plugins: "code paste fullscreen autosave link preview media image lists directionality",
+                toolbar: 'bold italic underline forecolor | bullist numlist | styleselect | undo redo | ltr rtl notranslate removeformat | aligncenter indent outdent | link image',
+                min_height: 400,
+                content_css : '{% static "css/tinymce_custom.css" %}',
+                language: '{{LANGUAGE_CODE|slice:"0:2"}}',
+                setup: (editor) => {
+                    editor.ui.registry.addButton('notranslate',
+                    {
+                        tooltip: '{% trans 'Do not translate the selected text.' %}',
+                        icon: 'permanent-pen',
+                            onAction: () => {
+                            editor.focus();
+                            val = tinymce.activeEditor.dom.getAttrib(tinyMCE.activeEditor.selection.getNode(), "translate", "yes");
+                            if(val == "no") {
+                                tinymce.activeEditor.dom.setAttrib(tinyMCE.activeEditor.selection.getNode(), "translate", null);
+                            } else if (editor.selection.getContent().length > 0) {
+                                editor.selection.setContent('<span class="notranslate" translate="no">' + editor.selection.getContent() + '</span>');
+                            }
+                        }
+                    });
+                    editor.ui.registry.addIcon('pin_icon', '<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">		<path d="M256,0C161.896,0,85.333,76.563,85.333,170.667c0,28.25,7.063,56.26,20.49,81.104L246.667,506.5			c1.875,3.396,5.448,5.5,9.333,5.5s7.458-2.104,9.333-5.5l140.896-254.813c13.375-24.76,20.438-52.771,20.438-81.021			C426.667,76.563,350.104,0,256,0z M256,256c-47.052,0-85.333-38.281-85.333-85.333c0-47.052,38.281-85.333,85.333-85.333			s85.333,38.281,85.333,85.333C341.333,217.719,303.052,256,256,256z"/></svg>');
+                    editor.ui.registry.addIcon('www_icon','<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 viewBox="0 0 26 26" style="enable-background:new 0 0 26 26;" xml:space="preserve">	<path style="fill:#030104;" d="M8.083,11.222L6.419,15c-0.041,0.094-0.144,0.154-0.257,0.154H5.31		c-0.113,0-0.216-0.061-0.256-0.154l-0.79-1.803c-0.077-0.178-0.147-0.348-0.213-0.517c-0.073,0.186-0.148,0.359-0.223,0.525		l-0.833,1.8c-0.042,0.091-0.144,0.149-0.255,0.149H1.888c-0.117,0-0.219-0.063-0.259-0.158l-1.557-3.779		c-0.03-0.074-0.018-0.156,0.034-0.221s0.135-0.103,0.225-0.103H1.29c0.121,0,0.227,0.069,0.263,0.169l0.684,1.92		c0.057,0.162,0.11,0.315,0.159,0.461c0.06-0.146,0.125-0.3,0.194-0.463l0.842-1.932c0.041-0.093,0.143-0.155,0.256-0.155H4.48		c0.115,0,0.217,0.063,0.258,0.157l0.798,1.89c0.072,0.17,0.136,0.329,0.195,0.479c0.049-0.142,0.106-0.296,0.171-0.465l0.737-1.898		c0.038-0.098,0.143-0.164,0.26-0.164h0.926c0.091,0,0.175,0.039,0.227,0.104C8.105,11.064,8.115,11.147,8.083,11.222z		 M17.005,11.222L15.341,15c-0.041,0.094-0.144,0.154-0.256,0.154h-0.854c-0.113,0-0.215-0.061-0.256-0.154l-0.789-1.803		c-0.078-0.178-0.148-0.348-0.214-0.517c-0.073,0.186-0.148,0.359-0.223,0.525l-0.833,1.8c-0.042,0.091-0.143,0.149-0.255,0.149		h-0.853c-0.116,0-0.219-0.063-0.259-0.158l-1.557-3.779c-0.03-0.074-0.018-0.156,0.034-0.221c0.052-0.064,0.136-0.103,0.225-0.103		h0.959c0.121,0,0.227,0.069,0.263,0.169l0.683,1.92c0.057,0.162,0.11,0.315,0.161,0.461c0.059-0.146,0.123-0.3,0.192-0.463		l0.843-1.932c0.04-0.093,0.142-0.155,0.256-0.155H13.4c0.115,0,0.218,0.063,0.258,0.157l0.799,1.89		c0.071,0.17,0.135,0.329,0.193,0.479c0.051-0.142,0.106-0.296,0.172-0.465l0.737-1.898c0.038-0.098,0.144-0.164,0.261-0.164h0.926		c0.092,0,0.177,0.039,0.227,0.104C17.026,11.064,17.038,11.147,17.005,11.222z M25.926,11.222L24.263,15		c-0.042,0.094-0.144,0.154-0.257,0.154h-0.853c-0.113,0-0.216-0.061-0.256-0.154l-0.789-1.803		c-0.078-0.178-0.148-0.348-0.214-0.517c-0.073,0.186-0.149,0.359-0.224,0.525l-0.833,1.8c-0.042,0.091-0.144,0.149-0.255,0.149		H19.73c-0.117,0-0.22-0.063-0.26-0.158l-1.557-3.779c-0.029-0.074-0.019-0.156,0.033-0.221s0.136-0.103,0.226-0.103h0.96		c0.121,0,0.227,0.069,0.262,0.169l0.684,1.92c0.057,0.162,0.11,0.315,0.16,0.461c0.059-0.146,0.123-0.3,0.192-0.463l0.843-1.932		c0.041-0.093,0.143-0.155,0.257-0.155h0.791c0.115,0,0.218,0.063,0.258,0.157l0.798,1.89c0.072,0.17,0.137,0.329,0.196,0.479		c0.049-0.142,0.106-0.296,0.171-0.465l0.738-1.898c0.037-0.098,0.142-0.164,0.26-0.164h0.926c0.092,0,0.176,0.039,0.227,0.104		C25.946,11.064,25.958,11.147,25.926,11.222z"/>		<path style="fill:#030104;" d="M2.71,9c0.283-0.718,0.637-1.401,1.057-2.037C3.829,6.975,3.887,7,3.952,7h1.88			c-0.199,0.634-0.355,1.309-0.49,2h2.055c0.155-0.699,0.335-1.376,0.562-2h9.986c0.227,0.624,0.407,1.301,0.562,2h2.055			c-0.135-0.691-0.291-1.366-0.49-2h1.88c0.065,0,0.123-0.025,0.186-0.037C22.556,7.599,22.911,8.282,23.194,9h2.121			c-1.691-5.216-6.591-9-12.363-9S2.28,3.784,0.588,9H2.71z M20.478,5H19.29c-0.258-0.543-0.542-1.05-0.851-1.519			C19.179,3.909,19.861,4.419,20.478,5z M12.952,2c1.551,0,2.983,1.154,4.062,3H8.89C9.969,3.154,11.401,2,12.952,2z M7.463,3.481			C7.155,3.95,6.871,4.457,6.613,5H5.426C6.043,4.419,6.725,3.909,7.463,3.481z"/>		<path style="fill:#030104;" d="M23.194,17c-0.283,0.719-0.638,1.4-1.057,2.037C22.075,19.025,22.017,19,21.952,19h-1.881			c0.199-0.634,0.355-1.309,0.49-2h-2.055c-0.154,0.699-0.335,1.377-0.562,2H7.959c-0.227-0.623-0.407-1.301-0.562-2H5.343			c0.135,0.691,0.291,1.366,0.49,2H3.952c-0.065,0-0.123,0.025-0.185,0.037C3.348,18.4,2.993,17.719,2.71,17H0.588			c1.692,5.216,6.592,9,12.364,9s10.672-3.784,12.363-9H23.194z M5.426,21h1.188c0.258,0.543,0.542,1.051,0.85,1.519			C6.725,22.091,6.043,21.581,5.426,21z M12.952,24c-1.551,0-2.983-1.154-4.062-3h8.123C15.935,22.846,14.503,24,12.952,24z			 M18.44,22.519c0.309-0.468,0.593-0.976,0.851-1.519h1.188C19.861,21.581,19.179,22.091,18.44,22.519z"/></svg>');
+                    editor.ui.registry.addIcon('call_icon', '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 width="16" height="16" viewBox="0 0 348.077 348.077" style="enable-background:new 0 0 348.077 348.077;"	 xml:space="preserve">			<path d="M340.273,275.083l-53.755-53.761c-10.707-10.664-28.438-10.34-39.518,0.744l-27.082,27.076				c-1.711-0.943-3.482-1.928-5.344-2.973c-17.102-9.476-40.509-22.464-65.14-47.113c-24.704-24.701-37.704-48.144-47.209-65.257				c-1.003-1.813-1.964-3.561-2.913-5.221l18.176-18.149l8.936-8.947c11.097-11.1,11.403-28.826,0.721-39.521L73.39,8.194				C62.708-2.486,44.969-2.162,33.872,8.938l-15.15,15.237l0.414,0.411c-5.08,6.482-9.325,13.958-12.484,22.02				C3.74,54.28,1.927,61.603,1.098,68.941C-6,127.785,20.89,181.564,93.866,254.541c100.875,100.868,182.167,93.248,185.674,92.876				c7.638-0.913,14.958-2.738,22.397-5.627c7.992-3.122,15.463-7.361,21.941-12.43l0.331,0.294l15.348-15.029				C350.631,303.527,350.95,285.795,340.273,275.083z"/></svg>');
+                    editor.ui.registry.addIcon('clock_icon', '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 width="16" height="16" viewBox="0 0 468.067 468.067" style="enable-background:new 0 0 468.067 468.067;"	 xml:space="preserve">	<path d="M431.38,0.225H36.685C16.458,0.225,0,16.674,0,36.898v394.268c0,20.221,16.458,36.677,36.685,36.677H431.38		c20.232,0,36.688-16.456,36.688-36.677V36.898C468.062,16.668,451.606,0.225,431.38,0.225z M406.519,41.969		c8.678,0,15.711,7.04,15.711,15.72c0,8.683-7.033,15.717-15.711,15.717c-8.688,0-15.723-7.04-15.723-15.717		C390.796,49.009,397.83,41.969,406.519,41.969z M350.189,41.969c8.688,0,15.723,7.04,15.723,15.72		c0,8.683-7.034,15.717-15.723,15.717c-8.684,0-15.711-7.04-15.711-15.717C334.479,49.009,341.513,41.969,350.189,41.969z		 M426.143,425.924H41.919V112.429h384.224V425.924z M234.031,385.902c66.212,0,120.095-53.871,120.095-120.096		c0-66.221-53.883-120.095-120.095-120.095c-66.215,0-120.095,53.874-120.095,120.095		C113.936,332.031,167.815,385.902,234.031,385.902z M234.031,169.923c52.866,0,95.884,43.016,95.884,95.884		c0,52.866-43.019,95.885-95.884,95.885c-52.869,0-95.884-43.019-95.884-95.885C138.146,212.938,181.162,169.923,234.031,169.923z		 M221.926,265.807v-60.526c0-6.682,5.423-12.105,12.105-12.105s12.105,5.423,12.105,12.105v48.42h49.935		c6.679,0,12.105,5.427,12.105,12.105c0,6.68-5.427,12.105-12.105,12.105h-62.04C227.349,277.912,221.926,272.486,221.926,265.807z"		/></svg>');
+                    editor.ui.registry.addIcon('email_icon', '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 viewBox="0 0 490.2 490.2" style="enable-background:new 0 0 490.2 490.2;" xml:space="preserve"><g>	<path d="M420.95,61.8C376.25,20.6,320.65,0,254.25,0c-69.8,0-129.3,23.4-178.4,70.3s-73.7,105.2-73.7,175		c0,66.9,23.4,124.4,70.1,172.6c46.9,48.2,109.9,72.3,189.2,72.3c47.8,0,94.7-9.8,140.7-29.5c15-6.4,22.3-23.6,16.2-38.7l0,0		c-6.3-15.6-24.1-22.8-39.6-16.2c-40,17.2-79.2,25.8-117.4,25.8c-60.8,0-107.9-18.5-141.3-55.6c-33.3-37-50-80.5-50-130.4		c0-54.2,17.9-99.4,53.6-135.7c35.6-36.2,79.5-54.4,131.5-54.4c47.9,0,88.4,14.9,121.4,44.7s49.5,67.3,49.5,112.5		c0,30.9-7.6,56.7-22.7,77.2c-15.1,20.6-30.8,30.8-47.1,30.8c-8.8,0-13.2-4.7-13.2-14.2c0-7.7,0.6-16.7,1.7-27.1l18.6-152.1h-64		l-4.1,14.9c-16.3-13.3-34.2-20-53.6-20c-30.8,0-57.2,12.3-79.1,36.8c-22,24.5-32.9,56.1-32.9,94.7c0,37.7,9.7,68.2,29.2,91.3		c19.5,23.2,42.9,34.7,70.3,34.7c24.5,0,45.4-10.3,62.8-30.8c13.1,19.7,32.4,29.5,57.9,29.5c37.5,0,69.9-16.3,97.2-49		c27.3-32.6,41-72,41-118.1C488.05,152.9,465.75,103,420.95,61.8z M273.55,291.9c-11.3,15.2-24.8,22.9-40.5,22.9		c-10.7,0-19.3-5.6-25.8-16.8c-6.6-11.2-9.9-25.1-9.9-41.8c0-20.6,4.6-37.2,13.8-49.8s20.6-19,34.2-19c11.8,0,22.3,4.7,31.5,14.2		s13.8,22.1,13.8,37.9C290.55,259.2,284.85,276.6,273.55,291.9z"/></g></svg>');
+                    editor.ui.registry.addIcon('idea_icon', '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16"><path fill="#444444" d="M11.7 1.9c-1-1.2-2.6-1.9-4.2-1.9s-3.2 0.7-4.2 1.9c-1 1.1-1.4 2.6-1.2 4 0.2 1.5 0.8 2.6 2.1 3.7 0.5 0.4 0.7 0.8 0.9 1.2 0 0.1 0.1 0.2 0.1 0.3-0.1 0.1-0.2 0.2-0.2 0.4 0 0.3 0.2 0.5 0.5 0.5-0.3 0-0.5 0.2-0.5 0.5s0.2 0.5 0.5 0.5c-0.3 0-0.5 0.2-0.5 0.5s0.2 0.5 0.5 0.5c-0.3 0-0.5 0.2-0.5 0.5s0.2 0.5 0.5 0.5h0.5c0 0.5 0.7 1 1.5 1s1.5-0.5 1.5-1h0.5c0.3 0 0.5-0.2 0.5-0.5s-0.2-0.5-0.5-0.5c0.3 0 0.5-0.2 0.5-0.5s-0.2-0.5-0.5-0.5c0.3 0 0.5-0.2 0.5-0.5s-0.2-0.5-0.5-0.5c0.3 0 0.5-0.2 0.5-0.5 0-0.2-0.1-0.3-0.2-0.4 0-0.1 0.1-0.1 0.1-0.2 0.2-0.4 0.4-0.8 0.9-1.2 1.3-1.1 1.9-2.2 2.1-3.8 0.2-1.4-0.2-2.8-1.2-4zM12 5.8c-0.2 1.3-0.7 2.2-1.8 3.2-0.6 0.5-0.9 1-1.2 1.4-0.2 0.5-0.3 0.6-0.5 0.6h-2c-0.2 0-0.3-0.1-0.5-0.6-0.2-0.4-0.5-1-1.1-1.6-1.3-1.1-1.6-2-1.8-3-0.2-1.1 0.2-2.3 0.9-3.2 0.9-1 2.2-1.6 3.5-1.6s2.6 0.6 3.5 1.6c0.7 0.9 1.1 2.1 1 3.2z"></path><path fill="#444444" d="M11 5h-1c0-0.7-0.8-2-2-2v-1c1.8 0 3 1.8 3 3z"></path></svg>');
+                    editor.ui.registry.addMenuItem('pinicon', {
+                        text: '{% trans 'Location' %}',
+                        icon: 'pin_icon',
+                        onAction: function () {
+                            editor.insertContent('<img src="{% static "svg/pin.svg" %}" style="width:1.5em">');
+                        }
+                    });
+                    editor.ui.registry.addMenuItem('wwwicon', {
+                        text: '{% trans 'Link' %}',
+                        icon: 'www_icon',
+                        onAction: function () {
+                            editor.insertContent('<img src="{% static "svg/world-wide-web.svg" %}" style="width:1.5em">');
+                        }
+                    });
+                    editor.ui.registry.addMenuItem('callicon', {
+                        text: '{% trans 'Phone' %}',
+                        icon: 'call_icon',
+                        onAction: function () {
+                            editor.insertContent('<img src="{% static "svg/call.svg" %}" style="width:1.5em">');
+                        }
+                    });
+                    editor.ui.registry.addMenuItem('clockicon', {
+                        text: '{% trans 'Opening Hours' %}',
+                        icon: 'clock_icon',
+                        onAction: function () {
+                            editor.insertContent('<img src="{% static "svg/clock.svg" %}" style="width:1.5em">');
+                        }
+                    });
+                    editor.ui.registry.addMenuItem('aticon', {
+                        text: '{% trans 'Email' %}',
+                        icon: 'email_icon',
+                        onAction: function () {
+                            editor.insertContent('<img src="{% static "svg/at.svg" %}" style="width:1.5em">');
+                        }
+                    });
+                    editor.ui.registry.addMenuItem('ideaicon', {
+                        text: '{% trans 'Hint' %}',
+                        icon: 'idea_icon',
+                        onAction: function () {
+                            editor.insertContent('<img src="{% static "svg/idea.svg" %}" style="width:1.5em">');
+                        }
+                    });
+                }{% has_perm 'cms.edit_events' request.user as can_edit_event %}{% if not can_edit_event or event_form.instance.id and event_form.instance.archived %},
             readonly : 1{% endif %}
-    });
+            });
 
-    custom_file_field();
-}, false);
-</script>
+            custom_file_field();
+        }, false);
+    </script>
 {% endblock %}

--- a/src/cms/templates/events/event_form.html
+++ b/src/cms/templates/events/event_form.html
@@ -260,9 +260,9 @@
                         <label class="mt-4 mb-2 block font-bold uppercase text-sm">{% trans 'Address' %}</label>
                         {% trans 'Name of event location' as poi_title_placeholder %}
                         <div class="relative my-2">
-                            <input id="poi-query-input" type="search" autocomplete="off" class="pr-8 appearance-none block w-full bg-white text-gray-800 placeholder-gray-800 border border-gray-400 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:placeholder-gray-600" placeholder="{% if poi %}{{ poi|poi_translation_title:current_language }}{% else %}{{ poi_title_placeholder }}{% endif %}" data-url="{% url 'search_poi_ajax' %}" data-event-id="{{ event_form.instance.id }}" data-region-slug="{{ region.slug }}" data-language-code="{{ LANGUAGE_CODE }}" data-default-placeholder="{{ poi_title_placeholder }}">
+                            <input id="poi-query-input" type="search" autocomplete="off" class="pr-8 appearance-none block w-full bg-white text-gray-800 placeholder-gray-800 border border-gray-400 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:placeholder-gray-600"{% if event_form.disabled %} disabled{% endif %} placeholder="{% if poi %}{{ poi|poi_translation_title:current_language }}{% else %}{{ poi_title_placeholder }}{% endif %}" data-url="{% url 'search_poi_ajax' %}" data-region-slug="{{ region.slug }}" data-default-placeholder="{{ poi_title_placeholder }}">
                             <div class="absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
-                                <button id="poi-remove" title="{% trans 'Remove location from event' %}">
+                                <button id="poi-remove" title="{% trans 'Remove location from event' %}"{% if event_form.disabled %} disabled{% endif %}>
                                     <i data-feather="trash-2" class="h-5 w-5"></i>
                                 </button>
                             </div>
@@ -399,8 +399,9 @@
     </script>
 {% endblock %}
 {% block javascript_nocompress %}
-    {# TODO: move script to compressable part above when code is stable #}
-    <script src="{% static 'js/event.js' %}"></script>
+    {% if not event_form.disabled %}
+        <script src="{% static 'js/event.js' %}"></script>
+    {% endif %}
     <script>
         {% get_current_language as LANGUAGE_CODE %}
         document.addEventListener('DOMContentLoaded', function(){

--- a/src/cms/templates/events/event_list_archived_row.html
+++ b/src/cms/templates/events/event_list_archived_row.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% load rules %}
 {% load content_filters %}
+{% load poi_filters %}
 
 <tr class="border-t border-solid border-gray-200 hover:bg-gray-100">
     <td class="px-2 min">
@@ -71,8 +72,8 @@
     </td>
     <td>
         {% if event.location is not None %}
-            <!-- TODO: filter location for title in correct language, e.g. event.location|poi_translation_title:language -->
-            {{ event.location|title }}
+            {% get_language LANGUAGE_CODE as current_language %}
+            {{ event.location|poi_translation_title:current_language }}
         {% else %}
             {% trans 'Not specified' %}
         {% endif %}

--- a/src/cms/templates/events/event_list_row.html
+++ b/src/cms/templates/events/event_list_row.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% load rules %}
 {% load content_filters %}
+{% load poi_filters %}
 
 <tr class="border-t border-solid border-gray-200 hover:bg-gray-100">
     <td style="padding-left: 10px">
@@ -71,8 +72,8 @@
     </td>
     <td>
         {% if event.location is not None %}
-            <!-- TODO: filter location for title in correct language, e.g. event.location|poi_translation_title:language -->
-            {{ event.location|title }}
+            {% get_language LANGUAGE_CODE as current_language %}
+            {{ event.location|poi_translation_title:current_language }}
         {% else %}
             {% trans 'Not specified' %}
         {% endif %}

--- a/src/cms/templatetags/content_filters.py
+++ b/src/cms/templatetags/content_filters.py
@@ -17,6 +17,9 @@ def get_translation(instance, language_code):
 def translated_language_name(language_code):
     return Language.objects.get(code=language_code).translated_name
 
+@register.simple_tag
+def get_language(language_code):
+    return Language.objects.get(code=language_code)
 
 # Unify the language codes of backend and content languages
 @register.simple_tag

--- a/src/cms/urls.py
+++ b/src/cms/urls.py
@@ -184,7 +184,11 @@ urlpatterns = [
             pages.save_mirrored_page,
             name='save_mirrored_page'
         ),
-
+        url(
+            r'^search_poi$',
+            events.search_poi_ajax,
+            name='search_poi_ajax'
+        ),
     ])),
 
     url(r'^(?P<region_slug>[-\w]+)/', include([

--- a/src/cms/views/events/__init__.py
+++ b/src/cms/views/events/__init__.py
@@ -3,5 +3,6 @@ from .event_list_view import EventListView
 from .event_actions import (
     archive,
     restore,
-    delete
+    delete,
+    search_poi_ajax
 )

--- a/src/cms/views/events/event_actions.py
+++ b/src/cms/views/events/event_actions.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext as _
 
 from ...constants import status
 from ...decorators import region_permission_required, staff_required
-from ...models import Event, Region, Language, POITranslation
+from ...models import Event, Region, POITranslation
 
 logger = logging.getLogger(__name__)
 
@@ -74,8 +74,6 @@ def search_poi_ajax(request):
     data = json.loads(request.body.decode('utf-8'))
     poi_query = data.get('query_string')
     region_slug = data.get('region_slug')
-    language_code = data.get('language_code')
-    event_id = data.get('event_id')
 
     logger.info('Ajax call: Live search for POIs with query "%s"', poi_query)
 
@@ -96,6 +94,5 @@ def search_poi_ajax(request):
     return render(request, 'events/_poi_query_result.html', {
         'poi_query': poi_query,
         'poi_query_result': poi_query_result,
-        'event_id': event_id,
-        'language': Language.objects.get(code=language_code)
+        'region': region
     })

--- a/src/cms/views/events/event_actions.py
+++ b/src/cms/views/events/event_actions.py
@@ -1,11 +1,18 @@
+import json
+import logging
+
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
-from django.shortcuts import redirect
+from django.db.models import Subquery, OuterRef
+from django.shortcuts import render, redirect
 from django.utils.translation import ugettext as _
 
+from ...constants import status
 from ...decorators import region_permission_required, staff_required
-from ...models import Event
+from ...models import Event, Region, POITranslation
+
+logger = logging.getLogger(__name__)
 
 
 @login_required
@@ -49,7 +56,6 @@ def restore(request, event_id, region_slug, language_code):
 @login_required
 @staff_required
 def delete(request, event_id, region_slug, language_code):
-
     event = Event.objects.get(id=event_id)
     if event.recurrence_rule:
         event.recurrence_rule.delete()
@@ -59,4 +65,33 @@ def delete(request, event_id, region_slug, language_code):
     return redirect('events', **{
         'region_slug': region_slug,
         'language_code': language_code,
+    })
+
+
+@login_required
+@region_permission_required
+def search_poi_ajax(request):
+    data = json.loads(request.body.decode('utf-8'))
+    poi_query = data.get('query_string')
+    region_slug = data.get('region_slug')
+
+    logger.info('Ajax call: Live search for POIs with query "%s"', poi_query)
+
+    region = Region.objects.get(slug=region_slug)
+
+    # All latest revisions of a POI (one for each language)
+    latest_public_poi_revisions = POITranslation.objects.filter(
+        poi=OuterRef('pk'),
+        status=status.PUBLIC
+    ).order_by('language', '-version').distinct('language').values('id')
+    # All POIs which are not archived and have a latest public revision which contains the query
+    poi_query_result = region.pois.prefetch_related('translations').filter(
+        archived=False,
+        translations__in=Subquery(latest_public_poi_revisions),
+        translations__title__icontains=poi_query
+    ).distinct()
+
+    return render(request, 'events/_poi_query_result.html', {
+        'poi_query': poi_query,
+        'poi_query_result': poi_query_result
     })

--- a/src/cms/views/events/event_actions.py
+++ b/src/cms/views/events/event_actions.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext as _
 
 from ...constants import status
 from ...decorators import region_permission_required, staff_required
-from ...models import Event, Region, POITranslation
+from ...models import Event, Region, Language, POITranslation
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +74,8 @@ def search_poi_ajax(request):
     data = json.loads(request.body.decode('utf-8'))
     poi_query = data.get('query_string')
     region_slug = data.get('region_slug')
+    language_code = data.get('language_code')
+    event_id = data.get('event_id')
 
     logger.info('Ajax call: Live search for POIs with query "%s"', poi_query)
 
@@ -93,5 +95,7 @@ def search_poi_ajax(request):
 
     return render(request, 'events/_poi_query_result.html', {
         'poi_query': poi_query,
-        'poi_query_result': poi_query_result
+        'poi_query_result': poi_query_result,
+        'event_id': event_id,
+        'language': Language.objects.get(code=language_code)
     })


### PR DESCRIPTION
With this PR:
* The location of an event is shown in the event list (non-archived as well as archived).
* If an event has a location, the location is also shown in the event form.
* Inside an event form, a location for an event can be searched (implemented with AJAX calls).
* From the search results, either an existing POI can be selected or a new POI can be created.

Fixes #247