### PR TITLE
Note for installation on Windows in documentation

### DIFF
--- a/sphinx/installation.rst
+++ b/sphinx/installation.rst
@@ -2,6 +2,10 @@
 Installation
 ************
 
+.. Note::
+
+    If you want to develop on Windows, we suggest using the `Windows Subsystem for Linux <https://docs.microsoft.com/en-us/windows/wsl/>`_ in combination with `Ubuntu <https://ubuntu.com/wsl>`_ and `postgresql <https://wiki.ubuntuusers.de/PostgreSQL/>`__ as local database server.
+
 
 Prerequisites
 =============


### PR DESCRIPTION
This adds a simple note to the Windows Subsystem for Linux (WSL) to the installation guide in our documentation.