### PR TITLE
Prevent the creation of region users without an assigned region

### DIFF
--- a/src/cms/forms/users/region_user_form.py
+++ b/src/cms/forms/users/region_user_form.py
@@ -22,3 +22,17 @@ class RegionUserForm(UserForm):
             'email',
             'is_active'
         ]
+
+    def __init__(self, data=None, instance=None):
+
+        logger.info('RegionUserForm instantiated with data %s and instance %s', data, instance)
+
+        # Instantiate ModelForm
+        super(RegionUserForm, self).__init__(data=data, instance=instance)
+
+    def save(self, *args, **kwargs):
+
+        logger.info('RegionUserForm saved with cleaned data %s and changed data %s', self.cleaned_data, self.changed_data)
+
+        # save ModelForm
+        return super(RegionUserForm, self).save(*args, **kwargs)

--- a/src/cms/forms/users/region_user_profile_form.py
+++ b/src/cms/forms/users/region_user_profile_form.py
@@ -17,7 +17,16 @@ class RegionUserProfileForm(UserProfileForm):
         model = UserProfile
         fields = ['organization']
 
+    def __init__(self, data=None, instance=None):
+
+        logger.info('RegionUserProfileForm instantiated with data %s and instance %s', data, instance)
+
+        # Instantiate ModelForm
+        super(RegionUserProfileForm, self).__init__(data=data, instance=instance)
+
     def save(self, *args, **kwargs):
+
+        logger.info('RegionUserProfileForm saved with cleaned data %s and changed data %s', self.cleaned_data, self.changed_data)
 
         # pop kwarg to make sure the super class does not get this param
         region = kwargs.pop('region', None)

--- a/src/cms/forms/users/user_form.py
+++ b/src/cms/forms/users/user_form.py
@@ -29,16 +29,12 @@ class UserForm(forms.ModelForm):
         fields = ['username', 'first_name', 'last_name', 'email',
                   'is_staff', 'is_active', 'is_superuser']
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, data=None, instance=None):
 
-        logger.info(
-            'New UserForm instantiated with args %s and kwargs %s',
-            args,
-            kwargs
-        )
+        logger.info('UserForm instantiated with data %s and instance %s', data, instance)
 
         # instantiate ModelForm
-        super(UserForm, self).__init__(*args, **kwargs)
+        super(UserForm, self).__init__(data=data, instance=instance)
 
         # check if user instance already exists
         if self.instance.id:
@@ -50,11 +46,7 @@ class UserForm(forms.ModelForm):
     # pylint: disable=arguments-differ
     def save(self, *args, **kwargs):
 
-        logger.info(
-            'UserForm saved with args %s and kwargs %s',
-            args,
-            kwargs
-        )
+        logger.info('UserForm saved with cleaned data %s and changed data %s', self.cleaned_data, self.changed_data)
 
         # save ModelForm
         user = super(UserForm, self).save(*args, **kwargs)

--- a/src/cms/forms/users/user_profile_form.py
+++ b/src/cms/forms/users/user_profile_form.py
@@ -20,8 +20,17 @@ class UserProfileForm(forms.ModelForm):
             'organization'
         ]
 
+    def __init__(self, data=None, instance=None):
+
+        logger.info('UserProfileForm instantiated with data %s and instance %s', data, instance)
+
+        # Instantiate ModelForm
+        super(UserProfileForm, self).__init__(data=data, instance=instance)
+
     # pylint: disable=arguments-differ
     def save(self, *args, **kwargs):
+
+        logger.info('UserProfileForm saved with cleaned data %s and changed data %s', self.cleaned_data, self.changed_data)
 
         logger.info(
             'UserProfileForm saved with args %s and kwargs %s',

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-09 16:20+0000\n"
+"POT-Creation-Date: 2020-05-23 10:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -2415,7 +2415,7 @@ msgstr ""
 #: views/regions/region_view.py:67 views/settings/user_settings_view.py:54
 #: views/settings/user_settings_view.py:74 views/users/region_user_view.py:84
 #: views/users/user_actions.py:90 views/users/user_list_view.py:90
-#: views/users/user_view.py:90
+#: views/users/user_view.py:92
 msgid "No changes detected."
 msgstr "Keine Änderungen vorgenommen."
 
@@ -2459,7 +2459,7 @@ msgstr "Sprach-Baum wurde erfolgreich erstellt."
 #: views/push_notifications/push_notification_view.py:126
 #: views/regions/region_view.py:56 views/roles/role_view.py:49
 #: views/users/region_user_view.py:87 views/users/user_actions.py:93
-#: views/users/user_list_view.py:93 views/users/user_view.py:93
+#: views/users/user_list_view.py:93 views/users/user_view.py:97
 msgid "Errors have occurred."
 msgstr "Es sind Fehler aufgetreten."
 
@@ -2737,19 +2737,27 @@ msgstr ""
 "Ihre Einstellungen."
 
 #: views/users/region_user_actions.py:19 views/users/user_actions.py:108
-#: views/users/user_list_view.py:108 views/users/user_view.py:108
+#: views/users/user_list_view.py:108 views/users/user_view.py:112
 msgid "User was successfully deleted."
 msgstr "Benutzer wurde erfolgreich gelöscht."
 
 #: views/users/region_user_view.py:73 views/users/user_actions.py:83
-#: views/users/user_list_view.py:83 views/users/user_view.py:83
+#: views/users/user_list_view.py:83 views/users/user_view.py:85
 msgid "User was successfully saved."
 msgstr "Benutzer wurde erfolgreich gespeichert."
 
 #: views/users/region_user_view.py:75 views/users/user_actions.py:85
-#: views/users/user_list_view.py:85 views/users/user_view.py:85
+#: views/users/user_list_view.py:85 views/users/user_view.py:87
 msgid "User was successfully created."
 msgstr "Benutzer wurde erfolgreich erstellt."
+
+#: views/users/user_view.py:94
+msgid ""
+"A user has to be either staff/superuser or needs to be restricted to at "
+"least one region."
+msgstr ""
+"Ein Benutzer muss entweder Mitarbeiter/Super-Administrator sein, oder "
+"mindestens einer Region zugewiesen sein."
 
 #~ msgid "This event does not have a physical location"
 #~ msgstr "Diese Veranstaltung hat keinen Veranstaltungsort"


### PR DESCRIPTION
- Add some extended logging for user forms
- Add check to make sure a user is either staff/superuser or is assigned to at least one region

Fixes: #393