### PR TITLE
Add pipenv installation hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Following packages are required for running the project (Install them with your 
 * npm
 * python3.7
 * python3-pip
-* python3-pipenv
+* pipenv for python3 (If no recent version is packaged for your distro, use `pip3 install pipenv --user`)
 * python3.7-dev (only on Ubuntu)
 * postgresql *OR* docker
 * GNU gettext tools (to make use of the internationalization feature)

--- a/dev-tools/install.sh
+++ b/dev-tools/install.sh
@@ -17,7 +17,9 @@ if [ ! -x "$(command -v pip3)" ]; then
     exit 1
 fi
 if [ ! -x "$(command -v pipenv)" ]; then
-    echo "Pipenv for Python3 is not installed. Please install python3-pipenv manually and run this script again." >&2
+    echo "Pipenv for Python3 is not installed. Please install it manually and run this script again." >&2
+    echo "The recommended way of installing pipenv is 'pip3 install pipenv --user'." >&2
+    echo "If you use this method, you might have to add 'export PATH=\$PATH:~/.local/bin' to your default shell config (e.g. '~/.bashrc' or '~/.zshrc')." >&2
     exit 1
 fi
 if [ ! -x "$(command -v npm)" ]; then


### PR DESCRIPTION
On some distros (like e.g. Ubuntu 20.04), there is no recent version of pipenv available. Instead of installing an old packaged version, it is better to install the most recent version via pip directly. As it is generally considered bad practice to install packages with pip globally, and it seems a bit esoteric to create a virtualenv in which we install pipenv which creates another virtualenv, I think it's best to install it into `~/.local/bin` with the `--user`-flag.