### PR TITLE
Improve documentation of forms

### DIFF
--- a/src/cms/_tests.py
+++ b/src/cms/_tests.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from .constants import position, status, region_status
@@ -51,7 +51,7 @@ class SetupClass(TestCase):
         return None
 
     def setUp(self):
-        self.user = User.objects.create_user('test', 'test@integreat.com', 'test')
+        self.user = get_user_model().objects.create_user('test', 'test@integreat.com', 'test')
         self.region = self.create_region({
             'name': 'demo',
             'events_enabled': True,

--- a/src/cms/forms/__init__.py
+++ b/src/cms/forms/__init__.py
@@ -1,0 +1,4 @@
+"""
+Forms for creating and modifying database objects.
+Please refer to :mod:`django.forms` for general information about Django forms (see also: :doc:`topics/forms/index`).
+"""

--- a/src/cms/forms/authentication/__init__.py
+++ b/src/cms/forms/authentication/__init__.py
@@ -1,1 +1,4 @@
+"""
+Forms related to the user and password management
+"""
 from .password_reset_form import PasswordResetConfirmForm

--- a/src/cms/forms/authentication/password_reset_form.py
+++ b/src/cms/forms/authentication/password_reset_form.py
@@ -1,13 +1,10 @@
-"""
-Forms related to the user creation and more
-"""
 from django.contrib.auth.forms import SetPasswordForm
 from django.utils.translation import ugettext as _
 
 
 class PasswordResetConfirmForm(SetPasswordForm):
     """
-    Form for resetting Passwords
+    Form for resetting passwords
     """
     error_messages = {
         'password_mismatch': _("The passwords do not match."),

--- a/src/cms/forms/events/__init__.py
+++ b/src/cms/forms/events/__init__.py
@@ -1,3 +1,6 @@
+"""
+Forms for creating or saving event objects and their corresponding event translation objects and recurrence rule objects
+"""
 from .event_form import EventForm
 from .event_translation_form import EventTranslationForm
 from .recurrence_rule_form import RecurrenceRuleForm

--- a/src/cms/forms/events/event_form.py
+++ b/src/cms/forms/events/event_form.py
@@ -1,6 +1,3 @@
-"""
-Form for creating or saving event objects and their corresponding event translation objects
-"""
 import logging
 
 from datetime import time
@@ -14,6 +11,9 @@ logger = logging.getLogger(__name__)
 
 
 class EventForm(forms.ModelForm):
+    """
+    Form for creating and modifying event objects
+    """
     is_all_day = forms.BooleanField(required=False)
     is_recurring = forms.BooleanField(required=False)
 

--- a/src/cms/forms/events/event_translation_form.py
+++ b/src/cms/forms/events/event_translation_form.py
@@ -1,6 +1,3 @@
-"""
-Form for creating or saving event objects and their corresponding event translation objects
-"""
 import logging
 
 from django import forms
@@ -13,6 +10,9 @@ logger = logging.getLogger(__name__)
 
 
 class EventTranslationForm(forms.ModelForm):
+    """
+    Form for creating and modifying event translation objects
+    """
 
     class Meta:
         model = EventTranslation

--- a/src/cms/forms/events/recurrence_rule_form.py
+++ b/src/cms/forms/events/recurrence_rule_form.py
@@ -1,6 +1,3 @@
-"""
-Form for creating or saving event objects and their corresponding event translation objects
-"""
 import logging
 
 from django import forms
@@ -13,6 +10,9 @@ logger = logging.getLogger(__name__)
 
 
 class RecurrenceRuleForm(forms.ModelForm):
+    """
+    Form for creating and modifying event recurrence rule objects
+    """
     has_recurrence_end_date = forms.BooleanField(required=False)
 
     class Meta:

--- a/src/cms/forms/language_tree/__init__.py
+++ b/src/cms/forms/language_tree/__init__.py
@@ -1,1 +1,4 @@
+"""
+Forms for creating and modifying language tree objects
+"""
 from .language_tree_node_form import LanguageTreeNodeForm

--- a/src/cms/forms/language_tree/language_tree_node_form.py
+++ b/src/cms/forms/language_tree/language_tree_node_form.py
@@ -1,6 +1,3 @@
-"""
-Form for creating a language tree node object
-"""
 from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
@@ -10,10 +7,7 @@ from ...models import LanguageTreeNode, Region
 
 class LanguageTreeNodeForm(forms.ModelForm):
     """
-    DjangoForm Class, that can be rendered to create deliverable HTML
-
-    Args:
-        forms : Defines the form as an Model form related to a database object
+    Form for creating and modifying language tree node objects
     """
 
     class Meta:

--- a/src/cms/forms/languages/__init__.py
+++ b/src/cms/forms/languages/__init__.py
@@ -1,1 +1,4 @@
+"""
+Forms for creating and modifying language objects
+"""
 from .language_form import LanguageForm

--- a/src/cms/forms/languages/language_form.py
+++ b/src/cms/forms/languages/language_form.py
@@ -1,6 +1,3 @@
-"""
-Form for creating a language object
-"""
 from django import forms
 
 from ...models import Language
@@ -8,10 +5,7 @@ from ...models import Language
 
 class LanguageForm(forms.ModelForm):
     """
-    DjangoForm Class, that can be rendered to create deliverable HTML
-
-    Args:
-        forms : Defines the form as an Model form related to a database object
+    Form for creating and modifying language objects
     """
 
     class Meta:

--- a/src/cms/forms/media/__init__.py
+++ b/src/cms/forms/media/__init__.py
@@ -1,1 +1,4 @@
+"""
+Forms for creating and modifying media objects
+"""
 from .document_form import DocumentForm

--- a/src/cms/forms/media/document_form.py
+++ b/src/cms/forms/media/document_form.py
@@ -4,6 +4,9 @@ from ...models import Document
 
 
 class DocumentForm(forms.ModelForm):
+    """
+    Form for creating and modifying document objects
+    """
 
     class Meta:
         model = Document

--- a/src/cms/forms/offer_templates/__init__.py
+++ b/src/cms/forms/offer_templates/__init__.py
@@ -1,1 +1,4 @@
+"""
+Forms for creating and modifying offer objects
+"""
 from .offer_template_form import OfferTemplateForm

--- a/src/cms/forms/offer_templates/offer_template_form.py
+++ b/src/cms/forms/offer_templates/offer_template_form.py
@@ -1,6 +1,4 @@
-"""
-Form for creating an offer_template object
-"""
+
 from django import forms
 
 from ...models import OfferTemplate
@@ -9,10 +7,7 @@ from ...utils.slug_utils import generate_unique_slug
 
 class OfferTemplateForm(forms.ModelForm):
     """
-    DjangoForm Class, that can be rendered to create deliverable HTML
-
-    Args:
-        forms : Defines the form as an Model form related to a database object
+    Form for creating and modifying offer template objects
     """
 
     class Meta:

--- a/src/cms/forms/organizations/__init__.py
+++ b/src/cms/forms/organizations/__init__.py
@@ -1,1 +1,4 @@
+"""
+Forms for creating and modifying organization objects
+"""
 from .organization_form import OrganizationForm

--- a/src/cms/forms/organizations/organization_form.py
+++ b/src/cms/forms/organizations/organization_form.py
@@ -1,6 +1,3 @@
-"""
-Form for creating an organization object
-"""
 from django import forms
 
 from ...models import Organization
@@ -8,10 +5,7 @@ from ...models import Organization
 
 class OrganizationForm(forms.ModelForm):
     """
-    DjangoForm Class, that can be rendered to create deliverable HTML
-
-    Args:
-        forms : Defines the form as an Model form related to a database object
+    Form for creating and modifying organization objects
     """
 
     class Meta:

--- a/src/cms/forms/pages/__init__.py
+++ b/src/cms/forms/pages/__init__.py
@@ -1,2 +1,5 @@
+"""
+Forms for creating and modifying page and page translation objects
+"""
 from .page_form import PageForm
 from .page_translation_form import PageTranslationForm

--- a/src/cms/forms/pages/page_form.py
+++ b/src/cms/forms/pages/page_form.py
@@ -1,6 +1,3 @@
-"""
-Form for creating a page object and page translation object
-"""
 import logging
 
 from django import forms
@@ -18,8 +15,7 @@ logger = logging.getLogger(__name__)
 
 class ParentField(forms.ModelChoiceField):
     """
-        Subclass of ModelChoiceField
-        Helper to overwrite the label function (which would otherwise call __str__)
+    Form field helper class to overwrite the label function (which would otherwise call __str__)
     """
     language = None
 
@@ -38,9 +34,8 @@ class ParentField(forms.ModelChoiceField):
 
 class MirrorPageField(forms.ModelChoiceField):
     """
-    Show ancestors page titles in mirror page select
+    Form field helper class to show ancestors page titles in mirror page select
     """
-
     # pylint: disable=arguments-differ
     def label_from_instance(self, page):
         return ' -> '.join([page_iter.best_language_title() for page_iter in page.get_ancestors(include_self=True)])
@@ -48,10 +43,7 @@ class MirrorPageField(forms.ModelChoiceField):
 
 class PageForm(forms.ModelForm):
     """
-    DjangoForm Class, that can be rendered to create deliverable HTML
-
-    Args:
-        forms : Defines the form as an Model form related to a database object
+    Form for creating and modifying page objects
     """
 
     position = forms.ChoiceField(choices=position.CHOICES, initial=position.FIRST_CHILD)

--- a/src/cms/forms/pages/page_translation_form.py
+++ b/src/cms/forms/pages/page_translation_form.py
@@ -1,6 +1,3 @@
-"""
-Form for creating a page object and page translation object
-"""
 import logging
 
 from django import forms
@@ -15,10 +12,7 @@ logger = logging.getLogger(__name__)
 
 class PageTranslationForm(forms.ModelForm):
     """
-    DjangoForm Class, that can be rendered to create deliverable HTML
-
-    Args:
-        forms : Defines the form as an Model form related to a database object
+    Form for creating and modifying page translation objects
     """
 
     class Meta:

--- a/src/cms/forms/pois/__init__.py
+++ b/src/cms/forms/pois/__init__.py
@@ -1,2 +1,5 @@
+"""
+Forms for creating and modifying POI and POI translation objects
+"""
 from .poi_form import POIForm
 from .poi_translation_form import POITranslationForm

--- a/src/cms/forms/pois/poi_form.py
+++ b/src/cms/forms/pois/poi_form.py
@@ -1,6 +1,3 @@
-"""
-Form for creating a poi object and poi translation object
-"""
 import logging
 
 from django import forms
@@ -13,10 +10,7 @@ logger = logging.getLogger(__name__)
 
 class POIForm(forms.ModelForm):
     """
-    DjangoForm Class, that can be rendered to create deliverable HTML
-
-    Args:
-        forms : Defines the form as an Model form related to a database object
+    Form for creating and modifying POI objects
     """
 
     class Meta:

--- a/src/cms/forms/pois/poi_translation_form.py
+++ b/src/cms/forms/pois/poi_translation_form.py
@@ -1,6 +1,3 @@
-"""
-Form for creating a poi object and poi translation object
-"""
 import logging
 
 from django import forms
@@ -16,10 +13,7 @@ logger = logging.getLogger(__name__)
 
 class POITranslationForm(forms.ModelForm):
     """
-    DjangoForm Class, that can be rendered to create deliverable HTML
-
-    Args:
-        forms : Defines the form as an Model form related to a database object
+    Form for creating and modifying POI translation objects
     """
 
     PUBLIC_CHOICES = (

--- a/src/cms/forms/push_notifications/__init__.py
+++ b/src/cms/forms/push_notifications/__init__.py
@@ -1,1 +1,4 @@
+"""
+Forms for creating and modifying push notification and push notification translation objects
+"""
 from .push_notification_form import PushNotificationForm, PushNotificationTranslationForm

--- a/src/cms/forms/push_notifications/push_notification_form.py
+++ b/src/cms/forms/push_notifications/push_notification_form.py
@@ -1,6 +1,3 @@
-"""
-Form for creating a user object
-"""
 from django import forms
 
 from ...models import PushNotification, PushNotificationTranslation
@@ -8,10 +5,7 @@ from ...models import PushNotification, PushNotificationTranslation
 
 class PushNotificationForm(forms.ModelForm):
     """
-    DjangoForm Class, that can be rendered to create deliverable HTML
-
-    Args:
-        forms : Defines the form as an Model form related to a database object
+    Form for creating and modifying push notification objects
     """
 
     class Meta:
@@ -23,10 +17,7 @@ class PushNotificationForm(forms.ModelForm):
 
 class PushNotificationTranslationForm(forms.ModelForm):
     """
-    DjangoForm Class, that can be rendered to create deliverable HTML
-
-    Args:
-        forms : Defines the form as an Model form related to a database object
+    Form for creating and modifying push notification translation objects
     """
 
     class Meta:

--- a/src/cms/forms/regions/__init__.py
+++ b/src/cms/forms/regions/__init__.py
@@ -1,1 +1,4 @@
+"""
+Forms for creating and modifying region objects
+"""
 from .region_form import RegionForm

--- a/src/cms/forms/regions/region_form.py
+++ b/src/cms/forms/regions/region_form.py
@@ -1,6 +1,3 @@
-"""
-Form for creating a region object
-"""
 import logging
 
 from django import forms
@@ -15,6 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 class RegionForm(forms.ModelForm):
+    """
+    Form for creating and modifying region objects
+    """
     duplicated_region = forms.ModelChoiceField(
         queryset=Region.objects.all(),
         empty_label=_("Do no import initial content"),
@@ -104,11 +104,17 @@ def duplicate_language_tree(source_region, target_region, source_parent_id=None,
     This is a recursive function to walk the whole language tree. It starts at root level with the default parent None.
     The recursion is necessary because the new nodes need their correct (also duplicated) parent node.
 
-    Args:
-        :param source_region: The region from which the language tree should be duplicated
-        :param target_region: The region to which the language tree should be added
-        :param source_parent_id: The current parent node id of the recursion
-        :param target_parent: The node of the target region which is the duplicate of the source parent node
+    :param source_region: The region from which the language tree should be duplicated
+    :type source_region: cms.models.regions.region.Region
+
+    :param target_region: The region to which the language tree should be added
+    :type target_region: cms.models.regions.region.Region
+
+    :param source_parent_id: The current parent node id of the recursion
+    :type source_parent_id: int
+
+    :param target_parent: The node of the target region which is the duplicate of the source parent node
+    :type target_parent: cms.models.pages.page.Page
     """
 
     # Iterate over all children of the current source parent, beginning with the root node
@@ -137,12 +143,20 @@ def duplicate_pages(source_region, target_region, source_parent_id=None, target_
     This is a recursive function to walk the whole page tree. It starts at root level with the default parent None.
     The recursion is necessary because the new pages need their correct (also duplicated) parent page.
 
-    Args:
-        :param source_region: The region from which the pages should be duplicated
-        :param target_region: The region to which the pages should be added
-        :param source_parent_id: The current parent page id of the recursion
-        :param target_parent: The page of the target region which is the duplicate of the source parent page
-        :param level: recursion level to get a pretty log output
+    :param source_region: The region from which the pages should be duplicated
+    :type source_region: cms.models.regions.region.Region
+
+    :param target_region: The region to which the pages should be added
+    :type target_region: cms.models.regions.region.Region
+
+    :param source_parent_id: The current parent page id of the recursion
+    :type source_parent_id: int
+
+    :param target_parent: The page of the target region which is the duplicate of the source parent page
+    :type target_parent: cms.models.pages.page.Page
+
+    :param level: recursion level to get a pretty log output
+    :type level: int
     """
 
     logger.info(
@@ -206,5 +220,7 @@ def duplicate_pages(source_region, target_region, source_parent_id=None, target_
 
 # pylint: disable=unused-argument
 def duplicate_media(source_region, target_region):
-    pass
+    """
+    Function to duplicate all media of one region to another.
+    """
     # TODO: implement duplication of all media files

--- a/src/cms/forms/roles/__init__.py
+++ b/src/cms/forms/roles/__init__.py
@@ -1,1 +1,4 @@
+"""
+Forms for creating and modifying user role objects
+"""
 from .role_form import RoleForm

--- a/src/cms/forms/roles/role_form.py
+++ b/src/cms/forms/roles/role_form.py
@@ -1,16 +1,10 @@
-"""
-Form for creating a group object
-"""
 from django import forms
 from django.contrib.auth.models import Group as Role
 
 
 class RoleForm(forms.ModelForm):
     """
-    DjangoForm Class, that can be rendered to create deliverable HTML
-
-    Args:
-        forms : Defines the form as an Model form related to a database object
+    Form for creating and modifying user role objects
     """
 
     class Meta:

--- a/src/cms/forms/users/__init__.py
+++ b/src/cms/forms/users/__init__.py
@@ -1,3 +1,6 @@
+"""
+Forms for creating and modifying user objects
+"""
 from .user_form import UserForm
 from .user_profile_form import UserProfileForm
 from .region_user_form import RegionUserForm

--- a/src/cms/forms/users/region_user_form.py
+++ b/src/cms/forms/users/region_user_form.py
@@ -1,6 +1,3 @@
-"""
-Form for creating a region user object
-"""
 import logging
 
 from django.contrib.auth import get_user_model
@@ -12,6 +9,9 @@ logger = logging.getLogger(__name__)
 
 
 class RegionUserForm(UserForm):
+    """
+    Form for creating and modifying region user objects
+    """
 
     class Meta:
         model = get_user_model()

--- a/src/cms/forms/users/region_user_profile_form.py
+++ b/src/cms/forms/users/region_user_profile_form.py
@@ -1,6 +1,3 @@
-"""
-Form for creating a region user object
-"""
 import logging
 
 
@@ -12,6 +9,9 @@ logger = logging.getLogger(__name__)
 
 
 class RegionUserProfileForm(UserProfileForm):
+    """
+    Form for creating and modifying region user profile objects
+    """
 
     class Meta:
         model = UserProfile

--- a/src/cms/forms/users/user_email_form.py
+++ b/src/cms/forms/users/user_email_form.py
@@ -1,6 +1,3 @@
-"""
-Form for changing a user's email address
-"""
 import logging
 
 from django import forms
@@ -11,6 +8,9 @@ logger = logging.getLogger(__name__)
 
 
 class UserEmailForm(forms.ModelForm):
+    """
+    Form for modifying user email addresses
+    """
 
     class Meta:
         model = get_user_model()

--- a/src/cms/forms/users/user_form.py
+++ b/src/cms/forms/users/user_form.py
@@ -1,6 +1,3 @@
-"""
-Form for creating a user object
-"""
 import logging
 
 from django import forms
@@ -13,6 +10,9 @@ logger = logging.getLogger(__name__)
 
 
 class UserForm(forms.ModelForm):
+    """
+    Form for creating and modifying user objects
+    """
 
     roles = forms.ModelMultipleChoiceField(
         queryset=Role.objects.all(),

--- a/src/cms/forms/users/user_password_form.py
+++ b/src/cms/forms/users/user_password_form.py
@@ -1,6 +1,3 @@
-"""
-Form for changing a user's password
-"""
 import logging
 
 from django import forms
@@ -13,6 +10,9 @@ logger = logging.getLogger(__name__)
 
 
 class UserPasswordForm(forms.ModelForm):
+    """
+    Form for changing a user's password
+    """
 
     old_password = forms.CharField(
         widget=forms.PasswordInput,

--- a/src/cms/forms/users/user_profile_form.py
+++ b/src/cms/forms/users/user_profile_form.py
@@ -12,6 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 class UserProfileForm(forms.ModelForm):
+    """
+    Form for creating and modifying user profile objects
+    """
 
     class Meta:
         model = UserProfile

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-24 10:26+0000\n"
+"POT-Creation-Date: 2020-07-29 13:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -203,7 +203,7 @@ msgstr "Entwurf"
 msgid "Pending Review"
 msgstr "Review ausstehend"
 
-#: constants/status.py:20 forms/pois/poi_translation_form.py:26
+#: constants/status.py:20 forms/pois/poi_translation_form.py:20
 msgid "Public"
 msgstr "Öffentlich"
 
@@ -259,7 +259,7 @@ msgstr "Dritte Woche"
 msgid "Fourth week"
 msgstr "Vierte Woche"
 
-#: forms/authentication/password_reset_form.py:13
+#: forms/authentication/password_reset_form.py:10
 msgid "The passwords do not match."
 msgstr "Die Passwörter stimmen nicht überein."
 
@@ -305,7 +305,7 @@ msgstr ""
 msgid "The recurrence end date has to be after the event's start date"
 msgstr "Das Ende der Wiederholung muss nach dem Veranstaltungsbeginn sein"
 
-#: forms/language_tree/language_tree_node_form.py:62
+#: forms/language_tree/language_tree_node_form.py:56
 msgid ""
 "This region has already a default language.Please specify a source language "
 "for this language."
@@ -313,7 +313,7 @@ msgstr ""
 "Diese Region besitzt bereits eine Standard-Sprache. Bitte geben Sie eine "
 "Quell-Sprache für diese Sprache ein."
 
-#: forms/language_tree/language_tree_node_form.py:71
+#: forms/language_tree/language_tree_node_form.py:65
 msgid ""
 "The source language belongs to another region.Please specify a source "
 "language of this region."
@@ -321,15 +321,15 @@ msgstr ""
 "Diese Quell-Sprache gehört zu einer anderen Region. Bitte geben Sie eine "
 "Quell-Sprache dieser Region ein."
 
-#: forms/pages/page_form.py:64
+#: forms/pages/page_form.py:56
 msgid "Embed mirrored page before this page"
 msgstr "Gespiegelte Seite vor dieser Seite einbinden"
 
-#: forms/pages/page_form.py:65
+#: forms/pages/page_form.py:57
 msgid "Embed mirrored page after this page"
 msgstr "Gespiegelte Seite nach dieser Seite einbinden"
 
-#: forms/pois/poi_translation_form.py:27
+#: forms/pois/poi_translation_form.py:21
 msgid "Private"
 msgstr "Privat"
 

--- a/src/cms/page_xliff_converter.py
+++ b/src/cms/page_xliff_converter.py
@@ -28,9 +28,11 @@ class TranslationXliffConverter: # pylint: disable=R0902
         Builds an LXML ETree from either the template or xliff_code parameter
 
         :param src_lang: source language of translation
-        :type src_lang: cms.models.languages.language.Language
+        :type src_lang: ~cms.models.languages.language.Language
+
         :param tgt_lang: target language of translation
-        :type tgt_lang: cms.models.languages.language.Language
+        :type tgt_lang: ~cms.models.languages.language.Language
+
         :param xliff_code: XML Code of XLIFF file to import
         :type xliff_code: str
         """
@@ -134,12 +136,16 @@ class TranslationXliffConverter: # pylint: disable=R0902
 
         :param page_id: the id of the page to which the translation is related
         :type page_id: int
+
         :param src_trans: source language page translation
-        :type src_trans: cms.models.pages.page_translation.PageTranslation
+        :type src_trans: ~cms.models.pages.page_translation.PageTranslation
+
         :param tgt_trans: target language page translation
-        :type tgt_trans: cms.models.pages.page_translation.PageTranslation
+        :type tgt_trans: ~cms.models.pages.page_translation.PageTranslation
+
         :param xliff_id: XLIFF ID
         :type xliff_id: str
+
         :return: UTF-8 encoded XML
         :rtype: str
         """
@@ -171,8 +177,10 @@ class TranslationXliffConverter: # pylint: disable=R0902
 
         :param unit_id: value for the unit id attribute
         :type unit_id: str
+
         :param source_text: source text to be translated
         :type source_text: str
+
         :param target_text: already available translation
         :type target_text: str
         """
@@ -219,9 +227,10 @@ class PageXliffHelper():
     def __init__(self, src_lang=None, tgt_lang=None):
         """
         :param src_lang: source language of translation
-        :type src_lang: cms.models.languages.language.Language
+        :type src_lang: ~cms.models.languages.language.Language
+
         :param tgt_lang: target language of translation
-        :type tgt_lang: cms.models.languages.language.Language
+        :type tgt_lang: ~cms.models.languages.language.Language
         """
         if src_lang is not None:
             self.src_lang = src_lang
@@ -235,6 +244,7 @@ class PageXliffHelper():
 
         :param content: content of file
         :type content: str
+
         :param file_path: path to newly created file
         :type file_path: str
         """
@@ -247,9 +257,10 @@ class PageXliffHelper():
         Create XLIFF file for source page translation and target language
 
         :param page: page of translation that should be exported
-        :type page: cms.models.pages.page.Page
+        :type page: ~cms.models.pages.page.Page
+
         :return: file path to XLIFF file
-        :rtype: string or None
+        :rtype: str or None
         """
         converter = TranslationXliffConverter(self.src_lang, self.tgt_lang)
 
@@ -287,6 +298,7 @@ class PageXliffHelper():
 
         :param source_file_paths: list of files to be zipped
         :type source_file_paths: list
+
         :param zip_file_path: path to zipped file
         :type zip_file_path: str
         """
@@ -302,9 +314,10 @@ class PageXliffHelper():
         Export a list of page IDs to a zip file containing XLIFFs for a specified target language
 
         :param region: region from which the XLIFFs should be exported
-        :type region: cms.models.regions.region.Region
+        :type region: ~cms.models.regions.region.Region
+
         :param pages: list of pages which should be translated
-        :type pages: list [ cms.models.pages.page.Page ]
+        :type pages: list [ ~cms.models.pages.page.Page ]
         """
         xliff_paths = []
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M")
@@ -324,6 +337,7 @@ class PageXliffHelper():
 
         :param title: title of page translation
         :type title: str
+
         :return: slug
         :rtype: str
         """
@@ -345,8 +359,10 @@ class PageXliffHelper():
 
         :param trans_fields: translated fields extracted from XLIFF file
         :type trans_fields: dict
+
         :param user: author of translations
-        :type user: django.contrib.auth.models.User
+        :type user: ~django.contrib.auth.models.User
+
         :return: failure/success for each page or overall failed
         :rtype: list or bool
         """
@@ -378,8 +394,10 @@ class PageXliffHelper():
 
         :param xliff_paths: paths to XLIFF files
         :type xliff_paths: list [ str ]
+
         :param user: author of page
         :type user: int
+
         :return: failure/success
         :rtype: bool
         """
@@ -403,6 +421,7 @@ class PageXliffHelper():
 
         :param zip_file_path: path to zip file
         :type zip_file_path: str
+
         :return: list of filenames
         :rtype: list
         """
@@ -419,6 +438,7 @@ class PageXliffHelper():
 
         :param xliff_paths: list of paths to XLIFF files
         :type xliff_paths: [ str ]
+
         :return: dictionaries containing diffs between XLIFF and current translation versions
         :rtype: list [ dict ]
         """
@@ -441,8 +461,10 @@ class PageXliffHelper():
 
         :param trans_fields: content extracted from XLIFF
         :type trans_fields: dict
+
         :param xliff_name: file name of XLIFF
         :type xliff_name: str
+
         :return: dictionary containing diff between XLIFF and current translation version
         :rtype: dict
         """

--- a/src/cms/templatetags/content_filters.py
+++ b/src/cms/templatetags/content_filters.py
@@ -18,14 +18,14 @@ def get_translation(instance, language_code):
     This tag returns the most recent translation of the requested content object in the requested language.
 
     :param instance: The content object instance
-    :type instance: Union [ ~cms.models.pages.page.Page, ~cms.models.events.event.Event, ~cms.models.pois.poi.POI ]
+    :type instance: ~cms.models.pages.page.Page, ~cms.models.events.event.Event or ~cms.models.pois.poi.POI
 
     :param language_code: The code of the requested language
     :type language_code: str
 
     :return: The translation object of the requested instance
-    :rtype: Union [ ~cms.models.pages.page_translation.PageTranslation,
-        ~cms.models.events.event_translation.EventTranslation, ~cms.models.pois.poi_translation.POITranslation ]
+    :rtype: ~cms.models.pages.page_translation.PageTranslation, ~cms.models.events.event_translation.EventTranslation,
+            or ~cms.models.pois.poi_translation.POITranslation
     """
     return instance.translations.filter(language__code=language_code).first()
 


### PR DESCRIPTION
This makes the form docstrings more consistent.

Unfortunately, the form fields for model forms are still missing because there is a bug in our dependency: edoburu/sphinxcontrib-django#27. I opened an upstream PR: edoburu/sphinxcontrib-django#28. In the case that this PR is not merged, we could think about adding a patch to our repo or installing our custom fork of sphinxcontrib-django as dependency.

Fixes #324