### PR TITLE
Fix non-existing language bug

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-19 15:33+0000\n"
+"POT-Creation-Date: 2020-07-15 16:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -19,8 +19,8 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: constants/administrative_division.py:52 templates/events/event_form.html:279
-#: templates/pois/poi_form.html:186 templates/pois/poi_list.html:67
-#: templates/pois/poi_list_archived.html:41
+#: templates/pois/poi_form.html:186 templates/pois/poi_list.html:70
+#: templates/pois/poi_list_archived.html:44
 msgid "City"
 msgstr "Stadt"
 
@@ -491,12 +491,12 @@ msgstr "Aktuelle Übersetzungen"
 
 #: templates/analytics/translation_coverage.html:46
 #: templates/events/event_form.html:92 templates/events/event_form.html:121
-#: templates/events/event_list_archived_row.html:51
-#: templates/events/event_list_row.html:51 templates/pages/page_form.html:94
+#: templates/events/event_list_archived_row.html:54
+#: templates/events/event_list_row.html:54 templates/pages/page_form.html:94
 #: templates/pages/page_form.html:123
-#: templates/pages/page_tree_archived_node.html:56
-#: templates/pages/page_tree_node.html:57 templates/pois/poi_form.html:83
-#: templates/pois/poi_form.html:112 templates/pois/poi_list_row.html:50
+#: templates/pages/page_tree_archived_node.html:59
+#: templates/pages/page_tree_node.html:60 templates/pois/poi_form.html:83
+#: templates/pois/poi_form.html:112 templates/pois/poi_list_row.html:53
 msgid "Currently in translation"
 msgstr "Wird derzeit übersetzt"
 
@@ -719,15 +719,15 @@ msgid "Edit event \"%(event_title)s\""
 msgstr "Event \"%(event_title)s\" bearbeiten"
 
 #: templates/events/event_form.html:52 templates/events/event_list.html:49
-#: templates/events/event_list.html:53
+#: templates/events/event_list.html:55
 #: templates/events/event_list_archived.html:25
-#: templates/events/event_list_archived.html:29
+#: templates/events/event_list_archived.html:31
 #: templates/pages/page_form.html:52 templates/pages/page_tree.html:77
-#: templates/pages/page_tree.html:81 templates/pages/page_tree_archived.html:33
-#: templates/pages/page_tree_archived.html:37 templates/pois/poi_form.html:51
-#: templates/pois/poi_list.html:50 templates/pois/poi_list.html:54
+#: templates/pages/page_tree.html:83 templates/pages/page_tree_archived.html:33
+#: templates/pages/page_tree_archived.html:39 templates/pois/poi_form.html:51
+#: templates/pois/poi_list.html:50 templates/pois/poi_list.html:56
 #: templates/pois/poi_list_archived.html:33
-#: templates/pois/poi_list_archived.html:37
+#: templates/pois/poi_list_archived.html:39
 msgid "Title in"
 msgstr "Titel auf"
 
@@ -754,32 +754,32 @@ msgid "Submit for review"
 msgstr "Zur Überprüfung vorlegen"
 
 #: templates/events/event_form.html:88 templates/events/event_form.html:117
-#: templates/events/event_list_archived_row.html:55
-#: templates/events/event_list_row.html:55 templates/pages/page_form.html:90
+#: templates/events/event_list_archived_row.html:58
+#: templates/events/event_list_row.html:58 templates/pages/page_form.html:90
 #: templates/pages/page_form.html:119
-#: templates/pages/page_tree_archived_node.html:60
-#: templates/pages/page_tree_node.html:61 templates/pois/poi_form.html:79
-#: templates/pois/poi_form.html:108 templates/pois/poi_list_row.html:54
+#: templates/pages/page_tree_archived_node.html:63
+#: templates/pages/page_tree_node.html:64 templates/pois/poi_form.html:79
+#: templates/pois/poi_form.html:108 templates/pois/poi_list_row.html:57
 msgid "Translation outdated"
 msgstr "Übersetzung ist veraltet"
 
 #: templates/events/event_form.html:96 templates/events/event_form.html:125
