### PR TITLE
Configure pylint for whole project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,9 +55,7 @@ jobs:
           at: .
       - run:
           name: Run pylint
-          command: |
-            cd src
-            pipenv run pylint_runner
+          command: pipenv run pylint_runner
   tests:
     docker:
       - image: circleci/python:3.7

--- a/.pylintrc
+++ b/.pylintrc
@@ -7,7 +7,7 @@ extension-pkg-whitelist=
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=migrations
+ignore=.venv,node_modules,migrations
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.
@@ -19,7 +19,7 @@ ignore-patterns=
 
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
 # number of processors available to use.
-jobs=2
+jobs=8
 
 # Control the amount of potential inferred values when inferring a single
 # object. This can help the performance when dealing with large functions or

--- a/dev-tools/pylint.sh
+++ b/dev-tools/pylint.sh
@@ -2,7 +2,7 @@
 
 # This script can be used to run the pylint_runner while ignoring migrations.
 
-cd $(dirname "$BASH_SOURCE")/../src
+cd $(dirname "$BASH_SOURCE")/..
 
 # Run pylint
 pipenv run pylint_runner

--- a/setup.py
+++ b/setup.py
@@ -19,14 +19,14 @@ setup(
     include_package_data=True,
     scripts=['src/integreat-cms-cli'],
     data_files=[
-                   ('lib/integreat-{}'.format(root), [os.path.join(root, f) for f in files])
-                   for root, _, files in os.walk('src/cms/templates/')
-               ] + [
-                   ('lib/integreat-{}'.format(root), [os.path.join(root, f) for f in files])
-                   for root, _, files in os.walk('src/cms/static/')
-               ] + [
-                   ('usr/lib/systemd/system/', ['systemd/integreat-cms@.service'])
-               ],
+        ('lib/integreat-{}'.format(root), [os.path.join(root, f) for f in files])
+        for root, _, files in os.walk('src/cms/templates/')
+    ] + [
+        ('lib/integreat-{}'.format(root), [os.path.join(root, f) for f in files])
+        for root, _, files in os.walk('src/cms/static/')
+    ] + [
+        ('usr/lib/systemd/system/', ['systemd/integreat-cms@.service'])
+    ],
     install_requires=[
         'beautifulsoup4',
         'cffi',


### PR DESCRIPTION
- Move `.pylintrc` from `src`-directory to top level
- Ignore `.venv` and `node_modules` in `.pylintrc`
- Fix indendation error in `setup.py`