### PR TITLE
Page order in page form

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-03 14:06+0000\n"
+"POT-Creation-Date: 2020-09-03 14:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -321,11 +321,11 @@ msgstr ""
 "Diese Quell-Sprache gehört zu einer anderen Region. Bitte geben Sie eine "
 "Quell-Sprache dieser Region ein."
 
-#: forms/pages/page_form.py:69
+#: forms/pages/page_form.py:111
 msgid "Embed mirrored page before this page"
 msgstr "Gespiegelte Seite vor dieser Seite einbinden"
 
-#: forms/pages/page_form.py:70
+#: forms/pages/page_form.py:112
 msgid "Embed mirrored page after this page"
 msgstr "Gespiegelte Seite nach dieser Seite einbinden"
 
@@ -492,8 +492,8 @@ msgstr "Aktuelle Übersetzungen"
 #: templates/analytics/translation_coverage.html:46
 #: templates/events/event_form.html:92 templates/events/event_form.html:121
 #: templates/events/event_list_archived_row.html:54
-#: templates/events/event_list_row.html:54 templates/pages/page_form.html:96
-#: templates/pages/page_form.html:125 templates/pages/page_sbs.html:65
+#: templates/events/event_list_row.html:54 templates/pages/page_form.html:95
+#: templates/pages/page_form.html:124 templates/pages/page_sbs.html:65
 #: templates/pages/page_sbs.html:124
 #: templates/pages/page_tree_archived_node.html:59
 #: templates/pages/page_tree_node.html:54 templates/pois/poi_form.html:83
@@ -723,7 +723,7 @@ msgstr "Event \"%(event_title)s\" bearbeiten"
 #: templates/events/event_list.html:55
 #: templates/events/event_list_archived.html:25
 #: templates/events/event_list_archived.html:31
-#: templates/pages/page_form.html:54 templates/pages/page_tree.html:61
+#: templates/pages/page_form.html:53 templates/pages/page_tree.html:61
 #: templates/pages/page_tree.html:67 templates/pages/page_tree_archived.html:33
 #: templates/pages/page_tree_archived.html:39 templates/pois/poi_form.html:51
 #: templates/pois/poi_list.html:50 templates/pois/poi_list.html:56
@@ -740,25 +740,25 @@ msgstr "Neue Event-Übersetzung erstellen"
 msgid "Create new event"
 msgstr "Veranstaltung erstellen"
 
-#: templates/events/event_form.html:67 templates/pages/page_form.html:69
+#: templates/events/event_form.html:67 templates/pages/page_form.html:68
 #: templates/pages/page_sbs.html:42 templates/pois/poi_form.html:64
 msgid "Save as draft"
 msgstr "Als Entwurf speichern"
 
-#: templates/events/event_form.html:70 templates/pages/page_form.html:73
+#: templates/events/event_form.html:70 templates/pages/page_form.html:72
 #: templates/pages/page_sbs.html:46 templates/pois/poi_form.html:65
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: templates/events/event_form.html:72 templates/pages/page_form.html:75
+#: templates/events/event_form.html:72 templates/pages/page_form.html:74
 #: templates/pages/page_sbs.html:48
 msgid "Submit for review"
 msgstr "Zur Überprüfung vorlegen"
 
 #: templates/events/event_form.html:88 templates/events/event_form.html:117
 #: templates/events/event_list_archived_row.html:58
-#: templates/events/event_list_row.html:58 templates/pages/page_form.html:92
-#: templates/pages/page_form.html:121 templates/pages/page_sbs.html:61
+#: templates/events/event_list_row.html:58 templates/pages/page_form.html:91
+#: templates/pages/page_form.html:120 templates/pages/page_sbs.html:61
 #: templates/pages/page_sbs.html:120
 #: templates/pages/page_tree_archived_node.html:63
 #: templates/pages/page_tree_node.html:58 templates/pois/poi_form.html:79
@@ -768,8 +768,8 @@ msgstr "Übersetzung ist veraltet"
 
 #: templates/events/event_form.html:96 templates/events/event_form.html:125
 #: templates/events/event_list_archived_row.html:62
-#: templates/events/event_list_row.html:62 templates/pages/page_form.html:100
-#: templates/pages/page_form.html:129 templates/pages/page_sbs.html:69
+#: templates/events/event_list_row.html:62 templates/pages/page_form.html:99
+#: templates/pages/page_form.html:128 templates/pages/page_sbs.html:69
 #: templates/pages/page_sbs.html:128
 #: templates/pages/page_tree_archived_node.html:67
 #: templates/pages/page_tree_node.html:62 templates/pois/poi_form.html:87
@@ -779,22 +779,22 @@ msgstr "Übersetzung ist aktuell"
 
 #: templates/events/event_form.html:101 templates/events/event_form.html:130
 #: templates/events/event_list_archived_row.html:67
