### PR TITLE
Documentation improvements

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -14,8 +14,6 @@ import inspect
 import importlib
 import django
 
-from sphinx.writers.html import HTMLTranslator
-
 from backend.settings import VERSION
 
 # Append project source directory to path environment variable
@@ -35,8 +33,6 @@ def setup(app):
     """
     # Register the docstring processor with sphinx to improve the appearance of Django models
     app.connect('autodoc-process-docstring', process_django_models)
-    # Patch HTMLTranslator to open external links in new tab
-    app.set_translator('html', PatchedHTMLTranslator)
 
 
 # -- Project information -----------------------------------------------------
@@ -186,22 +182,3 @@ def linkcode_resolve(domain, info):
         except (TypeError, IOError):
             pass
     return f"https://github.com/Integreat/cms-django/blob/develop/src/{filename}.py{line_number_reference}"
-
-# -- Link targets ------------------------------------------------------------
-
-
-# pylint: disable=abstract-method
-class PatchedHTMLTranslator(HTMLTranslator):
-    """Open external links in a new tab"""
-
-    def visit_reference(self, node):
-        if (
-                node.get('newtab') or
-                not (
-                    node.get('target') or
-                    node.get('internal') or
-                    'refuri' not in node
-                )
-        ):
-            node['target'] = '_blank'
-        super().visit_reference(node)

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -110,10 +110,10 @@ def process_django_models(app, what, name, obj, options, lines):
             field_module = type(field).__module__
             if field_module == 'django.contrib.postgres.fields.array':
                 # Fix intersphinx mappings for django.contrib.postgres fields
-                type_line = f':type {field.name}: `{field_module}.ArrayField <{postgres_docu}#arrayfield>`_'
+                type_line = f':type {field.name}: `ArrayField <{postgres_docu}#arrayfield>`_'
             elif field_module == 'django.contrib.postgres.fields.jsonb':
                 # Fix intersphinx mappings for django.contrib.postgres fields
-                type_line = f':type {field.name}: `{field_module}.JSONField <{postgres_docu}#jsonfield>`_'
+                type_line = f':type {field.name}: `JSONField <{postgres_docu}#jsonfield>`_'
             elif field_module in ['django.db.models.fields.related', 'mptt.fields']:
                 # Fix intersphinx mappings for related fields (ForeignKey, OneToOneField, ManyToManyField, ...)
                 # Also includes related MPTT fields (TreeForeignKey, TreeOneToOneField, TreeManyToManyField, ...)
@@ -128,7 +128,7 @@ def process_django_models(app, what, name, obj, options, lines):
                     # Scope with django.db.models * imports (remove all sub-module-paths)
                     field_module = 'django.db.models'
                 # Fix type hint to enable correct intersphinx mappings to other documentations
-                type_line = f':type {field.name}: {field_module}.{field_type}'
+                type_line = f':type {field.name}: ~{field_module}.{field_type}'
             # This loop gets the indexes which are needed to update the type hints of the model parameters.
             # It makes it possible to split the parameter section into multiple parts, e.g. params inherited from a base
             # model and params of a sub model (otherwise the type hints would not be recognized when separated from

--- a/sphinx/templates/layout.html
+++ b/sphinx/templates/layout.html
@@ -61,4 +61,10 @@
             left: 0; top: 0;
         }
     </style>
+    <script type="text/javascript">
+        <!-- Adds target=_blank to external links -->
+        $(document).ready(function () {
+            $('a[href^="http://"], a[href^="https://"]').not('a[class*=internal]').attr('target', '_blank');
+        });
+    </script>
 {% endblock %}

--- a/src/api/v3/feedback/page_feedback.py
+++ b/src/api/v3/feedback/page_feedback.py
@@ -10,17 +10,17 @@ class FeedbackData:
     This class is a generic api representation of cms feedback incl. its meta information stored in the database.
     It is used to examine feedback sent to the feedback api endpoint.
 
-    :param page_id: The id of the page this feedback is referring to, if empty the permalink is required, defaults to None
-    :type page_id: int
+    :param page_id: The id of the page this feedback is referring to, if empty the permalink is required, defaults to ``None``
+    :type page_id: int, optional
 
-    :param permalink: The permalink of the page this feedback is referring to, is empty the page_id is required, defaults to ''
-    :type permalink: str
+    :param permalink: The permalink of the page this feedback is referring to, is empty the page_id is required, defaults to ``''``
+    :type permalink: str, optional
 
-    :param comment: The descriptive feedback string, defaults to ''
-    :type comment: int
+    :param comment: The descriptive feedback string, defaults to ``''``
+    :type comment: int, optional
 
-    :param emotion: The emotion of the feedback, can be one of ['Pos', 'Neg', 'NA'], defaults to 'NA'
-    :type emotion: int
+    :param emotion: The emotion of the feedback, can be one of ``['Pos', 'Neg', 'NA']``, defaults to ``'NA'``
+    :type emotion: int, optional
     """
 
     def __init__(self, page_id, permalink, comment, emotion):