-#: templates/events/event_list_archived_row.html:59
-#: templates/events/event_list_row.html:59 templates/pages/page_form.html:98
+#: templates/events/event_list_archived_row.html:62
+#: templates/events/event_list_row.html:62 templates/pages/page_form.html:98
 #: templates/pages/page_form.html:127
-#: templates/pages/page_tree_archived_node.html:64
-#: templates/pages/page_tree_node.html:65 templates/pois/poi_form.html:87
-#: templates/pois/poi_form.html:116 templates/pois/poi_list_row.html:58
+#: templates/pages/page_tree_archived_node.html:67
+#: templates/pages/page_tree_node.html:68 templates/pois/poi_form.html:87
+#: templates/pois/poi_form.html:116 templates/pois/poi_list_row.html:61
 msgid "Translation up-to-date"
 msgstr "Übersetzung ist aktuell"
 
 #: templates/events/event_form.html:101 templates/events/event_form.html:130
-#: templates/events/event_list_archived_row.html:64
-#: templates/events/event_list_row.html:64 templates/pages/page_form.html:103
+#: templates/events/event_list_archived_row.html:67
+#: templates/events/event_list_row.html:67 templates/pages/page_form.html:103
 #: templates/pages/page_form.html:132
-#: templates/pages/page_tree_archived_node.html:69
-#: templates/pages/page_tree_node.html:70 templates/pois/poi_form.html:92
-#: templates/pois/poi_form.html:121 templates/pois/poi_list_row.html:63
+#: templates/pages/page_tree_archived_node.html:72
+#: templates/pages/page_tree_node.html:73 templates/pois/poi_form.html:92
+#: templates/pois/poi_form.html:121 templates/pois/poi_list_row.html:66
 msgid "Translation missing"
 msgstr "Übersetzung fehlt"
 
@@ -857,14 +857,14 @@ msgid "Date"
 msgstr "Datum"
 
 #: templates/events/event_form.html:191 templates/events/event_form.html:205
-#: templates/events/event_list.html:65
-#: templates/events/event_list_archived.html:41
+#: templates/events/event_list.html:68
+#: templates/events/event_list_archived.html:44
 msgid "Start"
 msgstr "Beginn"
 
 #: templates/events/event_form.html:195 templates/events/event_form.html:209
-#: templates/events/event_list.html:66
-#: templates/events/event_list_archived.html:42
+#: templates/events/event_list.html:69
+#: templates/events/event_list_archived.html:45
 msgid "End"
 msgstr "Ende"
 
@@ -932,12 +932,12 @@ msgstr ""
 "Veranstaltungsortes einzutippen"
 
 #: templates/events/event_form.html:277 templates/pois/poi_form.html:180
-#: templates/pois/poi_list.html:65 templates/pois/poi_list_archived.html:39
+#: templates/pois/poi_list.html:68 templates/pois/poi_list_archived.html:42
 msgid "Street"
 msgstr "Straße"
 
 #: templates/events/event_form.html:281 templates/pois/poi_form.html:189
-#: templates/pois/poi_list.html:68 templates/pois/poi_list_archived.html:42
+#: templates/pois/poi_list.html:71 templates/pois/poi_list_archived.html:45
 msgid "Country"
 msgstr "Land"
 
@@ -958,7 +958,7 @@ msgid "Set icon"
 msgstr "Icon festlegen"
 
 #: templates/events/event_form.html:298
-#: templates/events/event_list_archived_row.html:94
+#: templates/events/event_list_archived_row.html:97
 msgid "Restore event"
 msgstr "Veranstaltung wiederherstellen"
 
@@ -966,7 +966,8 @@ msgstr "Veranstaltung wiederherstellen"
 msgid "Restore this event"
 msgstr "Diese Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:304 templates/events/event_list_row.html:97
+#: templates/events/event_form.html:304
+#: templates/events/event_list_row.html:100
 msgid "Archive event"
 msgstr "Veranstaltung archivieren"
 
@@ -975,8 +976,8 @@ msgid "Archive this event"
 msgstr "Diese Veranstaltung archivieren"
 
 #: templates/events/event_form.html:313
-#: templates/events/event_list_archived_row.html:99
-#: templates/events/event_list_row.html:102
+#: templates/events/event_list_archived_row.html:102
+#: templates/events/event_list_row.html:105
 msgid "Delete event"
 msgstr "Veranstaltung löschen"
 