-#: templates/events/event_list_row.html:67 templates/pages/page_form.html:105
-#: templates/pages/page_form.html:134
+#: templates/events/event_list_row.html:67 templates/pages/page_form.html:104
+#: templates/pages/page_form.html:133
 #: templates/pages/page_tree_archived_node.html:72
 #: templates/pages/page_tree_node.html:67 templates/pois/poi_form.html:92
 #: templates/pois/poi_form.html:121 templates/pois/poi_list_row.html:66
 msgid "Translation missing"
 msgstr "Übersetzung fehlt"
 
-#: templates/events/event_form.html:106 templates/pages/page_form.html:110
+#: templates/events/event_form.html:106 templates/pages/page_form.html:109
 #: templates/pages/page_sbs.html:133 templates/pois/poi_form.html:97
 msgid "Create Translation"
 msgstr "Übersetzung erstellen"
 
 #: templates/events/event_form.html:145 templates/events/event_list.html:47
 #: templates/events/event_list_archived.html:23
-#: templates/pages/page_form.html:149 templates/pages/page_sbs.html:79
+#: templates/pages/page_form.html:148 templates/pages/page_sbs.html:79
 #: templates/pages/page_sbs.html:146 templates/pages/page_sbs.html:151
 #: templates/pages/page_tree_archived.html:31 templates/pois/poi_form.html:136
 #: templates/pois/poi_list.html:48 templates/pois/poi_list_archived.html:31
@@ -803,7 +803,7 @@ msgstr "Version"
 
 #: templates/events/event_form.html:147 templates/events/event_list.html:48
 #: templates/events/event_list_archived.html:24
-#: templates/pages/page_form.html:151 templates/pages/page_sbs.html:81
+#: templates/pages/page_form.html:150 templates/pages/page_sbs.html:81
 #: templates/pages/page_sbs.html:148 templates/pages/page_sbs.html:153
 #: templates/pages/page_tree.html:60 templates/pages/page_tree_archived.html:32
 #: templates/pois/poi_form.html:138 templates/pois/poi_list.html:49
@@ -812,20 +812,20 @@ msgstr "Version"
 msgid "Status"
 msgstr "Status"
 
-#: templates/events/event_form.html:150 templates/pages/page_form.html:154
+#: templates/events/event_form.html:150 templates/pages/page_form.html:153
 #: templates/pages/page_sbs.html:83 templates/pages/page_sbs.html:156
 #: templates/pois/poi_form.html:141 templates/regions/region_form.html:53
 msgid "Permalink"
 msgstr "Permalink"
 
-#: templates/events/event_form.html:152 templates/pages/page_form.html:156
+#: templates/events/event_form.html:152 templates/pages/page_form.html:155
 #: templates/pages/page_sbs.html:158 templates/regions/region_form.html:55
 msgid " Leave blank to generate unique permalink from title"
 msgstr ""
 " Dieses Feld freilassen, um eine eindeutigen Permalink aus dem Titel zu "
 "generieren"
 
-#: templates/events/event_form.html:163 templates/pages/page_form.html:167
+#: templates/events/event_form.html:163 templates/pages/page_form.html:166
 #: templates/pages/page_sbs.html:97 templates/pages/page_sbs.html:169
 #: templates/pages/page_xliff_confirm.html:43 templates/pois/poi_form.html:151
 #: templates/push_notifications/push_notification_form.html:49
@@ -833,7 +833,7 @@ msgstr ""
 msgid "Title"
 msgstr "Titel"
 
-#: templates/events/event_form.html:164 templates/pages/page_form.html:168
+#: templates/events/event_form.html:164 templates/pages/page_form.html:167
 #: templates/pages/page_sbs.html:170 templates/pois/poi_form.html:152
 msgid "Insert title here"
 msgstr "Titel hier eingeben"
@@ -846,17 +846,17 @@ msgstr "Beschreibung"
 msgid "Insert description here"
 msgstr "Beschreibung hier eingeben"
 
-#: templates/events/event_form.html:169 templates/pages/page_form.html:173
+#: templates/events/event_form.html:169 templates/pages/page_form.html:172
 #: templates/pages/page_sbs.html:175 templates/pois/poi_form.html:159
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
 
-#: templates/events/event_form.html:171 templates/pages/page_form.html:175
+#: templates/events/event_form.html:171 templates/pages/page_form.html:174
 #: templates/pages/page_sbs.html:177 templates/pois/poi_form.html:161
 msgid "This change does not require an update of the translations"
 msgstr "Diese Änderung erfordert keine angepasste Übersetzung"
 
-#: templates/events/event_form.html:181 templates/pages/page_form.html:217
+#: templates/events/event_form.html:181 templates/pages/page_form.html:216
 #: templates/pois/poi_form.html:171
 msgid "Settings for all translations"
 msgstr "Einstellungen für alle Übersetzungen"
@@ -954,14 +954,14 @@ msgstr "Land"
 msgid "Map"
 msgstr "Karte"
 
