### PR TITLE
Add logging for log in/out to syslog, fixes #321

### DIFF
--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -184,9 +184,33 @@ FILER_CANONICAL_URL = 'media/'
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
+    'formatters': {
+        'default': {
+            'format': 'INTEGREAT CMS - %(levelname)s: %(message)s',
+        },
+        'console': {
+            'format': '%(asctime)s INTEGREAT CMS - %(levelname)s: %(message)s',
+            'datefmt': '%b %d %H:%M:%S',
+        }
+    },
     'handlers': {
         'console': {
-            'class': 'logging.StreamHandler'
+            'class': 'logging.StreamHandler',
+            'formatter': 'console'
+        },
+        'authlog': {
+            'level': 'INFO',
+            'class': 'logging.handlers.SysLogHandler',
+            'address': '/dev/log',
+            'facility': 'auth',
+            'formatter': 'default',
+        },
+        'syslog': {
+            'level': 'INFO',
+            'class': 'logging.handlers.SysLogHandler',
+            'address': '/dev/log',
+            'facility': 'syslog',
+            'formatter': 'default',
         },
     },
     'loggers': {
@@ -209,6 +233,10 @@ LOGGING = {
             'handlers': ['console'],
             'level': 'DEBUG',
             'propagate': True,
+        },
+        'auth': {
+            'handlers': ['console', 'authlog', 'syslog'],
+            'level': 'INFO',
         },
     }
 }

--- a/src/cms/apps.py
+++ b/src/cms/apps.py
@@ -1,7 +1,10 @@
 import logging
 import sys
+
 from django.conf import settings
 from django.apps import AppConfig
+from django.contrib.auth.signals import user_logged_in, user_logged_out, user_login_failed
+from django.dispatch import receiver
 
 logger = logging.getLogger(__name__)
 
@@ -27,3 +30,21 @@ class CmsConfig(AppConfig):
         if settings.SECRET_KEY == '-!v282$zj815_q@htaxcubylo)(l%a+k*-xi78hw*#s2@i86@_' and not settings.DEBUG:
             logger.error("You are running the Integreat CMS in production mode. Change the SECRET_KEY in the settings.py!")
             sys.exit(1)
+
+
+authlog = logging.getLogger("auth")
+
+@receiver(user_logged_in)
+def user_logged_in_callback(sender, request, user, **kwargs):  # pylint: disable=unused-argument
+    ip = request.META.get('REMOTE_ADDR')
+    authlog.info('login user=%s, ip=%s', user, ip)
+
+@receiver(user_logged_out)
+def user_logged_out_callback(sender, request, user, **kwargs):  # pylint: disable=unused-argument
+    ip = request.META.get('REMOTE_ADDR')
+    authlog.info('logout user=%s, ip=%s', user, ip)
+
+@receiver(user_login_failed)
+def user_login_failed_callback(sender, credentials, request, **kwargs):  # pylint: disable=unused-argument
+    ip = request.META.get('REMOTE_ADDR')
+    authlog.warning('login failed user=%s, ip=%s', credentials['username'], ip)


### PR DESCRIPTION
Add handler for authentication syslog and add messages for log in (attempts) and log out of users.

Creates messages like
```
Jul 29 16:28:36 INTEGREAT CMS - WARNING: login failed user=asdf, ip=127.0.0.1
Jul 29 16:29:08 INTEGREAT CMS - INFO: login user=root, ip=127.0.0.1
Jul 29 16:29:10 INTEGREAT CMS - INFO: logout user=root, ip=127.0.0.1
```


Missing:
* Verify that it actually logs to syslog