@@ -1035,50 +1036,50 @@ msgstr "Veranstaltung erstellen"
 msgid "ID"
 msgstr "ID"
 
-#: templates/events/event_list.html:64
-#: templates/events/event_list_archived.html:40
+#: templates/events/event_list.html:67
+#: templates/events/event_list_archived.html:43
 msgid "Event location"
 msgstr "Veranstaltungsort"
 
-#: templates/events/event_list.html:67
-#: templates/events/event_list_archived.html:43
+#: templates/events/event_list.html:70
+#: templates/events/event_list_archived.html:46
 #: templates/languages/language_list.html:31
 #: templates/offer_templates/offer_template_list.html:29
 #: templates/organizations/organization_list.html:27
-#: templates/pages/page_tree.html:93 templates/pages/page_tree_archived.html:48
-#: templates/pois/poi_list.html:69 templates/pois/poi_list_archived.html:43
+#: templates/pages/page_tree.html:96 templates/pages/page_tree_archived.html:51
+#: templates/pois/poi_list.html:72 templates/pois/poi_list_archived.html:46
 #: templates/roles/list.html:25
 msgid "Options"
 msgstr "Optionen"
 
-#: templates/events/event_list.html:80
+#: templates/events/event_list.html:83
 msgid "No events available yet."
 msgstr "Noch keine Veranstaltungen vorhanden."
 
-#: templates/events/event_list_archived.html:56
+#: templates/events/event_list_archived.html:59
 msgid "No events archived yet."
 msgstr "Noch keine Veranstaltungen archiviert."
 
 #: templates/events/event_list_archived_row.html:25
-#: templates/events/event_list_archived_row.html:38
+#: templates/events/event_list_archived_row.html:40
 #: templates/events/event_list_row.html:25
-#: templates/events/event_list_row.html:38
+#: templates/events/event_list_row.html:40
 #: templates/pages/page_tree_archived_node.html:30
-#: templates/pages/page_tree_archived_node.html:43
+#: templates/pages/page_tree_archived_node.html:45
 #: templates/pages/page_tree_node.html:31
-#: templates/pages/page_tree_node.html:44
+#: templates/pages/page_tree_node.html:46
 #: templates/pois/poi_list_archived_row.html:24
-#: templates/pois/poi_list_archived_row.html:37
-#: templates/pois/poi_list_row.html:24 templates/pois/poi_list_row.html:37
+#: templates/pois/poi_list_archived_row.html:39
+#: templates/pois/poi_list_row.html:24 templates/pois/poi_list_row.html:39
 msgid "Translation not available"
 msgstr "Übersetzung nicht verfügbar"
 
-#: templates/events/event_list_archived_row.html:78
-#: templates/events/event_list_row.html:78
+#: templates/events/event_list_archived_row.html:81
+#: templates/events/event_list_row.html:81
 msgid "Not specified"
 msgstr "Nicht festgelegt"
 
-#: templates/events/event_list_row.html:94
+#: templates/events/event_list_row.html:97
 msgid "Edit event"
 msgstr "Veranstaltung bearbeiten"
 
@@ -1188,7 +1189,7 @@ msgstr "Erstellt"
 
 #: templates/languages/language_list.html:30
 #: templates/offer_templates/offer_template_list.html:27
-#: templates/pages/page_tree.html:92 templates/regions/region_list.html:33
+#: templates/pages/page_tree.html:95 templates/regions/region_list.html:33
 msgid "Last updated"
 msgstr "Zuletzt aktualisiert"
 
@@ -1507,7 +1508,7 @@ msgstr ""
 "beliebige Seiten zu ändern."
 
 #: templates/pages/page_form.html:273 templates/pages/page_form.html:274
-#: templates/pages/page_tree_archived_node.html:85
+#: templates/pages/page_tree_archived_node.html:88
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
@@ -1516,7 +1517,7 @@ msgid "Restore this page"
 msgstr "Diese Seite wiederherstellen"
 
 #: templates/pages/page_form.html:278 templates/pages/page_form.html:279
-#: templates/pages/page_tree_node.html:95
+#: templates/pages/page_tree_node.html:98
 msgid "Archive page"
 msgstr "Seite archivieren"
 