-#: templates/events/event_form.html:287 templates/pages/page_form.html:265
+#: templates/events/event_form.html:287 templates/pages/page_form.html:266
 #: templates/pois/poi_form.html:203 templates/regions/region_form.html:80
 msgid "Icon"
 msgstr "Icon"
 
 #: templates/events/event_form.html:291
 #: templates/organizations/organization_form.html:65
-#: templates/pages/page_form.html:269 templates/pois/poi_form.html:207
+#: templates/pages/page_form.html:270 templates/pois/poi_form.html:207
 #: templates/regions/region_form.html:89
 msgid "Set icon"
 msgstr "Icon festlegen"
@@ -994,37 +994,37 @@ msgstr "Veranstaltung löschen"
 msgid "Delete this event"
 msgstr "Diese Veranstaltung löschen"
 
-#: templates/events/event_form.html:423 templates/pages/page_form.html:362
+#: templates/events/event_form.html:423 templates/pages/page_form.html:367
 #: templates/pages/page_sbs.html:215 templates/pois/poi_form.html:271
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
-#: templates/events/event_form.html:442 templates/pages/page_form.html:381
+#: templates/events/event_form.html:442 templates/pages/page_form.html:386
 #: templates/pages/page_sbs.html:234 templates/pois/poi_form.html:290
 msgid "Location"
 msgstr "Ort"
 
-#: templates/events/event_form.html:449 templates/pages/page_form.html:388
+#: templates/events/event_form.html:449 templates/pages/page_form.html:393
 #: templates/pages/page_sbs.html:241 templates/pois/poi_form.html:297
 msgid "Link"
 msgstr "Link"
 
-#: templates/events/event_form.html:456 templates/pages/page_form.html:395
+#: templates/events/event_form.html:456 templates/pages/page_form.html:400
 #: templates/pages/page_sbs.html:248 templates/pois/poi_form.html:304
 msgid "Phone"
 msgstr "Telefon"
 
-#: templates/events/event_form.html:463 templates/pages/page_form.html:402
+#: templates/events/event_form.html:463 templates/pages/page_form.html:407
 #: templates/pages/page_sbs.html:255 templates/pois/poi_form.html:311
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
-#: templates/events/event_form.html:470 templates/pages/page_form.html:409
+#: templates/events/event_form.html:470 templates/pages/page_form.html:414
 #: templates/pages/page_sbs.html:262 templates/pois/poi_form.html:318
 msgid "Email"
 msgstr "Email"
 
-#: templates/events/event_form.html:477 templates/pages/page_form.html:416
+#: templates/events/event_form.html:477 templates/pages/page_form.html:421
 #: templates/pages/page_sbs.html:269 templates/pois/poi_form.html:325
 msgid "Hint"
 msgstr "Tipp"
@@ -1396,6 +1396,10 @@ msgstr "Vorschaubild"
 msgid "No organizations available yet."
 msgstr "Noch keine Organisationen vorhanden."
 
+#: templates/pages/_page_order_table.html:48
+msgid "New Page"
+msgstr "Neue Seite"
+
 #: templates/pages/_page_permission_table.html:29
 msgid "Editors"
 msgstr "Bearbeiter"
@@ -1457,62 +1461,62 @@ msgstr "Alle Übersetzungen dieser Seite werden wiederhergestellt."
 msgid "Yes, restore this page now."
 msgstr "Ja, die Seite wiederherstellen."
 
-#: templates/pages/page_form.html:47
+#: templates/pages/page_form.html:46
 #, python-format
 msgid "Edit page \"%(page_title)s\""
 msgstr "Seite \"%(page_title)s\" bearbeiten"
 
-#: templates/pages/page_form.html:58
+#: templates/pages/page_form.html:57
 msgid "Create new translation"
 msgstr "Neue Übersetzung erstellen"
 
-#: templates/pages/page_form.html:61
+#: templates/pages/page_form.html:60
 msgid "Create new page"
 msgstr "Neue Seite erstellen"
 
-#: templates/pages/page_form.html:170 templates/pages/page_sbs.html:100
+#: templates/pages/page_form.html:169 templates/pages/page_sbs.html:100
 #: templates/pages/page_sbs.html:172 templates/pages/page_xliff_confirm.html:45
 #: templates/push_notifications/push_notification_form.html:54
 msgid "Content"
 msgstr "Inhalt"
 
-#: templates/pages/page_form.html:171 templates/pages/page_sbs.html:173
+#: templates/pages/page_form.html:170 templates/pages/page_sbs.html:173
 msgid "Insert content here"
 msgstr "Inhalt hier eingeben"
 
-#: templates/pages/page_form.html:186
+#: templates/pages/page_form.html:185
 msgid "Side-by-Side view"
 msgstr "Side-by-Side-Ansicht"
 
-#: templates/pages/page_form.html:193
+#: templates/pages/page_form.html:192
 msgid "Direction of translation"
 msgstr "Übersetzungsrichtung"
 
