### PR TITLE
Improve sphinx documentation config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ jobs:
           command: |
             cd $TMP_DIR
             git add --all
-            git commit -m "Update documentation of commit ${CIRCLE_SHA1}" || true
+            git commit -m "Update documentation of commit ${CIRCLE_SHA1} [skip ci]" || true
             git push origin $BRANCH
 
 workflows:

--- a/dev-tools/generate_documentation.sh
+++ b/dev-tools/generate_documentation.sh
@@ -46,9 +46,14 @@ find sphinx -type f -name "*.rst" | xargs sed -i \
     -e 's/Cms/CMS/g;s/Api/API/g;s/Poi/POI/g;s/Mfa/MFA/g' # Make specific keywords uppercase
 
 # Compile .rst files to html documentation
-pipenv run sphinx-build -E sphinx docs
+pipenv run sphinx-build -j auto sphinx docs
 
 # Move german translation file to original file again
 if [[ -f "${TRANSLATION_FILE}.lock" ]]; then
     mv "${TRANSLATION_FILE}.lock" "${TRANSLATION_FILE}"
 fi
+
+# Remove temporary intermediate build files
+rm -r docs/.doctrees
+rm -r docs/_sources
+rm docs/.buildinfo

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -68,6 +68,7 @@ intersphinx_mapping = {
     'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
     'django': ('https://docs.djangoproject.com/en/2.2/',
                'https://docs.djangoproject.com/en/2.2/_objects/'),
+    'django-mptt': ('https://django-mptt.readthedocs.io/en/latest/', None),
 }
 
 # The path for patched template files
@@ -94,44 +95,88 @@ html_show_sourcelink = False
 # -- Modify default Django model parameter types------------------------------
 
 
-# pylint: disable=unused-argument
+# pylint: disable=unused-argument, too-many-locals, too-many-branches
 def process_django_models(app, what, name, obj, options, lines):
     """Append correct param types from fields to model documentation."""
     if inspect.isclass(obj) and issubclass(obj, django.db.models.Model):
         # Intersphinx mapping to django.contrib.postgres documentation does not work, so here the manual link
-        postgres_docu = 'https://docs.djangoproject.com/en/2.2/ref/contrib/postgres/fields/'
-        for field in obj._meta.fields:
-            field_type = type(field)
-            module = field_type.__module__
-            # Fix intersphinx mappings for django.contrib.postgres fields
-            if module == 'django.contrib.postgres.fields.array':
-                lines.append(
-                    ':type {}: `{}.ArrayField <{}#arrayfield>`_'.format(
-                        field.attname,
-                        module,
-                        postgres_docu
-                    )
+        postgres_docu = intersphinx_mapping.get('django')[1][0] + 'ref/contrib/postgres/fields/'
+        # include_hidden to get also ManyToManyFields
+        for field in obj._meta.get_fields(include_hidden=True):
+            field_type = type(field).__name__
+            field_module = type(field).__module__
+            if field_module == 'django.contrib.postgres.fields.array':
+                # Fix intersphinx mappings for django.contrib.postgres fields
+                type_line = ':type {}: `{}.ArrayField <{}#arrayfield>`_'.format(
+                    field.name,
+                    field_module,
+                    postgres_docu
                 )
-                continue
-            if module == 'django.contrib.postgres.fields.jsonb':
-                lines.append(
-                    ':type {}: `{}.JSONField <{}#jsonfield>`_'.format(
-                        field.attname,
-                        module,
-                        postgres_docu
-                    )
+            elif field_module == 'django.contrib.postgres.fields.jsonb':
+                # Fix intersphinx mappings for django.contrib.postgres fields
+                type_line = ':type {}: `{}.JSONField <{}#jsonfield>`_'.format(
+                    field.name,
+                    field_module,
+                    postgres_docu
                 )
-                continue
-            if 'django.db.models' in module:
-                # scope with django.db.models * imports
-                module = 'django.db.models'
-            lines.append(
-                ':type {}: {}.{}'.format(
-                    field.attname,
-                    module,
-                    field_type.__name__
+            elif field_module in ['django.db.models.fields.related', 'mptt.fields']:
+                # Fix intersphinx mappings for related fields (ForeignKey, OneToOneField, ManyToManyField, ...)
+                # Also includes related MPTT fields (TreeForeignKey, TreeOneToOneField, TreeManyToManyField, ...)
+                remote_model = field.remote_field.get_related_field().model
+                type_line = ':type {}: {} to :class:`~{}.{}`'.format(
+                    field.name,
+                    field_type,
+                    remote_model.__module__,
+                    remote_model.__name__
                 )
-            )
+            elif field_module == 'django.db.models.fields.reverse_related':
+                # Fix intersphinx mappings for reverse related fields (ManyToOneRel, OneToOneRel, ManyToManyRel, ...)
+                remote_model = field.remote_field.model
+                type_line = ':type {}: Reverse {} Relation from :class:`~{}.{}`'.format(
+                    field.name,
+                    field_type[:-3],
+                    remote_model.__module__,
+                    remote_model.__name__
+                )
+            else:
+                if 'django.db.models' in field_module:
+                    # Scope with django.db.models * imports (remove all sub-module-paths)
+                    field_module = 'django.db.models'
+                # Fix type hint to enable correct intersphinx mappings to other documentations
+                type_line = ':type {}: {}.{}'.format(
+                    field.name,
+                    field_module,
+                    field_type
+                )
+            # This loop gets the indexes which are needed to update the type hints of the model parameters.
+            # It makes it possible to split the parameter section into multiple parts, e.g. params inherited from a base
+            # model and params of a sub model (otherwise the type hints would not be recognized when separated from
+            # the parameter description).
+            param_index = None
+            next_param_index = None
+            type_index = None
+            for index, line in enumerate(lines):
+                if param_index is None and ':param {}:'.format(field.name) in line:
+                    # The index of the field param is only used to determine the next param line
+                    param_index = index
+                elif param_index is not None and next_param_index is None and (':param ' in line or line == ''):
+                    # The line of the next param after the field, this is the index where we will insert the type.
+                    # Sometimes the param descriptions extend over multiple lines, so we cannot just do param_index + 1.
+                    # If the line is empty, the param description is finished, even if it extends over multiple lines.
+                    next_param_index = index
+                elif type_index is None and ':type {}:'.format(field.name) in line:
+                    # The index of the old type hint, we will either move this line or replace it
+                    type_index = index
+                    break
+            if next_param_index is None:
+                # In case the current field is the last param, we just append the type at the very end of lines
+                next_param_index = len(lines)
+            # For some params, the type line is not automatically generated and thus the type_index might be `None`
+            if type_index is not None:
+                # We delete the old type index, because we will replace it with the new type line
+                del lines[type_index]
+            # Insert the new type line just before the next param
+            lines.insert(next_param_index, type_line)
     return lines
 
 


### PR DESCRIPTION
This PR adds improvements to our automatic sphinx documentation build:

- Add support for multiple sections of parameters (this makes model docstring more readable by e.g. separating normal fields from related fields and reverse relations)
- Improve appearance of related fields in model docstrings
- Remove temporary build files to reduce noise in the automatic updates on gh-pages
- Run sphinx-build in multiple threads
- Skip CircleCI build for automated documentation commits on gh-pages