@@ -1525,14 +1526,14 @@ msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
 #: templates/pages/page_form.html:287 templates/pages/page_form.html:291
-#: templates/pages/page_tree_archived_node.html:94
-#: templates/pages/page_tree_node.html:104
+#: templates/pages/page_tree_archived_node.html:97
+#: templates/pages/page_tree_node.html:107
 msgid "Delete page"
 msgstr "Seite löschen"
 
 #: templates/pages/page_form.html:289
-#: templates/pages/page_tree_archived_node.html:90
-#: templates/pages/page_tree_node.html:100 views/pages/page_actions.py:93
+#: templates/pages/page_tree_archived_node.html:93
+#: templates/pages/page_tree_node.html:103 views/pages/page_actions.py:93
 msgid "You cannot delete a page which has children."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
@@ -1567,7 +1568,7 @@ msgstr "Seite erstellen"
 msgid "You can only create pages in the default language"
 msgstr "Sie können Seiten nur in der Standard-Sprache anlegen"
 
-#: templates/pages/page_tree.html:113
+#: templates/pages/page_tree.html:116
 msgid "No pages available yet."
 msgstr "Noch keine Seiten vorhanden."
 
@@ -1575,21 +1576,21 @@ msgstr "Noch keine Seiten vorhanden."
 msgid "Archived Pages"
 msgstr "Archivierte Seiten"
 
-#: templates/pages/page_tree_archived.html:64
+#: templates/pages/page_tree_archived.html:67
 msgid "No pages archived yet."
 msgstr "Noch keine Seiten archiviert."
 
-#: templates/pages/page_tree_archived_node.html:82
-#: templates/pages/page_tree_node.html:88
+#: templates/pages/page_tree_archived_node.html:85
+#: templates/pages/page_tree_node.html:91
 msgid "View page"
 msgstr "Seite ansehen"
 
-#: templates/pages/page_tree_archived_node.html:100
-#: templates/pages/page_tree_node.html:110
+#: templates/pages/page_tree_archived_node.html:103
+#: templates/pages/page_tree_node.html:113
 msgid "Download page"
 msgstr "Seite herunterladen"
 
-#: templates/pages/page_tree_node.html:91
+#: templates/pages/page_tree_node.html:94
 msgid "Edit page"
 msgstr "Seite bearbeiten"
 
@@ -1658,8 +1659,8 @@ msgstr "Kurzbeschreibung hier eingeben"
 msgid "Insert street here"
 msgstr "Straße hier eingeben"
 
-#: templates/pois/poi_form.html:183 templates/pois/poi_list.html:66
-#: templates/pois/poi_list_archived.html:40
+#: templates/pois/poi_form.html:183 templates/pois/poi_list.html:69
+#: templates/pois/poi_list_archived.html:43
 msgid "Postal Code"
 msgstr "Postleitzahl"
 
@@ -1696,7 +1697,7 @@ msgid "Insert latitude here"
 msgstr "Geographische Breite hier eingeben"
 
 #: templates/pois/poi_form.html:214 templates/pois/poi_form.html:215
-#: templates/pois/poi_list_archived_row.html:55
+#: templates/pois/poi_list_archived_row.html:58
 msgid "Restore POI"
 msgstr "POI Wiederherstellen"
 
@@ -1705,7 +1706,7 @@ msgid "Restore this POI"
 msgstr "Diesen POI wiederherstellen"
 
 #: templates/pois/poi_form.html:219 templates/pois/poi_form.html:220
-#: templates/pois/poi_list_row.html:89
+#: templates/pois/poi_list_row.html:92
 msgid "Archive POI"
 msgstr "POI archivieren"
 
@@ -1714,8 +1715,8 @@ msgid "Archive this POI"
 msgstr "Diesen POI archivieren"
 
 #: templates/pois/poi_form.html:227 templates/pois/poi_form.html:228
-#: templates/pois/poi_list_archived_row.html:59
-#: templates/pois/poi_list_row.html:93
+#: templates/pois/poi_list_archived_row.html:62
+#: templates/pois/poi_list_row.html:96
 msgid "Delete POI"
 msgstr "POI löschen"
 
@@ -1731,7 +1732,7 @@ msgstr "Archivierte POIs"
 msgid "Create POI"
 msgstr "POI erstellen"
 