-#: templates/pages/page_form.html:207
+#: templates/pages/page_form.html:206
 msgid "Show translations side by side"
 msgstr "Übersetzungen nebeneinander anzeigen"
 
-#: templates/pages/page_form.html:224
+#: templates/pages/page_form.html:223
 msgid "Positioning"
 msgstr "Anordnung"
 
-#: templates/pages/page_form.html:225
-msgid "Relationship"
-msgstr "Verhältnis"
+#: templates/pages/page_form.html:224
+msgid "Parent Page"
+msgstr "Übergeordnete Seite"
 
-#: templates/pages/page_form.html:229
-msgid "Page"
-msgstr "Seite"
+#: templates/pages/page_form.html:233
+msgid "Order"
+msgstr "Reihenfolge"
 
-#: templates/pages/page_form.html:237
+#: templates/pages/page_form.html:238
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: templates/pages/page_form.html:258
+#: templates/pages/page_form.html:259
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: templates/pages/page_form.html:259
+#: templates/pages/page_form.html:260
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -1520,37 +1524,37 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: templates/pages/page_form.html:276 templates/pages/page_form.html:277
+#: templates/pages/page_form.html:277 templates/pages/page_form.html:278
 #: templates/pages/page_tree_archived_node.html:87
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
-#: templates/pages/page_form.html:278
+#: templates/pages/page_form.html:279
 msgid "Restore this page"
 msgstr "Diese Seite wiederherstellen"
 
-#: templates/pages/page_form.html:281 templates/pages/page_form.html:282
+#: templates/pages/page_form.html:282 templates/pages/page_form.html:283
 #: templates/pages/page_tree_node.html:91
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: templates/pages/page_form.html:284
+#: templates/pages/page_form.html:285
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: templates/pages/page_form.html:290 templates/pages/page_form.html:294
+#: templates/pages/page_form.html:291 templates/pages/page_form.html:295
 #: templates/pages/page_tree_archived_node.html:96
 #: templates/pages/page_tree_node.html:100
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: templates/pages/page_form.html:292
+#: templates/pages/page_form.html:293
 #: templates/pages/page_tree_archived_node.html:92
 #: templates/pages/page_tree_node.html:96 views/pages/page_actions.py:85
 msgid "You cannot delete a page which has children."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: templates/pages/page_form.html:296
+#: templates/pages/page_form.html:297
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
@@ -2505,7 +2509,7 @@ msgstr ""
 "Sie können diese Veranstaltung nicht bearbeiten, weil sie archiviert ist."
 
 #: views/events/event_view.py:141 views/pages/page_sbs_view.py:150
-#: views/pages/page_view.py:146 views/pois/poi_view.py:104
+#: views/pages/page_view.py:161 views/pois/poi_view.py:104
 #: views/regions/region_view.py:46 views/settings/user_settings_view.py:51
 #: views/settings/user_settings_view.py:68 views/users/region_user_view.py:83
 #: views/users/user_view.py:74
@@ -2560,7 +2564,7 @@ msgstr "Sprach-Baum wurde erfolgreich erstellt."
 #: views/language_tree/language_tree_node_view.py:77
 #: views/offer_templates/offer_template_view.py:49
 #: views/organizations/organization_view.py:47 views/pages/page_sbs_view.py:148
-#: views/pages/page_view.py:129
+#: views/pages/page_view.py:143
 #: views/push_notifications/push_notification_view.py:152
 #: views/regions/region_view.py:40 views/roles/role_view.py:46
 #: views/users/region_user_view.py:86 views/users/user_view.py:84
@@ -2686,19 +2690,19 @@ msgstr ""
 "Sie können die Side-by-Side-Ansicht nicht verwenden, wenn die Quell-"
 "Übersetzung (in diesem Fall {source_language}) nicht existiert."
 
-#: views/pages/page_sbs_view.py:158 views/pages/page_view.py:176
+#: views/pages/page_sbs_view.py:158 views/pages/page_view.py:192
 msgid "Translation was successfully created and published."
 msgstr "Übersetzung wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/pages/page_sbs_view.py:162 views/pages/page_view.py:179
+#: views/pages/page_sbs_view.py:162 views/pages/page_view.py:195
 msgid "Translation was successfully created."
 msgstr "Übersetzung wurde erfolgreich erstellt."
 
-#: views/pages/page_sbs_view.py:167 views/pages/page_view.py:182
+#: views/pages/page_sbs_view.py:167 views/pages/page_view.py:198
 msgid "Translation was successfully published."
 msgstr "Übersetzung wurde erfolgreich veröffentlicht."
 
-#: views/pages/page_sbs_view.py:170 views/pages/page_view.py:184
+#: views/pages/page_sbs_view.py:170 views/pages/page_view.py:200
 msgid "Translation was successfully saved."
 msgstr "Übersetzung wurde erfolgreich gespeichert."
 
@@ -2726,15 +2730,15 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um diese Seite zu bearbeiten, aber "
 "Sie können Änderungen vornehmen und diese zur Überprüfung vorlegen."
 
