### PR TITLE
Check translations in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
           root: .
           paths:
             - .venv
+            - src/integreat_cms.egg-info
   npm-install:
     docker:
         - image: circleci/node:lts
@@ -70,9 +71,6 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Install integreat-cms
-          command: pipenv install '-e .[dev]'
-      - run:
           name: Migrate database
           command: |
             pipenv run integreat-cms-cli makemigrations cms
@@ -90,9 +88,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run:
-          name: Install integreat-cms
-          command: pipenv install '-e .[dev]'
       - run:
           name: Compile CSS
           command: npx lessc -clean-css src/cms/static/css/style.less src/cms/static/css/style.min.css

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,17 @@ jobs:
           command: pipenv run integreat-cms-cli test cms --set=COVERAGE
       - store_artifacts:
           path: htmlcov
+  check-translations:
+    docker:
+      - image: timoludwig/python-node-gettext:latest
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Check translation file for missing or empty entries
+          command: ./dev-tools/check_translations.sh
   bundle-static-files:
     docker:
       - image: timoludwig/python-node-gettext:latest
@@ -187,6 +198,9 @@ workflows:
           requires:
             - pipenv-install
       - tests:
+          requires:
+            - pipenv-install
+      - check-translations:
           requires:
             - pipenv-install
       - bundle-static-files:

--- a/dev-tools/check_translations.sh
+++ b/dev-tools/check_translations.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This script can be used to check the translation file for missing or empty entries.
+
+# Check if pcregrep is installed
+if [ ! -x "$(command -v pcregrep)" ]; then
+    echo "PCRE grep is not installed. Please install pcregrep manually and run this script again." >&2
+    exit 1
+fi
+
+# Change directory to make sure to ignore files in the venv
+cd $(dirname "$BASH_SOURCE")/../src/cms
+
+# Re-generating translation file
+pipenv run integreat-cms-cli makemessages -l de > /dev/null
+
+# Check for missing entries
+if ! git diff --shortstat locale/de/LC_MESSAGES/django.po | grep -q "1 file changed, 1 insertion(+), 1 deletion(-)"; then
+    echo "Your translation file is not up to date. Please run ./dev-tools/translate.sh and check if any strings need manual translation." >&2
+    exit 1
+fi
+
+# Check for empty entries
+if pcregrep -Mq 'msgstr ""\n\n' locale/de/LC_MESSAGES/django.po; then
+    echo "You have empty entries in your translation file. Please translate them manually." >&2
+    exit 1
+fi
+
+echo "Your translation file looks good!"

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -796,7 +796,7 @@ msgstr "Status"
 #: templates/events/event_form.html:150 templates/pages/page_form.html:152
 #: templates/pois/poi_form.html:141 templates/regions/region_form.html:53
 msgid "Permalink"
-msgstr ""
+msgstr "Permalink"
 
 #: templates/events/event_form.html:152 templates/pages/page_form.html:154
 #: templates/regions/region_form.html:55
@@ -1021,7 +1021,7 @@ msgstr "Veranstaltung erstellen"
 #: templates/pages/page_tree.html:74 templates/pages/page_tree_archived.html:30
 #: templates/pois/poi_list.html:47 templates/pois/poi_list_archived.html:30
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #: templates/events/event_list.html:64
 #: templates/events/event_list_archived.html:40


### PR DESCRIPTION
This adds a new job in our CircleCI workflow, which checks, whether the translation file has 
- missing entries (e.g. because `integreat-cms-cli makemessages` was forgotten)
- empty entries (e.g. because new added strings were not translated)

Depends on: #400
Fixes: #404