### PR TITLE
Fix CircleCI build for dependabot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,3 +249,6 @@ workflows:
               only: develop
       - docker-images:
           context: docker-hub
+          filters:
+            branches:
+              ignore: /^dependabot\/.*/


### PR DESCRIPTION
This adds a filter to the `docker-images` job to ignore branches of the dependabot.
This should be no problem because the dependabot does not modify the docker images and the dependency versions have no influence on the docker images build.

You can verify that this works if the `docker-images` job for this PR is not run, since I used the same naming scheme as the dependabot.

Fixes #440