-#: views/pages/page_view.py:169
+#: views/pages/page_view.py:185
 msgid "Page was successfully created and published."
 msgstr "Seite wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/pages/page_view.py:172
+#: views/pages/page_view.py:188
 msgid "Page was successfully created."
 msgstr "Seite wurde erfolgreich erstellt."
 
-#: views/pages/page_view.py:221
+#: views/pages/page_view.py:237
 #, python-brace-format
 msgid "{source_language} to {target_language}"
 msgstr "{source_language} nach {target_language}"
@@ -2887,6 +2891,12 @@ msgstr ""
 "Ein Benutzer muss entweder Mitarbeiter/Super-Administrator sein, oder "
 "mindestens einer Region zugewiesen sein."
 
+#~ msgid "Relationship"
+#~ msgstr "Verhältnis"
+
+#~ msgid "Page"
+#~ msgstr "Seite"
+
 #~ msgid "Download page"
 #~ msgstr "Seite herunterladen"
 
@@ -2896,6 +2906,7 @@ msgstr ""
 #~ msgid "WebApp-URL"
 #~ msgstr "WebApp-URL"
 
+#~| msgid "Export"
 #~ msgid "Export XLIFF"
 #~ msgstr "XLIFF Exportieren"
 
@@ -3056,12 +3067,6 @@ msgstr ""
 
 #~ msgid "Turkish"
 #~ msgstr "Türkisch"
-
-#~ msgid "Parent page"
-#~ msgstr "Übergeordnete Seite"
-
-#~ msgid "Order"
-#~ msgstr "Reihenfolge"
 
 #~ msgid "Integreat CMS"
 #~ msgstr "Integreat CMS"

--- a/src/cms/models/pages/page.py
+++ b/src/cms/models/pages/page.py
@@ -97,6 +97,24 @@ class Page(MPTTModel):
                 languages.append(page_translation.language)
         return languages
 