--- a/src/api/v3/single_page.py
+++ b/src/api/v3/single_page.py
@@ -14,7 +14,7 @@ def single_page(request, region_slug, language_code):
     requested page does not exist.
 
     :param request: The request that has been sent to the Django server
-    :type request: django.http.HttpRequest
+    :type request: ~django.http.HttpRequest
 
     :param region_slug: Slug defining the region
     :type region_slug: str
@@ -22,10 +22,10 @@ def single_page(request, region_slug, language_code):
     :param language_code: Code to identify the desired language
     :type language_code: str
 
-    :raises django.http.Http404: HTTP status 404 if the request is malformed or no page with the given id or url exists.
+    :raises ~django.http.Http404: HTTP status 404 if the request is malformed or no page with the given id or url exists.
 
     :return: Return a JSON with the requested page and a HTTP status 200.
-    :rtype: django.http.JsonResponse
+    :rtype: ~django.http.JsonResponse
     """
     region = get_object_or_404(Region, slug=region_slug)
 

--- a/src/backend/context_processors.py
+++ b/src/backend/context_processors.py
@@ -11,7 +11,7 @@ def region_slug_processor(request):
     (If there is no current region, it contains all regions).
 
     :param request: The current http request
-    :type request: django.http.HttpRequest
+    :type request: ~django.http.HttpRequest
 
     :return: The current region and all other regions
     :rtype: dict

--- a/src/cms/models/events/event.py
+++ b/src/cms/models/events/event.py
@@ -52,7 +52,7 @@ class Event(models.Model):
         translation exists.
 
         :return: list of all :class:`~cms.models.languages.language.Language` an event is translated into
-        :rtype: list [ cms.models.languages.language.Language ]
+        :rtype: list [ ~cms.models.languages.language.Language ]
         """
         event_translations = self.translations.prefetch_related('language').all()
         languages = []
@@ -101,7 +101,7 @@ class Event(models.Model):
 
         :return: The event translation in the requested :class:`~cms.models.languages.language.Language` or :obj:`None`
                  if no translation exists