-#: templates/pois/poi_list.html:79 templates/pois/poi_list_archived.html:53
+#: templates/pois/poi_list.html:82 templates/pois/poi_list_archived.html:56
 msgid "No POIs available yet."
 msgstr "Noch keine POIs vorhanden."
 

--- a/src/cms/templates/events/event_list.html
+++ b/src/cms/templates/events/event_list.html
@@ -50,7 +50,10 @@
                 {% get_current_language as LANGUAGE_CODE %}
                 {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
                 {% if LANGUAGE_CODE != language.code %}
-                    <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {% translated_language_name LANGUAGE_CODE %}</th>
+                    {% get_language LANGUAGE_CODE as backend_language %}
+                    {% if backend_language %}
+                        <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
+                    {% endif %}
                 {% endif %}
                 <th class="text-sm text-left uppercase py-3 px-2">
                     <div class="lang-grid flags">

--- a/src/cms/templates/events/event_list_archived.html
+++ b/src/cms/templates/events/event_list_archived.html
@@ -26,7 +26,10 @@
                 {% get_current_language as LANGUAGE_CODE %}
                 {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
                 {% if LANGUAGE_CODE != language.code %}
-                    <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {% translated_language_name LANGUAGE_CODE %}</th>
+                    {% get_language LANGUAGE_CODE as backend_language %}
+                    {% if backend_language %}
+                        <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
+                    {% endif %}
                 {% endif %}
                 <th class="text-sm text-left uppercase py-3 px-2">
                     <div class="lang-grid flags">

--- a/src/cms/templates/events/event_list_archived_row.html
+++ b/src/cms/templates/events/event_list_archived_row.html
@@ -29,16 +29,19 @@
     {% get_current_language as LANGUAGE_CODE %}
     {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
     {% if LANGUAGE_CODE != language.code %}
-        {% get_translation event LANGUAGE_CODE as backend_translation %}
-        <td>
-            <a href="{% url 'edit_event' event_id=event.id region_slug=region.slug language_code=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
-                {% if backend_translation %}
-                    {{ backend_translation.title }}
-                {% else %}
-                    <i>{% trans 'Translation not available' %}</i>
-                {% endif %}
-            </a>
-        </td>
+        {% get_language LANGUAGE_CODE as backend_language %}
+        {% if backend_language %}
+            {% get_translation event LANGUAGE_CODE as backend_translation %}
+            <td>
+                <a href="{% url 'edit_event' event_id=event.id region_slug=region.slug language_code=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
+                    {% if backend_translation %}
+                        {{ backend_translation.title }}
+                    {% else %}
+                        <i>{% trans 'Translation not available' %}</i>
+                    {% endif %}
+                </a>
+            </td>
+        {% endif %}
     {% endif %}
     <td>
         <div class="block py-3 px-2 text-gray-800">

--- a/src/cms/templates/events/event_list_row.html
+++ b/src/cms/templates/events/event_list_row.html
@@ -29,16 +29,19 @@
     {% get_current_language as LANGUAGE_CODE %}
     {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
     {% if LANGUAGE_CODE != language.code %}
-        {% get_translation event LANGUAGE_CODE as backend_translation %}
-        <td>
-            <a href="{% url 'edit_event' event_id=event.id region_slug=region.slug language_code=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
-                {% if backend_translation %}
-                    {{ backend_translation.title }}
-                {% else %}
-                    <i>{% trans 'Translation not available' %}</i>
-                {% endif %}
-            </a>
-        </td>
+        {% get_language LANGUAGE_CODE as backend_language %}
+        {% if backend_language %}
+            {% get_translation event LANGUAGE_CODE as backend_translation %}
+            <td>
+                <a href="{% url 'edit_event' event_id=event.id region_slug=region.slug language_code=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
+                    {% if backend_translation %}
+                        {{ backend_translation.title }}
+                    {% else %}
+                        <i>{% trans 'Translation not available' %}</i>
+                    {% endif %}
+                </a>
+            </td>
+        {% endif %}
     {% endif %}
     <td>
         <div class="block py-3 px-2 text-gray-800">

--- a/src/cms/templates/pages/page_tree.html
+++ b/src/cms/templates/pages/page_tree.html
@@ -78,7 +78,10 @@
                 {% get_current_language as LANGUAGE_CODE %}
                 {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
                 {% if LANGUAGE_CODE != language.code %}
-                    <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {% translated_language_name LANGUAGE_CODE %}</th>
+                    {% get_language LANGUAGE_CODE as backend_language %}
+                    {% if backend_language %}
+                        <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
+                    {% endif %}
                 {% endif %}
                 <th class="text-sm text-left uppercase py-3 px-2">
                     <div class="lang-grid flags whitespace-no-wrap">

--- a/src/cms/templates/pages/page_tree_archived.html
+++ b/src/cms/templates/pages/page_tree_archived.html
@@ -34,7 +34,10 @@
                 {% get_current_language as LANGUAGE_CODE %}
                 {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
                 {% if LANGUAGE_CODE != language.code %}
-                    <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {% translated_language_name LANGUAGE_CODE %}</th>
+                    {% get_language LANGUAGE_CODE as backend_language %}
+                    {% if backend_language %}
+                        <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
+                    {% endif %}
                 {% endif %}
                 <th class="text-sm text-left uppercase py-3 px-2">
                     <div class="lang-grid flags whitespace-no-wrap">

--- a/src/cms/templates/pages/page_tree_archived_node.html
+++ b/src/cms/templates/pages/page_tree_archived_node.html
@@ -34,16 +34,19 @@
     {% get_current_language as LANGUAGE_CODE %}
     {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
     {% if LANGUAGE_CODE != language.code %}
-        {% get_translation page LANGUAGE_CODE as backend_translation %}
-        <td>
-            <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_code=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
-                {% if backend_translation %}
-                    {{ backend_translation.title }}
-                {% else %}
-                    <i>{% trans 'Translation not available' %}</i>
-                {% endif %}
-            </a>
-        </td>
+        {% get_language LANGUAGE_CODE as backend_language %}
+        {% if backend_language %}
+            {% get_translation page LANGUAGE_CODE as backend_translation %}
+            <td>
+                <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_code=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
+                    {% if backend_translation %}
+                        {{ backend_translation.title }}
+                    {% else %}
+                        <i>{% trans 'Translation not available' %}</i>
+                    {% endif %}
+                </a>
+            </td>
+        {% endif %}
     {% endif %}
     <td class="whitespace-no-wrap">
         <div class="block py-3 px-2 text-gray-800">

--- a/src/cms/templates/pages/page_tree_node.html
+++ b/src/cms/templates/pages/page_tree_node.html
@@ -35,16 +35,19 @@
     {% get_current_language as LANGUAGE_CODE %}
     {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
     {% if LANGUAGE_CODE != language.code %}
-        {% get_translation page LANGUAGE_CODE as backend_translation %}
-        <td>
-            <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_code=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
-                {% if backend_translation %}
-                    {{ backend_translation.title }}
-                {% else %}
-                    <i>{% trans 'Translation not available' %}</i>
-                {% endif %}
-            </a>
-        </td>
+        {% get_language LANGUAGE_CODE as backend_language %}
+        {% if backend_language %}
+            {% get_translation page LANGUAGE_CODE as backend_translation %}
+            <td>
+                <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_code=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
+                    {% if backend_translation %}
+                        {{ backend_translation.title }}
+                    {% else %}
+                        <i>{% trans 'Translation not available' %}</i>
+                    {% endif %}
+                </a>
+            </td>
+        {% endif %}
     {% endif %}
     <td class="whitespace-no-wrap">
         <div class="block py-3 px-2 text-gray-800">

--- a/src/cms/templates/pois/poi_list.html
+++ b/src/cms/templates/pois/poi_list.html
@@ -51,7 +51,10 @@
                 {% get_current_language as LANGUAGE_CODE %}
                 {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
                 {% if LANGUAGE_CODE != language.code %}
-                    <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {% translated_language_name LANGUAGE_CODE %}</th>
+                    {% get_language LANGUAGE_CODE as backend_language %}
+                    {% if backend_language %}
+                        <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
+                    {% endif %}
                 {% endif %}
                 <th class="text-sm text-left uppercase py-3 px-2">
                     <div class="lang-grid flags" style="white-space: nowrap;">

--- a/src/cms/templates/pois/poi_list_archived.html
+++ b/src/cms/templates/pois/poi_list_archived.html
@@ -34,7 +34,10 @@
                 {% get_current_language as LANGUAGE_CODE %}
                 {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
                 {% if LANGUAGE_CODE != language.code %}
-                    <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {% translated_language_name LANGUAGE_CODE %}</th>
+                    {% get_language LANGUAGE_CODE as backend_language %}
+                    {% if backend_language %}
+                        <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
+                    {% endif %}
                 {% endif %}
                 <th class="text-sm text-left uppercase py-3">{% trans 'Street' %}</th>
                 <th class="text-sm text-left uppercase py-3">{% trans 'Postal Code' %}</th>

--- a/src/cms/templates/pois/poi_list_archived_row.html
+++ b/src/cms/templates/pois/poi_list_archived_row.html
@@ -28,16 +28,19 @@
     {% get_current_language as LANGUAGE_CODE %}
     {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
     {% if LANGUAGE_CODE != language.code %}
-        {% get_translation poi LANGUAGE_CODE as backend_translation %}
-        <td>
-            <a href="{% url 'edit_poi' poi_id=poi.id region_slug=region.slug language_code=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
-                {% if backend_translation %}
-                    {{ backend_translation.title }}
-                {% else %}
-                    <i>{% trans 'Translation not available' %}</i>
-                {% endif %}
-            </a>
-        </td>
+        {% get_language LANGUAGE_CODE as backend_language %}
+        {% if backend_language %}
+            {% get_translation poi LANGUAGE_CODE as backend_translation %}
+            <td>
+                <a href="{% url 'edit_poi' poi_id=poi.id region_slug=region.slug language_code=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
+                    {% if backend_translation %}
+                        {{ backend_translation.title }}
+                    {% else %}
+                        <i>{% trans 'Translation not available' %}</i>
+                    {% endif %}
+                </a>
+            </td>
+        {% endif %}
     {% endif %}
 	<td>
 		{{ poi.address }}

--- a/src/cms/templates/pois/poi_list_row.html
+++ b/src/cms/templates/pois/poi_list_row.html
@@ -28,16 +28,19 @@
     {% get_current_language as LANGUAGE_CODE %}
     {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
     {% if LANGUAGE_CODE != language.code %}
-        {% get_translation poi LANGUAGE_CODE as backend_translation %}
-        <td>
-            <a href="{% url 'edit_poi' poi_id=poi.id region_slug=region.slug language_code=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
-                {% if backend_translation %}
-                    {{ backend_translation.title }}
-                {% else %}
-                    <i>{% trans 'Translation not available' %}</i>
-                {% endif %}
-            </a>
-        </td>
+        {% get_language LANGUAGE_CODE as backend_language %}
+        {% if backend_language %}
+            {% get_translation poi LANGUAGE_CODE as backend_translation %}
+            <td>
+                <a href="{% url 'edit_poi' poi_id=poi.id region_slug=region.slug language_code=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
+                    {% if backend_translation %}
+                        {{ backend_translation.title }}
+                    {% else %}
+                        <i>{% trans 'Translation not available' %}</i>
+                    {% endif %}
+                </a>
+            </td>
+        {% endif %}
     {% endif %}
 	<td>
 		<div class="block py-3 px-2 text-gray-800">

--- a/src/cms/templatetags/content_filters.py
+++ b/src/cms/templatetags/content_filters.py
@@ -15,11 +15,14 @@ def get_translation(instance, language_code):
 
 @register.simple_tag
 def translated_language_name(language_code):
-    return Language.objects.get(code=language_code).translated_name
+    language = Language.objects.filter(code=language_code)
+    if language.exists():
+        return language.first().translated_name
+    return ''
 
 @register.simple_tag
 def get_language(language_code):
-    return Language.objects.get(code=language_code)
+    return Language.objects.filter(code=language_code).first()
 
 # Unify the language codes of backend and content languages
 @register.simple_tag


### PR DESCRIPTION
- This allows backend languages which are not contained in the content languages or have a different language code
- The table column of translation titles in the current backend languages is now hidden when the backend language does not exist in the content languages

Fixes #434