### PR TITLE
Compress JS & CSS only in production mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,11 +73,11 @@ jobs:
       - run:
           name: Migrate database
           command: |
-            pipenv run integreat-cms-cli makemigrations cms
-            pipenv run integreat-cms-cli migrate
+            pipenv run integreat-cms-cli makemigrations cms --settings=backend.circleci_settings
+            pipenv run integreat-cms-cli migrate --settings=backend.circleci_settings
       - run:
           name: Run tests
-          command: pipenv run integreat-cms-cli test cms --set=COVERAGE
+          command: pipenv run integreat-cms-cli test cms --set=COVERAGE --settings=backend.circleci_settings
       - store_artifacts:
           path: htmlcov
   check-translations:
@@ -104,12 +104,12 @@ jobs:
           command: npx lessc -clean-css src/cms/static/css/style.less src/cms/static/css/style.min.css
       - run:
           name: Compress JS & CSS
-          command: pipenv run integreat-cms-cli compress
+          command: pipenv run integreat-cms-cli compress --settings=backend.circleci_settings
       - run:
           name: Compile translation file
           command: |
             cd src/cms
-            pipenv run integreat-cms-cli compilemessages
+            pipenv run integreat-cms-cli compilemessages --settings=backend.circleci_settings
       - persist_to_workspace:
           root: .
           paths:

--- a/dev-tools/run.sh
+++ b/dev-tools/run.sh
@@ -25,9 +25,6 @@ if nc -w1 localhost 5432; then
     # Compile CSS
     npx lessc -clean-css src/cms/static/css/style.less src/cms/static/css/style.min.css
 
-    # Apply Compressing
-    pipenv run integreat-cms-cli compress
-
     # Re-generating translation file and compile it
     ./dev-tools/translate.sh
 
@@ -66,9 +63,6 @@ else
 
     # Compile CSS
     sudo -u $SUDO_USER env PATH="$PATH" npx lessc -clean-css src/cms/static/css/style.less src/cms/static/css/style.min.css
-
-    # Apply Compressing
-    sudo -u $SUDO_USER env PATH="$PATH" pipenv run integreat-cms-cli compress
 
     # Re-generating translation file and compile it
     sudo -u $SUDO_USER env PATH="$PATH" ./dev-tools/translate.sh

--- a/src/backend/circleci_settings.py
+++ b/src/backend/circleci_settings.py
@@ -1,0 +1,5 @@
+# pylint: disable=wildcard-import
+# pylint: disable=unused-wildcard-import
+from .settings import *
+
+COMPRESS_ENABLED = True

--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -234,7 +234,7 @@ COMPRESS_PRECOMPILERS = (
     ('module', 'compressor_toolkit.precompilers.ES6Compiler'),
     ('css', 'compressor_toolkit.precompilers.SCSSCompiler'),
 )
-COMPRESS_ENABLED = True
+COMPRESS_ENABLED = False
 COMPRESS_OFFLINE = True
 
 # GVZ (Gemeindeverzeichnis) API URL


### PR DESCRIPTION
- Add CircleCI settings for Django
- Compress JS & CSS only in production mode

Fixes: #419 
Fixes: #420