-        :rtype: cms.models.events.event_translation.EventTranslation
+        :rtype: ~cms.models.events.event_translation.EventTranslation
         """
         return self.translations.filter(language__code=language_code).first()
 
@@ -132,7 +132,7 @@ class Event(models.Model):
 
         :return: A :class:`~django.db.models.query.QuerySet` of either archived or not archived events in the requested
                  :class:`~cms.models.regions.region.Region`
-        :rtype: django.db.models.query.QuerySet
+        :rtype: ~django.db.models.query.QuerySet
         """
         events = cls.objects.all().prefetch_related(
             'translations'
@@ -148,13 +148,13 @@ class Event(models.Model):
         Expects ``start < end``.
 
         :param start: the begin of the requested interval.
-        :type start: datetime.datetime
+        :type start: ~datetime.datetime
 
         :param end: the end of the requested interval.
-        :type end: datetime.datetime
+        :type end: ~datetime.datetime
 
         :return: Returns start datetimes of occurrences of the event that are in the given timeframe
-        :rtype: list [ datetime.datetime ]
+        :rtype: list [ ~datetime.datetime ]
         """
         event_start = datetime.combine(
             self.start_date,
@@ -211,7 +211,7 @@ class Event(models.Model):
         :type language_code: str
 
         :return: The public translation of an event
-        :rtype: cms.models.events.event_translation.EventTranslation
+        :rtype: ~cms.models.events.event_translation.EventTranslation
         """
         return self.translations.filter(
             language__code=language_code,

--- a/src/cms/models/events/event.py
+++ b/src/cms/models/events/event.py
@@ -127,7 +127,7 @@ class Event(models.Model):
         :param region_slug: slug of the :class:`~cms.models.regions.region.Region` the event belongs to
         :type region_slug: str
 
-        :param archived: whether or not archived events should be returned
+        :param archived: whether or not archived events should be returned, defaults to ``False``
         :type archived: bool, optional
 
         :return: A :class:`~django.db.models.query.QuerySet` of either archived or not archived events in the requested

--- a/src/cms/models/events/event_translation.py
+++ b/src/cms/models/events/event_translation.py
@@ -55,7 +55,7 @@ class EventTranslation(models.Model):
         for all content types
 
         :return: The event to which the translation belongs
-        :rtype: cms.models.events.event.Event
+        :rtype: ~cms.models.events.event.Event
         """
         return self.event
 
@@ -115,7 +115,7 @@ class EventTranslation(models.Model):
         :return: The event translation in the source :class:`~cms.models.languages.language.Language` (:obj:`None` if
                  the translation is in the :class:`~cms.models.regions.region.Region`'s default
                  :class:`~cms.models.languages.language.Language`)
-        :rtype: cms.models.events.event_translation.EventTranslation
+        :rtype: ~cms.models.events.event_translation.EventTranslation
         """
         source_language_tree_node = self.event.region.language_tree_nodes.get(language=self.language).parent
         if source_language_tree_node:
@@ -129,7 +129,7 @@ class EventTranslation(models.Model):
         If the translation itself is not public, this property can return a revision which is older than ``self``.
 
         :return: The latest public revision of the translation
-        :rtype: cms.models.events.event_translation.EventTranslation
+        :rtype: ~cms.models.events.event_translation.EventTranslation
         """
         return self.event.translations.filter(
             language=self.language,
@@ -142,7 +142,7 @@ class EventTranslation(models.Model):
         This property is a link to the most recent major version of this translation.
 
         :return: The latest major revision of the translation
-        :rtype: cms.models.events.event_translation.EventTranslation
+        :rtype: ~cms.models.events.event_translation.EventTranslation
         """
         return self.event.translations.filter(
             language=self.language,
@@ -156,7 +156,7 @@ class EventTranslation(models.Model):
         This is used when translations, which are derived from this translation, check whether they are up to date.
 
         :return: The latest major public revision of the translation
-        :rtype: cms.models.events.event_translation.EventTranslation
+        :rtype: ~cms.models.events.event_translation.EventTranslation
         """
         return self.event.translations.filter(
             language=self.language,
@@ -170,7 +170,7 @@ class EventTranslation(models.Model):
         This property is a shortcut to the previous revision of this translation
 
         :return: The previous translation
-        :rtype: cms.models.events.event_translation.EventTranslation
+        :rtype: ~cms.models.events.event_translation.EventTranslation
         """
         version = self.version - 1
         return self.event.translations.filter(

--- a/src/cms/models/media/document.py
+++ b/src/cms/models/media/document.py
@@ -23,7 +23,7 @@ class Document(models.Model):
         :type using: str, optional
 
         :param keep_parents: If the model is a sub-model of another, setting ``keep_parents = True`` will keep the data
-                             in the parent database table
+                             in the parent database table, defaults to ``False``
         :type keep_parents: bool, optional
 
         :return: The number of objects deleted and a dictionary with the number of deletions per object type.

--- a/src/cms/models/offers/offer_template.py
+++ b/src/cms/models/offers/offer_template.py
@@ -19,6 +19,8 @@ class OfferTemplate(models.Model):
     :param post_data: If additional post data is required for retrieving the url, it has to be stored in this dict.
     :param use_postal_code: If and how the postal code should be injected in the url or post data (choices:
                             :mod:`cms.constants.postal_code`)
+    :param created_date: The date and time when the offer template was created
+    :param last_updated: The date and time when the offer template was last updated
 
     Reverse relationships:
 

--- a/src/cms/models/pages/page.py
+++ b/src/cms/models/pages/page.py
@@ -21,7 +21,6 @@ class Page(MPTTModel):
     :param id: The database id of the page
     :param icon: The title image of the page
     :param archived: Whether or not the page is archived
-    :param mirrored_page: If the page embeds live content from another page, it is referenced here.
     :param mirrored_page_first: If ``mirrored_page`` is not ``None``, this field determines whether the live content is
                                 embedded before the content of this page or after.
     :param created_date: The date and time when the page was created
@@ -39,6 +38,7 @@ class Page(MPTTModel):
 
     :param parent: The parent page of this page (related name: ``children``)
     :param region: The region to which the page belongs (related name: ``pages``)
+    :param mirrored_page: If the page embeds live content from another page, it is referenced here.
     :param editors: A list of users who have the permission to edit this specific page (related name:
                     ``editable_pages``). Only has effect if these users do not have the permission to edit pages anyway.
     :param publishers: A list of users who have the permission to publish this specific page (related name:
@@ -122,7 +122,7 @@ class Page(MPTTModel):
         and filters them to the first requested :class:`~cms.models.languages.language.Language` code that matches.
         So a lower list index means a higher priority.
 
-        :param language_code: A list of :class:`~cms.models.languages.language.Language` codes
+        :param language_code: A list of :class:`~cms.models.languages.language.Language` codes, defaults to ``None``
         :type language_code: list [ str ], optional
 
         :return: The first page translation which matches one of the :class:`~cms.models.languages.language.Language`
@@ -215,7 +215,7 @@ class Page(MPTTModel):
         :param region_slug: slug of the :class:`~cms.models.regions.region.Region` the page belongs to
         :type region_slug: str
 
-        :param archived: whether or not archived pages should be returned
+        :param archived: whether or not archived pages should be returned, defaults to ``False``
         :type archived: bool, optional
 
         :return: A :class:`~django.db.models.query.QuerySet` of either archived or not archived pages in the requested

--- a/src/cms/models/pages/page.py
+++ b/src/cms/models/pages/page.py
@@ -90,7 +90,7 @@ class Page(MPTTModel):
         translation exists.
 
         :return: list of all :class:`~cms.models.languages.language.Language` a page is translated into
-        :rtype: list [ cms.models.languages.language.Language ]
+        :rtype: list [ ~cms.models.languages.language.Language ]
         """
         page_translations = self.translations.prefetch_related('language').all()
         languages = []
@@ -109,7 +109,7 @@ class Page(MPTTModel):
 
         :return: The page translation in the requested :class:`~cms.models.languages.language.Language` or :obj:`None`
                  if no translation exists
-        :rtype: cms.models.pages.page_translation.PageTranslation
+        :rtype: ~cms.models.pages.page_translation.PageTranslation
         """
         return self.translations.filter(
             language__code=language_code
@@ -127,7 +127,7 @@ class Page(MPTTModel):
 
         :return: The first page translation which matches one of the :class:`~cms.models.languages.language.Language`
                  given or :obj:`None` if no translation exists
-        :rtype: cms.models.pages.page_translation.PageTranslation
+        :rtype: ~cms.models.pages.page_translation.PageTranslation
         """
         # Taking [] directly as default parameter would be dangerous because it is mutable
         if not priority_language_codes:
@@ -145,7 +145,7 @@ class Page(MPTTModel):
         :type language_code: str
 
         :return: The public translation of a page
-        :rtype: cms.models.pages.page_translation.PageTranslation
+        :rtype: ~cms.models.pages.page_translation.PageTranslation
         """
         return self.translations.filter(
             language__code=language_code,
@@ -189,7 +189,7 @@ class Page(MPTTModel):
         :type region_slug: str
 
         :return: All archived pages of this region
-        :rtype: django.db.models.query.QuerySet
+        :rtype: ~django.db.models.query.QuerySet
         """
         return Page.objects.filter(archived=True, region__slug=region_slug)
 
@@ -220,7 +220,7 @@ class Page(MPTTModel):
 
         :return: A :class:`~django.db.models.query.QuerySet` of either archived or not archived pages in the requested
                  :class:`~cms.models.regions.region.Region`
-        :rtype: django.db.models.query.QuerySet
+        :rtype: ~django.db.models.query.QuerySet
         """
         return cls.objects.all().prefetch_related(
             'translations'

--- a/src/cms/models/pages/page_translation.py
+++ b/src/cms/models/pages/page_translation.py
@@ -60,7 +60,7 @@ class PageTranslation(models.Model):
         for all content types
 
         :return: The page to which the translation belongs
-        :rtype: cms.models.pages.page.Page
+        :rtype: ~cms.models.pages.page.Page
         """
         return self.page
 
@@ -133,7 +133,7 @@ class PageTranslation(models.Model):
         :return: The page translation in the source :class:`~cms.models.languages.language.Language` (:obj:`None` if
                  the translation is in the :class:`~cms.models.regions.region.Region`'s default
                  :class:`~cms.models.languages.language.Language`)
-        :rtype: cms.models.pages.page_translation.PageTranslation
+        :rtype: ~cms.models.pages.page_translation.PageTranslation
         """
         source_language_tree_node = self.page.region.language_tree_nodes.get(language=self.language).parent
         if source_language_tree_node:
@@ -147,7 +147,7 @@ class PageTranslation(models.Model):
         If the translation itself is not public, this property can return a revision which is older than ``self``.
 
         :return: The latest public revision of the translation
-        :rtype: cms.models.pages.page_translation.PageTranslation
+        :rtype: ~cms.models.pages.page_translation.PageTranslation
         """
         return self.page.translations.filter(
             language=self.language,
@@ -160,7 +160,7 @@ class PageTranslation(models.Model):
         This property is a link to the most recent major version of this translation.
 
         :return: The latest major revision of the translation
-        :rtype: cms.models.pages.page_translation.PageTranslation
+        :rtype: ~cms.models.pages.page_translation.PageTranslation
         """
         return self.page.translations.filter(
             language=self.language,
@@ -174,7 +174,7 @@ class PageTranslation(models.Model):
         This is used when translations, which are derived from this translation, check whether they are up to date.
 
         :return: The latest major public revision of the translation
-        :rtype: cms.models.pages.page_translation.PageTranslation
+        :rtype: ~cms.models.pages.page_translation.PageTranslation
         """
         return self.page.translations.filter(
             language=self.language,
@@ -188,7 +188,7 @@ class PageTranslation(models.Model):
         This property is a shortcut to the previous revision of this translation
 
         :return: The previous translation
-        :rtype: cms.models.pages.page_translation.PageTranslation
+        :rtype: ~cms.models.pages.page_translation.PageTranslation
         """
         version = self.version - 1
         return self.page.translations.filter(
@@ -268,13 +268,13 @@ class PageTranslation(models.Model):
         a :class:`~cms.models.regions.region.Region` in a specific :class:`~cms.models.languages.language.Language`
 
         :param region_slug: The requested :class:`~cms.models.regions.region.Region`
-        :type region_slug: cms.models.regions.region.Region
+        :type region_slug: ~cms.models.regions.region.Region
 
         :param language_code: The requested :class:`~cms.models.languages.language.Language`
-        :type language_code: cms.models.languages.language.Language
+        :type language_code: ~cms.models.languages.language.Language
 
         :return: A :class:`~django.db.models.query.QuerySet` of all page translations of a region in a specific language
-        :rtype: django.db.models.query.QuerySet
+        :rtype: ~django.db.models.query.QuerySet
         """
         return cls.objects.filter(page__region=region, language=language).distinct('page')
 
@@ -285,13 +285,13 @@ class PageTranslation(models.Model):
         returns only page translations which are up to date
 
         :param region_slug: The requested :class:`~cms.models.regions.region.Region`
-        :type region_slug: cms.models.regions.region.Region
+        :type region_slug: ~cms.models.regions.region.Region
 
         :param language_code: The requested :class:`~cms.models.languages.language.Language`
-        :type language_code: cms.models.languages.language.Language
+        :type language_code: ~cms.models.languages.language.Language
 
         :return: All up to date translations of a region in a specific language
-        :rtype: list [ cms.models.pages.page_translation.PageTranslation ]
+        :rtype: list [ ~cms.models.pages.page_translation.PageTranslation ]
         """
         return [t for t in cls.objects.filter(page__region=region, language=language).distinct('page') if t.is_up_to_date]
 
@@ -302,13 +302,13 @@ class PageTranslation(models.Model):
         returns only page translations which are currently being translated by an external translator
 
         :param region_slug: The requested :class:`~cms.models.regions.region.Region`
-        :type region_slug: cms.models.regions.region.Region
+        :type region_slug: ~cms.models.regions.region.Region
 
         :param language_code: The requested :class:`~cms.models.languages.language.Language`
-        :type language_code: cms.models.languages.language.Language
+        :type language_code: ~cms.models.languages.language.Language
 
         :return: All currently translated translations of a region in a specific language
-        :rtype: list [ cms.models.pages.page_translation.PageTranslation ]
+        :rtype: list [ ~cms.models.pages.page_translation.PageTranslation ]
         """
         return [t for t in cls.objects.filter(page__region=region, language=language).distinct('page') if t.currently_in_translation]
 
@@ -319,13 +319,13 @@ class PageTranslation(models.Model):
         returns only page translations which are outdated
 
         :param region_slug: The requested :class:`~cms.models.regions.region.Region`
-        :type region_slug: cms.models.regions.region.Region
+        :type region_slug: ~cms.models.regions.region.Region
 
         :param language_code: The requested :class:`~cms.models.languages.language.Language`
-        :type language_code: cms.models.languages.language.Language
+        :type language_code: ~cms.models.languages.language.Language
 
         :return: All outdated translations of a region in a specific language
-        :rtype: list [ cms.models.pages.page_translation.PageTranslation ]
+        :rtype: list [ ~cms.models.pages.page_translation.PageTranslation ]
         """
         return [t for t in cls.objects.filter(page__region=region, language=language).distinct('page') if t.is_outdated]
 

--- a/src/cms/models/pois/poi.py
+++ b/src/cms/models/pois/poi.py
@@ -51,7 +51,7 @@ class POI(models.Model):
 
         :return: A :class:`~django.db.models.query.QuerySet` of either archived or not archived POIs in the requested
                  :class:`~cms.models.regions.region.Region`
-        :rtype: django.db.models.query.QuerySet
+        :rtype: ~django.db.models.query.QuerySet
         """
 
         return cls.objects.all().prefetch_related(
@@ -68,7 +68,7 @@ class POI(models.Model):
         translation exists.
 
         :return: list of all :class:`~cms.models.languages.language.Language` a POI is translated into
-        :rtype: list [ cms.models.languages.language.Language ]
+        :rtype: list [ ~cms.models.languages.language.Language ]
         """
         poi_translations = self.translations.prefetch_related('language').all()
         languages = []
@@ -86,7 +86,7 @@ class POI(models.Model):
 
         :return: The POI translation in the requested :class:`~cms.models.languages.language.Language` or :obj:`None`
                  if no translation exists
-        :rtype: cms.models.pois.poi_translation.POITranslation
+        :rtype: ~cms.models.pois.poi_translation.POITranslation
         """
         return self.translations.filter(
             language__code=language_code
@@ -100,7 +100,7 @@ class POI(models.Model):
         :type language_code: str
 
         :return: The public translation of a POI
-        :rtype: cms.models.pois.poi_translation.POITranslation
+        :rtype: ~cms.models.pois.poi_translation.POITranslation
         """
         return self.translations.filter(
             language__code=language_code,

--- a/src/cms/models/pois/poi.py
+++ b/src/cms/models/pois/poi.py
@@ -46,7 +46,7 @@ class POI(models.Model):
         :param region_slug: slug of the :class:`~cms.models.regions.region.Region` the POI belongs to
         :type region_slug: str
 
-        :param archived: whether or not archived POIs should be returned
+        :param archived: whether or not archived POIs should be returned, defaults to ``False``
         :type archived: bool, optional
 
         :return: A :class:`~django.db.models.query.QuerySet` of either archived or not archived POIs in the requested

--- a/src/cms/models/pois/poi_translation.py
+++ b/src/cms/models/pois/poi_translation.py
@@ -57,7 +57,7 @@ class POITranslation(models.Model):
         for all content types
 
         :return: The POI to which the translation belongs
-        :rtype: cms.models.pois.poi.POI
+        :rtype: ~cms.models.pois.poi.POI
         """
         return self.poi
 
@@ -117,7 +117,7 @@ class POITranslation(models.Model):
         :return: The POI translation in the source :class:`~cms.models.languages.language.Language` (:obj:`None` if
                  the translation is in the :class:`~cms.models.regions.region.Region`'s default
                  :class:`~cms.models.languages.language.Language`)
-        :rtype: cms.models.pois.poi_translation.POITranslation
+        :rtype: ~cms.models.pois.poi_translation.POITranslation
         """
         source_language_tree_node = self.poi.region.language_tree_nodes.get(language=self.language).parent
         if source_language_tree_node:
@@ -131,7 +131,7 @@ class POITranslation(models.Model):
         If the translation itself is not public, this property can return a revision which is older than ``self``.
 
         :return: The latest public revision of the translation
-        :rtype: cms.models.pois.poi_translation.POITranslation
+        :rtype: ~cms.models.pois.poi_translation.POITranslation
         """
         return self.poi.translations.filter(
             language=self.language,
@@ -144,7 +144,7 @@ class POITranslation(models.Model):
         This property is a link to the most recent major version of this translation.
 
         :return: The latest major revision of the translation
-        :rtype: cms.models.pois.poi_translation.POITranslation
+        :rtype: ~cms.models.pois.poi_translation.POITranslation
         """
         return self.poi.translations.filter(
             language=self.language,
@@ -158,7 +158,7 @@ class POITranslation(models.Model):
         This is used when translations, which are derived from this translation, check whether they are up to date.
 
         :return: The latest major public revision of the translation
-        :rtype: cms.models.pois.poi_translation.POITranslation
+        :rtype: ~cms.models.pois.poi_translation.POITranslation
         """
         return self.poi.translations.filter(
             language=self.language,
@@ -172,7 +172,7 @@ class POITranslation(models.Model):
         This property is a shortcut to the previous revision of this translation
 
         :return: The previous translation
-        :rtype: cms.models.pois.poi_translation.POITranslation
+        :rtype: ~cms.models.pois.poi_translation.POITranslation
         """
         version = self.version - 1
         return self.poi.translations.filter(

--- a/src/cms/models/regions/region.py
+++ b/src/cms/models/regions/region.py
@@ -90,7 +90,7 @@ class Region(models.Model):
         :class:`~cms.models.languages.language_tree_node.LanguageTreeNode` which belongs to this region.
 
         :return: A list of all :class:`~cms.models.languages.language.Language` object instances of a region
-        :rtype: list [ cms.models.languages.language.Language ]
+        :rtype: list [ ~cms.models.languages.language.Language ]
         """
         language_tree_nodes = self.language_tree_nodes.select_related('language').all()
         return [language_tree_node.language for language_tree_node in language_tree_nodes]
@@ -102,7 +102,7 @@ class Region(models.Model):
         root :class:`~cms.models.languages.language_tree_node.LanguageTreeNode` of this region.
 
         :return: The root :class:`~cms.models.languages.language.Language` of a region
-        :rtype: cms.models.languages.language.Language
+        :rtype: ~cms.models.languages.language.Language
         """
         tree_root = self.language_tree_nodes.filter(level=0).first()
         return tree_root.language if tree_root else None
@@ -114,7 +114,7 @@ class Region(models.Model):
         :func:`backend.context_processors.region_slug_processor`
 
         :return: The root :class:`~cms.models.languages.language.Language` of a region
-        :rtype: cms.models.languages.language.Language
+        :rtype: ~cms.models.languages.language.Language
         """
         # if rendered url is edit_region, the region slug originates from the region form.
         if not hasattr(request, 'resolver_match') or request.resolver_match.url_name == 'edit_region':

--- a/src/cms/utils/file_utils.py
+++ b/src/cms/utils/file_utils.py
@@ -13,7 +13,7 @@ def save_file(request):
     Example usage: :class:`cms.views.media.media_edit_view.MediaEditView`
 
     :param request: The current request submitting the file(s)
-    :type request: django.http.HttpRequest
+    :type request: ~django.http.HttpRequest
 
     :return: A dictionary containing the :class:`~cms.forms.media.document_form.DocumentForm` object and the boolean return status
     :rtype: dict

--- a/src/cms/utils/slug_utils.py
+++ b/src/cms/utils/slug_utils.py
@@ -27,11 +27,11 @@ def generate_unique_slug(form_object, foreign_model):
     * :func:`cms.forms.pois.poi_translation_form.POITranslationForm.clean_slug`
 
     :param form_object: The form which contains the slug field
-    :type form_object: django.forms.Form
+    :type form_object: ~django.forms.Form
 
     :param foreign_model: If the form instance has a foreign key to another model (e.g. because it is a translation of
                           a content-object), this paramaeter contains the model of the foreign related object.
-    :type foreign_model: django.db.models.Model
+    :type foreign_model: ~django.db.models.Model
 
     :return: An unique slug identifier
     :rtype: str

--- a/src/gvz_api/utils.py
+++ b/src/gvz_api/utils.py
@@ -121,8 +121,8 @@ class GvzApiWrapper():
         :param region_name: name of a region (city name, county name, etc)
         :type region_name: str
 
-        :param region_type: administrative division type of region (choices: :mod:`cms.constants.administrative_division`), defaults to None
-        :type region_type: str
+        :param region_type: administrative division type of region (choices: :mod:`cms.constants.administrative_division`), defaults to ``None``
+        :type region_type: str, optional
 
         :return: JSON search results defined in the GVZ API
         :rtype: str
@@ -166,14 +166,14 @@ class GvzRegion():
     Represents a region in the GVZ, initial values will be retrieved
     from API on initialization.
 
-    :param region_key: official ID for a region, i.e. Gemeindeschlüssel, defaults to None
-    :type region_key: str
+    :param region_key: official ID for a region, i.e. Gemeindeschlüssel, defaults to ``None``
+    :type region_key: str, optional
 
-    :param region_name: name of a region (city name, county name, etc), defaults to None
-    :type region_name: str
+    :param region_name: name of a region (city name, county name, etc), defaults to ``None``
+    :type region_name: str, optional
 
-    :param region_type: administrative division type of region (choices: :mod:`cms.constants.administrative_division`), defaults to None
-    :type region_type: str
+    :param region_type: administrative division type of region (choices: :mod:`cms.constants.administrative_division`), defaults to ``None``
+    :type region_type: str, optional
     """
 
     def __init__(self, region_key=None, region_name=None, region_type=None):

--- a/src/gvz_api/utils.py
+++ b/src/gvz_api/utils.py
@@ -86,8 +86,8 @@ class GvzApiWrapper():
         :param region_type: type of a region
         :type region_type: str
 
-        :return: administrative division of the region
-        :rtype: cms.constants.administrative_division
+        :return: administrative division of the region (choices: :mod:`cms.constants.administrative_division`)
+        :rtype: str
         """
         if region_type in ("Stadt", "Kreisfreie Stadt"):
             return administrative_division.CITY
@@ -121,8 +121,8 @@ class GvzApiWrapper():
         :param region_name: name of a region (city name, county name, etc)
         :type region_name: str
 
-        :param region_type: administrative division type of region, defaults to None
-        :type region_type: cms.constants.administrative_division
+        :param region_type: administrative division type of region (choices: :mod:`cms.constants.administrative_division`), defaults to None
+        :type region_type: str
 
         :return: JSON search results defined in the GVZ API
         :rtype: str
@@ -172,8 +172,8 @@ class GvzRegion():
     :param region_name: name of a region (city name, county name, etc), defaults to None
     :type region_name: str
 
-    :param region_type: administrative division type of region, defaults to None
-    :type region_type: cms.constants.administrative_division
+    :param region_type: administrative division type of region (choices: :mod:`cms.constants.administrative_division`), defaults to None
+    :type region_type: str
     """
 
     def __init__(self, region_key=None, region_name=None, region_type=None):


### PR DESCRIPTION
This is a collection of small documentation improvements where I didn't open an issue for every tiny detail.
Parts of these changes are very opinionated, so they are not necessary required changes.

- Use js instead of sphinx patch to open links in new tab

    This makes is easier to keep up with upstream changes of sphinx and the rtd theme.
    Additionally, it fixes some ugly borders around parameter lists.

- Fix parameter type of administrative division

    `cms.constants.administrative_division` is a module of string constants and not a valid parameter type.

- Hide module path of return types

    This makes the type hints more readable in my opinion.

- Minor improvements

    - Add missing offer template parameters
    - Move `Page.mirrored_page` to relationship fields
    - Add default values of optional parameters and vice versa