+    def get_previous_sibling(self, *filter_args, **filter_kwargs):
+        # Only consider siblings from this region
+        filter_kwargs["region"] = self.region
+        return super(Page, self).get_previous_sibling(*filter_args, **filter_kwargs)
+
+    def get_next_sibling(self, *filter_args, **filter_kwargs):
+        # Only consider siblings from this region
+        filter_kwargs["region"] = self.region
+        return super(Page, self).get_next_sibling(*filter_args, **filter_kwargs)
+
+    def get_siblings(self, include_self=False):
+        # Return only siblings from the same region
+        return (
+            super(Page, self)
+            .get_siblings(include_self=include_self)
+            .filter(region=self.region)
+        )
+
     def get_translation(self, language_code):
         """
         This function uses the reverse foreign key ``self.translations`` to get all translations of ``self``

--- a/src/cms/static/css/style.less
+++ b/src/cms/static/css/style.less
@@ -220,7 +220,7 @@ h2.heading {
 
             &.level-1 {
                 > td:first-child {
-                    padding-left: 11px;
+                    padding-left: 22px;
                 }
             }
 
@@ -251,6 +251,23 @@ h2.heading {
             td.min, th.min {
                 width: 1%;
                 white-space: nowrap;
+            }
+        }
+    }
+}
+
+#page_order_table .table-listing {
+    table {
+        tr {
+            &:not(.drop-between) td {
+                height: 38px;
+            }
+            td:first-child {
+                > span {
+                    svg {
+                        left: 0.5rem;
+                    }
+                }
             }
         }
     }

--- a/src/cms/static/js/pages/page_order.js
+++ b/src/cms/static/js/pages/page_order.js
@@ -1,0 +1,131 @@
+// Event handler for changing the parent page option
+u('#parent').on('change', get_page_order_table);
+
+// This function updates the page order table each time the parent select changes
+function get_page_order_table(event) {
+    // Get selected option node
+    let selected_option = u('#parent').children('option[value="' + event.target.value + '"]');
+    // Fetch page order table
+    fetch(selected_option.data('url')).then(function (response) {
+        if (response.ok) {
+            return response.text();
+        }
+        throw new Error(response.statusText);
+    }).then(function (html) {
+        // Load new page order table
+        u('#page_order_table').html(html);
+        // Check if the page is part of the parent's children
+        let page_contained_in_siblings = u('.drag').data('contained-in-siblings');
+        if (page_contained_in_siblings) {
+            // Reset hidden field values to default value
+            u('#id_related_page').attr('value', u('#id_related_page').first().defaultValue);
+            u('#id_position').attr('value', u('#id_position').first().defaultValue);
+        } else {
+            // Change hidden field values to last child of parent
+            u('#id_related_page').attr('value', event.target.value);
+            u('#id_position').attr('value', 'last-child');
+        }
+        // Update the modified page title
+        update_page_title();
+        // Trigger icon replacement
+        feather.replace();
+        // Register event handlers
+        register_event_handlers();
+    }).catch(function (error) {
+        // Show error message instead of table
+        u('#page_order_table').html('<div class="bg-red-100 border-l-4 border-red-500 text-red-500 px-4 py-3 my-4" role="alert"><p>' + error.message + '</p></div>');
+    });
+}
+
+// Event handler for updating the page title
+u('#id_title').on('input', update_page_title);
+
+// This function inserts the updated page title in the page order table
+function update_page_title() {
+    let page_title = u('#id_title').first().value;
+    if (page_title == "") {
+        page_title = u('#page_title').data('default-title');
+    }
+    u('#page_title').html(page_title);
+}
+
+// Function for registering all event handlers for drag/drop events
+function register_event_handlers() {
+    // At first, reset all existing handlers
+    u('.drop').each(function(node) {
+        u(node).off('dragleave,dragover,drop');
+    });
+    // Event handlers for drag events
+    u('.drag').on('dragstart', dragstart);
+    u('.drag').handle('dragend', dragend);
+    // Event handlers for drop events
+    u('.drop').each(function(node) {
+        u(node).handle('dragover', dragover);
+        u(node).handle('dragleave', dragleave);
+        u(node).handle('drop', drop);
+    });
+}
+
+// Register all handlers once initially
+register_event_handlers();
+
+// This function handles the start of a dragging event
+function dragstart(event) {
+    // change appearance of dragged item
+    u(event.target).removeClass('text-gray-800');
+    u(event.target).addClass('text-blue-500');
+    // show dropping regions between table rows
+    u('.drop-between').each(function(node)  {
+        u(node).closest('tr').removeClass("hidden");
+    });
+}
+
+// This function adds the hover effect when the dragged page is hovered over a valid drop region
+function dragover(event) {
+    u(event.target.parentElement).closest('tr').addClass("drop-allow");
+}
+
+// This function handles the event that the drag stops, no matter if on a valid drop region or not
+function dragend(event) {
+    // Hide the drop regions between table rows
+    u('.drop-between').each(function(node) {
+        u(node).closest('tr').addClass("hidden");
+    });
+    // Change appearance of dragged item
+    u(event.target).removeClass('text-blue-500');
+    u(event.target).addClass('text-gray-800');
+}
+
+// This function handles the event then the cursor leaves a drop region without actually dropping
+function dragleave(event) {
+    // Remove hover effect on allowed or disallowed drop regions
+    var target = u(event.target.parentElement).closest('tr');
+    target.removeClass("drop-allow");
+}
+
+// This function handles the event when the page is dropped onto the target div
+function drop(event) {
+    // Get the table row which was dragged
+    let dragged_page = u('.drag').closest('tr');
+    // Get the table row onto which the page was dropped
+    let target = u(event.target.parentElement).closest('tr');
+    // Insert the page before the drop target
+    target.before(dragged_page);
+    // Remove the page from its original position
+    dragged_page.remove()
+    // Toggle classes to deactivate the drop region where the dragged page was dropped
+    target.toggleClass('drop drop-deactivated drop-between drop-between-deactivated');
+    // Remove the drop-allow class which creates the hover effect (blue line)
+    target.removeClass('drop-allow');
+    // Toggle classes to activate the previously deactivated drop regions
+    u('.drop-deactivated').toggleClass('drop drop-deactivated');
+    u('.drop-between-deactivated').toggleClass('drop-between drop-between-deactivated');
+    // Read form field values from data attributes
+    let target_id = target.attr("data-drop-id");
+    let position = target.attr("data-drop-position");
+    // Passing the values to the hidden fields
+    u('#id_related_page').attr('value', target.data('drop-id'));
+    u('#id_position').attr('value', target.data('drop-position'));
+    // Register new event handlers
+    register_event_handlers();
+}

--- a/src/cms/templates/pages/_page_order_table.html
+++ b/src/cms/templates/pages/_page_order_table.html
@@ -1,0 +1,64 @@
+{% load i18n %}
+{% load mptt_tags %}
+{% load content_filters %}
+{% load page_filters %}
+<div class="table-listing">
+    <table class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white table-auto">
+        <tbody>
+            {% get_current_language as LANGUAGE_CODE %}
+            {% unify_language_code LANGUAGE_CODE as LANGUAGE_CODE %}
+            {% recursetree siblings %}
+                {% get_translation node LANGUAGE_CODE as node_backend_translation %}
+                {% if node == page %}
+                    <tr class="border-2 border-blue-500 hover:bg-gray-100">
+                        <td class="single_icon min">
+                            <span data-contained-in-siblings="true" class="drag text-gray-800 block py-3 pr-2 cursor-move" draggable="true">
+                                <i data-feather="move"></i>
+                            </span>
+                        </td>
+                        <td id="page_title" data-default-title="{{ node_backend_translation.title }}">{{ node_backend_translation.title }}</td>
+                    </tr>
+                {% else %}
+                    {% if page and node.get_previous_sibling == page %}
+                        <tr data-drop-id="{{ node.id }}" data-drop-position="left" class="drop-deactivated drop-between-deactivated h-3 -m-3 hidden"><td colspan="2"><div><span></span></div></td></tr>
+                    {% else %}
+                        <tr data-drop-id="{{ node.id }}" data-drop-position="left" class="drop drop-between h-3 -m-3 hidden"><td colspan="2"><div><span></span></div></td></tr>
+                    {% endif %}
+                    <tr class="border border-gray-200 hover:bg-gray-100">
+                        <td></td>
+                        <td>{{ node_backend_translation.title }}</td>
+                    </tr>
+                    {% if not node.get_next_sibling %}
+                        {% if not page in node.get_siblings %}
+                            <tr data-drop-id="{{ node.id }}" data-drop-position="right" class="drop-deactivated drop-between-deactivated h-3 -m-3 hidden"><td colspan="2"><div><span></span></div></td></tr>
+                        {% else %}
+                            <tr data-drop-id="{{ node.id }}" data-drop-position="right" class="drop drop-between h-3 -m-3 hidden"><td colspan="2"><div><span></span></div></td></tr>
+                        {% endif %}
+                    {% endif %}
+                {% endif %}
+            {% endrecursetree %}
+            {% if not page in siblings %}
+                {% if not page %}
+                    <tr class="border-2 border-blue-500 hover:bg-gray-100">
+                        <td class="single_icon min">
+                            <span class="drag text-gray-800 block py-3 pr-2 cursor-move" draggable="true">
+                                <i data-feather="move"></i>
+                            </span>
+                        </td>
+                        <td id="page_title" data-default-title="{% trans 'New Page' %}">{% trans 'New Page' %}</td>
+                    </tr>
+                {% else %}
+                    {% get_translation page LANGUAGE_CODE as backend_translation %}
+                    <tr class="border-2 border-blue-500 hover:bg-gray-100">
+                        <td class="single_icon min">
+                            <span class="drag text-gray-800 block py-3 pr-2 cursor-move" draggable="true">
+                                <i data-feather="move"></i>
+                            </span>
+                        </td>
+                        <td id="page_title" data-default-title="{{ backend_translation.title }}">{{ backend_translation.title }}</td>
+                    </tr>
+                {% endif %}
+            {% endif %}
+        </tbody>
+    </table>
+</div>

--- a/src/cms/templates/pages/page_form.html
+++ b/src/cms/templates/pages/page_form.html
@@ -11,7 +11,6 @@
 {% block css %}
     <link href="{% static 'tinymce/skins/ui/oxide/skin.min.css' %}" rel="stylesheet" type="text/css">
     <link href="{% static 'tinymce/skins/ui/oxide/content.min.css' %}" rel="stylesheet" type="text/css">
-    <link href="{% static 'tinymce/skins/content/default/content.css' %}" rel="stylesheet"type="text/css">
 {% endblock %}
 
 {% block javascript_head %}
@@ -222,16 +221,18 @@
             <div class="w-full mb-4 rounded border-2 border-solid border-blue-500 shadow bg-white">
                 <div class="w-full p-4">
                     <span class="font-bold mb-2 mt-4 block">{% trans 'Positioning' %}</span>
-                    <label for="position" class="text-xs uppercase block mt-4">{% trans 'Relationship' %}</label>
+                    <label for="parent" class="text-xs uppercase">{% trans 'Parent Page' %}</label>
                     <div class="relative my-2">
-                        {% render_field page_form.position placeholder="0" id="position" class="appearance-none block w-full bg-gray-200 text-gray-600 border border-gray-200 rounded mb-2 py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
-                    </div>
-                    <label for="parent" class="text-xs uppercase">{% trans 'Page' %}</label>
-                    <div class="relative my-2">
+                        {% render_field page_form.related_page %}
+                        {% render_field page_form.position %}
                         {% render_field page_form.parent id="parent" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
                         <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
                             <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
                         </div>
+                    </div>
+                    <label class="text-xs uppercase">{% trans 'Order' %}</label>
+                    <div id="page_order_table" class="mb-4">
+                        {% include "pages/_page_order_table.html" %}
                     </div>
                     {% if page %}
                     <span class="font-bold mb-2 mt-4">{% trans 'Embed live content' %}</span>
@@ -317,6 +318,10 @@
         {% endif %}
     {% endif %}
 {% endif %}
+{% endblock %}
+
+{% block javascript %}
+<script src="{% static 'js/pages/page_order.js' %}"></script>
 {% endblock %}
 
 {% block javascript_nocompress %}

--- a/src/cms/urls.py
+++ b/src/cms/urls.py
@@ -280,6 +280,16 @@ urlpatterns = [
                     pages.save_mirrored_page,
                     name="save_mirrored_page",
                 ),
+                url(
+                    r"^(?P<region_slug>[-\w]+)/(?P<parent_id>[0-9]+)/new_order_table$",
+                    pages.get_new_page_order_table_ajax,
+                    name="get_new_page_order_table_ajax",
+                ),
+                url(
+                    r"^(?P<region_slug>[-\w]+)/(?P<page_id>[0-9]+)/(?P<parent_id>[0-9]+)/order_table$",
+                    pages.get_page_order_table_ajax,
+                    name="get_page_order_table_ajax",
+                ),
                 url(r"^search_poi$", events.search_poi_ajax, name="search_poi_ajax"),
             ]
         ),

--- a/src/cms/views/pages/__init__.py
+++ b/src/cms/views/pages/__init__.py
@@ -14,6 +14,8 @@ from .page_actions import (
     move_page,
     grant_page_permission_ajax,
     revoke_page_permission_ajax,
+    get_page_order_table_ajax,
+    get_new_page_order_table_ajax,
     get_pages_list_ajax,
     save_mirrored_page,
 )

--- a/src/cms/views/pages/page_actions.py
+++ b/src/cms/views/pages/page_actions.py
@@ -420,6 +420,44 @@ def revoke_page_permission_ajax(request):
 
 
 @login_required
+@region_permission_required
+@permission_required("cms.edit_pages", raise_exception=True)
+def get_page_order_table_ajax(request, region_slug, page_id, parent_id):
+
+    page = Page.objects.get(id=page_id, region__slug=region_slug)
+
+    if parent_id == "0":
+        siblings = Page.objects.filter(level=0, region__slug=region_slug)
+    else:
+        siblings = Page.objects.filter(parent__id=parent_id, region__slug=region_slug)
+
+    logger.debug(
+        "Page order table for page %s and siblings %s", page, siblings,
+    )
+
+    return render(
+        request, "pages/_page_order_table.html", {"page": page, "siblings": siblings,},
+    )
+
+
+@login_required
+@region_permission_required
+@permission_required("cms.edit_pages", raise_exception=True)
+def get_new_page_order_table_ajax(request, region_slug, parent_id):
+
+    if parent_id == "0":
+        siblings = Page.objects.filter(level=0, region__slug=region_slug)
+    else:
+        siblings = Page.objects.filter(parent__id=parent_id, region__slug=region_slug)
+
+    logger.debug(
+        "Page order table for a new page and siblings %s", siblings,
+    )
+
+    return render(request, "pages/_page_order_table.html", {"siblings": siblings,},)
+
+
+@login_required
 @permission_required("cms.edit_pages", raise_exception=True)
 def get_pages_list_ajax(request):
     decoded_json = json.loads(request.body.decode("utf-8"))

--- a/src/cms/views/pages/page_view.py
+++ b/src/cms/views/pages/page_view.py
@@ -70,9 +70,16 @@ class PageView(PermissionRequiredMixin, TemplateView):
             instance=page_translation, disabled=disabled
         )
 
+        # Pass side by side language options
         side_by_side_language_options = self.get_side_by_side_language_options(
             region, language, page
         )
+
+        # Pass siblings to template to enable rendering of page order table
+        if not page or not page.parent:
+            siblings = Page.objects.filter(level=0, region=region)
+        else:
+            siblings = page.parent.children.all()
 
         return render(
             request,
@@ -82,6 +89,7 @@ class PageView(PermissionRequiredMixin, TemplateView):
                 "page_form": page_form,
                 "page_translation_form": page_translation_form,
                 "page": page,
+                "siblings": siblings,
                 "language": language,
                 # Languages for tab view
                 "languages": region.languages if page else [language],
@@ -99,6 +107,12 @@ class PageView(PermissionRequiredMixin, TemplateView):
         page_translation_instance = PageTranslation.objects.filter(
             page=page_instance, language=language,
         ).first()
+
+        # Pass siblings to template to enable rendering of page order table
+        if not page_instance or not page_instance.parent:
+            siblings = Page.objects.filter(level=0, region=region)
+        else:
+            siblings = page_instance.parent.children.all()
 
         if not request.user.has_perm("cms.edit_page", page_instance):
             raise PermissionDenied
@@ -135,6 +149,7 @@ class PageView(PermissionRequiredMixin, TemplateView):
                     "page_form": page_form,
                     "page_translation_form": page_translation_form,
                     "page": page_instance,
+                    "siblings": siblings,
                     "language": language,
                     # Languages for tab view
                     "languages": region.languages if page_instance else [language],
@@ -152,6 +167,7 @@ class PageView(PermissionRequiredMixin, TemplateView):
                     "page_form": page_form,
                     "page_translation_form": page_translation_form,
                     "page": page_instance,
+                    "siblings": siblings,
                     "language": language,
                     # Languages for tab view
                     "languages": region.languages if page_instance else [language],


### PR DESCRIPTION
Control arrangement of pages within the page form:

1. Select parent page via dropdown
2. Change order between siblings via drag & drop

![Screenshot Integreat CMS](https://user-images.githubusercontent.com/16021269/90114080-82d0cc00-dd52-11ea-8067-d6210d1c122e.png)

Fixes #50