### PR TITLE
Improve documentation of cms urls

### DIFF
--- a/src/cms/urls.py
+++ b/src/cms/urls.py
@@ -1,4 +1,8 @@
-"""Provides routing to all submodules inside the application
+"""
+Django URL dispatcher for the cms package.
+See :mod:`backend.urls` for the other namespaces of this application.
+
+For more information on this file, see :doc:`topics/http/urls`.
 """
 from django.conf.urls import include, url
 from django.conf.urls.static import static


### PR DESCRIPTION
I think this is enough, the [standard Django docu](https://docs.djangoproject.com/en/2.2/topics/http/urls/) referenced here has covered this topic very well.

Fixes #334