### PR TITLE
Fix CircleCI build times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
           root: .
           paths:
             - .venv
+            - src/integreat_cms.egg-info
   npm-install:
     docker:
         - image: circleci/node:lts
@@ -70,9 +71,6 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Install integreat-cms
-          command: pipenv install '-e .[dev]'
-      - run:
           name: Migrate database
           command: |
             pipenv run integreat-cms-cli makemigrations cms
@@ -90,9 +88,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run:
-          name: Install integreat-cms
-          command: pipenv install '-e .[dev]'
       - run:
           name: Compile CSS
           command: npx lessc -clean-css src/cms/static/css/style.less src/cms/static/css/style.min.css


### PR DESCRIPTION
Sometimes, the CircleCI build takes nearly 10 minutes instead of ~3mins.
I think this is due to the jobs "tests" and "build-static-files" which install the cms again after all dependencies have been installed in "pipenv-install" already. This install command does not use the already installed package versions of Pipfile.lock, but updates them which additionally creates the problem that our builds no not reproduce our local environments.

This PR removes the separate install command and passes `src/integreat_cms.egg-info` instead, which fixes the problem that the command `integreat-cms-cli` was not found.

Fixes: #401