### PR TITLE
Region selection improvements

### DIFF
--- a/src/backend/context_processors.py
+++ b/src/backend/context_processors.py
@@ -7,18 +7,24 @@ from cms.models import Region
 def region_slug_processor(request):
     """
     This context processor retrieves the current ``region`` parameter and passes it to the templates.
-    Additionally, the ``regions``-variable contains all other regions except the current region
-    (If there is no current region, it contains all regions).
+    Additionally, the ``other_regions``-variable contains all other regions which are available via quick access.
+    Usually, these are the regions configured in each user's user profile, but if there are none set, we just list all
+    available regions, ordered by the ``last_updated`` attribute.
 
     :param request: The current http request
     :type request: ~django.http.HttpRequest
 
-    :return: The current region and all other regions
+    :return: The current region and other quick access regions
     :rtype: dict
     """
-    region = Region.get_current_region(request)
-    if region:
-        regions = Region.objects.exclude(slug=region.slug)
+    current_region = Region.get_current_region(request)
+    if request.user.is_authenticated and request.user.profile.regions.exists():
+        other_regions = request.user.profile.regions
     else:
-        regions = Region.objects.all()
-    return {"regions": regions, "region": region}
+        other_regions = Region.objects
+    if current_region:
+        other_regions = other_regions.exclude(slug=current_region.slug)
+    return {
+        "other_regions": other_regions.order_by("-last_updated")[:10],
+        "region": current_region,
+    }

--- a/src/cms/admin.py
+++ b/src/cms/admin.py
@@ -18,6 +18,8 @@ from .models import POI
 from .models import POITranslation
 from .models import Region
 from .models import RecurrenceRule
+from .models import UserMfa
+from .models import UserProfile
 
 admin.site.register(Event)
 admin.site.register(EventTranslation)
@@ -32,3 +34,5 @@ admin.site.register(POI)
 admin.site.register(POITranslation)
 admin.site.register(Region)
 admin.site.register(RecurrenceRule)
+admin.site.register(UserMfa)
+admin.site.register(UserProfile)

--- a/src/cms/fixtures/test_data.json
+++ b/src/cms/fixtures/test_data.json
@@ -18,6 +18,15 @@
     }
   },
   {
+    "model": "cms.userprofile",
+    "pk": 1,
+    "fields": {
+      "user": 1,
+      "organization": null,
+      "regions": []
+    }
+  },
+  {
     "model": "cms.region",
     "pk": 1,
     "fields": {

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-03 12:58+0000\n"
+"POT-Creation-Date: 2020-09-03 13:22+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -355,31 +355,31 @@ msgstr "Die Passwörter stimmen nicht überein."
 msgid "Search"
 msgstr "Suchen"
 
-#: templates/_base.html:28 templates/_base.html:43
+#: templates/_base.html:28 templates/_base.html:41
 msgid "Network Management"
 msgstr "Netzwerkverwaltung"
 
-#: templates/_base.html:86
+#: templates/_base.html:84
 msgid "Help"
 msgstr "Hilfe"
 
-#: templates/_base.html:90
+#: templates/_base.html:88
 msgid "Author Chat"
 msgstr "Autorenchat"
 
-#: templates/_base.html:94
+#: templates/_base.html:92
 msgid "User Settings"
 msgstr "Benutzereinstellungen"
 
-#: templates/_base.html:98
+#: templates/_base.html:96
 msgid "Django Administration"
 msgstr "Django Administration"
 
-#: templates/_base.html:102
+#: templates/_base.html:100
 msgid "Log out"
 msgstr "Abmelden"
 
-#: templates/_base.html:109 templates/authentication/login.html:10
+#: templates/_base.html:107 templates/authentication/login.html:10
 #: templates/authentication/login_mfa.html:10
 #: templates/settings/mfa/add_key.html:10
 #: templates/settings/mfa/authenticate.html:10
@@ -387,93 +387,93 @@ msgstr "Abmelden"
 msgid "Integreat Logo"
 msgstr "Integreat Logo"
 
-#: templates/_base.html:115
+#: templates/_base.html:113
 msgid "My Dashboard"
 msgstr "Mein Dashboard"
 
-#: templates/_base.html:119 templates/analytics/translation_coverage.html:12
+#: templates/_base.html:117 templates/analytics/translation_coverage.html:12
 msgid "Translation Report"
 msgstr "Übersetzungs-Bericht"
 
-#: templates/_base.html:124 templates/regions/region_form.html:131
+#: templates/_base.html:122 templates/regions/region_form.html:131
 #: templates/statistics/statistics_dashboard.html:8
 msgid "Statistics"
 msgstr "Statistiken"
 
-#: templates/_base.html:129
+#: templates/_base.html:127
 msgid "Media Library"
 msgstr "Medienbibliothek"
 
-#: templates/_base.html:133 templates/pages/page_tree.html:17
+#: templates/_base.html:131 templates/pages/page_tree.html:17
 #: templates/regions/region_form.html:205
 msgid "Pages"
 msgstr "Seiten"
 
-#: templates/_base.html:137 templates/events/event_list.html:14
+#: templates/_base.html:135 templates/events/event_list.html:14
 #: templates/regions/region_form.html:206
 msgid "Events"
 msgstr "Veranstaltungen"
 
-#: templates/_base.html:141 templates/pois/poi_list.html:15
+#: templates/_base.html:139 templates/pois/poi_list.html:15
 msgid "Points of Interest"
 msgstr "Points of Interest"
 
-#: templates/_base.html:145 templates/_base.html:190
+#: templates/_base.html:143 templates/_base.html:188
 #: templates/regions/region_form.html:203
 msgid "Users"
 msgstr "Benutzer"
 
-#: templates/_base.html:149 templates/_base.html:206
+#: templates/_base.html:147 templates/_base.html:204
 msgid "Feedback"
 msgstr "Feedback"
 
-#: templates/_base.html:153
+#: templates/_base.html:151
 msgid "Push Notifications"
 msgstr "Push-Benachrichtigungen"
 
-#: templates/_base.html:157
+#: templates/_base.html:155
 msgid "PDF Export"
 msgstr "PDF Export"
 
-#: templates/_base.html:161 templates/offers/offer_list.html:9
+#: templates/_base.html:159 templates/offers/offer_list.html:9
 msgid "Offers"
 msgstr "Angebote"
 
-#: templates/_base.html:165
+#: templates/_base.html:163
 msgid "Imprint"
 msgstr "Impressum"
 
-#: templates/_base.html:169 templates/language_tree/language_tree.html:9
+#: templates/_base.html:167 templates/language_tree/language_tree.html:9
 msgid "Language tree"
 msgstr "Sprach-Baum"
 
-#: templates/_base.html:173 templates/_base.html:210
+#: templates/_base.html:171 templates/_base.html:208
 #: templates/statistics/statistics_dashboard.html:62
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: templates/_base.html:178
+#: templates/_base.html:176
 msgid "Admin Dashboard"
 msgstr "Admin Dashboard"
 
-#: templates/_base.html:182 templates/users/admin/user.html:92
+#: templates/_base.html:180 templates/users/admin/user.html:92
 msgid "Regions"
 msgstr "Regionen"
 
-#: templates/_base.html:186 templates/regions/region_form.html:204
+#: templates/_base.html:184 templates/regions/region_form.html:204
 msgid "Languages"
 msgstr "Sprachen"
 
-#: templates/_base.html:194 templates/users/admin/user.html:87
+#: templates/_base.html:192 templates/users/admin/user.html:87
 #: templates/users/region/user.html:77
 msgid "Roles"
 msgstr "Rollen"
 
-#: templates/_base.html:198
+#: templates/_base.html:196
 msgid "Organizations"
 msgstr "Organisationen"
 
-#: templates/_base.html:202
+#: templates/_base.html:200
 msgid "Offer templates"
 msgstr "Angebots-Vorlagen"
 
@@ -808,7 +808,7 @@ msgstr "Version"
 #: templates/pages/page_tree.html:59 templates/pages/page_tree_archived.html:32
 #: templates/pois/poi_form.html:138 templates/pois/poi_list.html:49
 #: templates/pois/poi_list_archived.html:32
-#: templates/regions/region_form.html:96 templates/regions/region_list.html:34
+#: templates/regions/region_form.html:96 templates/regions/region_list.html:32
 msgid "Status"
 msgstr "Status"
 
@@ -1190,13 +1190,13 @@ msgstr "Name auf"
 
 #: templates/languages/language_list.html:29
 #: templates/offer_templates/offer_template_list.html:28
-#: templates/regions/region_list.html:32
+#: templates/regions/region_list.html:30
 msgid "Created"
 msgstr "Erstellt"
 
 #: templates/languages/language_list.html:30
 #: templates/offer_templates/offer_template_list.html:27
-#: templates/pages/page_tree.html:78 templates/regions/region_list.html:33
+#: templates/pages/page_tree.html:78 templates/regions/region_list.html:31
 msgid "Last updated"
 msgstr "Zuletzt aktualisiert"
 
@@ -1330,7 +1330,8 @@ msgstr "Angebots-Vorlagen verwalten"
 msgid "Active since"
 msgstr "Aktiv seit"
 
-#: templates/offers/offer_list.html:33 templates/settings/user.html:64
+#: templates/offers/offer_list.html:33 templates/regions/region_list.html:33
+#: templates/settings/user.html:64
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -2048,17 +2049,13 @@ msgstr "Regionen"
 msgid "Create region"
 msgstr "Region erstellen"
 
-#: templates/regions/region_list.html:30
-msgid "CMS-URL"
-msgstr "CMS-URL"
-
-#: templates/regions/region_list.html:31
-msgid "WebApp-URL"
-msgstr "WebApp-URL"
-
-#: templates/regions/region_list.html:43
+#: templates/regions/region_list.html:42
 msgid "No regions available yet."
 msgstr "Noch keine Regionen vorhanden."
+
+#: templates/regions/region_list_row.html:31
+msgid "Open Dashboard"
+msgstr "Dashboard öffnen"
 
 #: templates/roles/list.html:9
 msgid "Manage Roles"
@@ -2881,6 +2878,12 @@ msgid ""
 msgstr ""
 "Ein Benutzer muss entweder Mitarbeiter/Super-Administrator sein, oder "
 "mindestens einer Region zugewiesen sein."
+
+#~ msgid "CMS-URL"
+#~ msgstr "CMS-URL"
+
+#~ msgid "WebApp-URL"
+#~ msgstr "WebApp-URL"
 
 #~| msgid "Export"
 #~ msgid "Export XLIFF"

--- a/src/cms/templates/_base.html
+++ b/src/cms/templates/_base.html
@@ -30,12 +30,10 @@
 	        {% endif %}
         </div>
         <div id="instance-selector-list" class="absolute shadow rounded-b">
-	        {% for other_region in user.profile.regions.all %}
-		        {% if not other_region == region %}
-		            <a href="{% url 'dashboard' region_slug=other_region.slug %}" class="block px-4 py-3 text-gray-800 hover:bg-gray-400">
-		                {{ other_region.name }}
-		            </a>
-		        {% endif %}
+	        {% for other_region in other_regions %}
+				<a href="{% url 'dashboard' region_slug=other_region.slug %}" class="block px-4 py-3 text-gray-800 hover:bg-gray-400">
+					{{ other_region.name }}
+				</a>
 	        {% endfor %}
 	        {% if user.is_superuser or user.is_staff %}
 		        {% if region %}

--- a/src/cms/templates/regions/region_list.html
+++ b/src/cms/templates/regions/region_list.html
@@ -27,11 +27,10 @@
             <tr class="border-b border-solid border-gray-200">
                 <th class="text-sm text-left uppercase py-3 pl-4 pr-2">{% trans 'Administrative division' %}</th>
                 <th class="text-sm text-left uppercase py-3 pl-4 pr-2">{% trans 'Name' %}</th>
-                <th class="text-sm text-left uppercase py-3 px-2">{% trans 'CMS-URL' %}</th>
-                <th class="text-sm text-left uppercase py-3 px-2">{% trans 'WebApp-URL' %}</th>
                 <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Created' %}</th>
                 <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Last updated' %}</th>
-                <th class="text-sm text-left uppercase py-3 pl-2 pr-4 min">{% trans 'Status' %}</th>
+                <th class="text-sm text-left uppercase py-3 px-2 min">{% trans 'Status' %}</th>
+                <th class="text-sm text-right uppercase py-3 pl-2 pr-4">{% trans 'Actions' %}</th>
             </tr>
         </thead>
         <tbody>

--- a/src/cms/templates/regions/region_list_row.html
+++ b/src/cms/templates/regions/region_list_row.html
@@ -1,3 +1,5 @@
+{% load i18n %}
+
 <tr class="border-t border-solid border-gray-200 hover:bg-gray-100">
     <td class="pl-2">
         <a href="{% url 'edit_region' region_slug=region.slug %}" class="block py-3 px-2 text-gray-800">
@@ -10,16 +12,6 @@
         </a>
     </td>
 	<td>
-		<a href="{% url 'dashboard' region_slug=region.slug %}" class="block py-3 px-2 text-gray-800">
-			{{ request.scheme }}://{{ request.get_host }}{% url 'dashboard' region_slug=region.slug %}
-		</a>
-	</td>
-	<td>
-		<a href="https://integreat.app{% url 'dashboard' region_slug=region.slug %}" target="_blank" rel="noopener noreferrer" class="block py-3 px-2 text-gray-800">
-			https://integreat.app{% url 'dashboard' region_slug=region.slug %}
-		</a>
-	</td>
-	<td>
         <a href="{% url 'edit_region' region_slug=region.slug %}" class="block py-3 px-2 text-gray-800">
 			{{ region.created_date }}
         </a>
@@ -29,9 +21,14 @@
 			{{ region.last_updated }}
         </a>
 	</td>
-	<td class="pr-2">
+	<td>
         <a href="{% url 'edit_region' region_slug=region.slug %}" class="block py-3 px-2 text-gray-800">
 			{{ region.get_status_display }}
         </a>
+	</td>
+	<td class="pr-2 text-right">
+		<a href="{% url 'dashboard' region_slug=region.slug %}" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
+			{% trans 'Open Dashboard' %}
+		</a>
 	</td>
 </tr>


### PR DESCRIPTION
-  Quick access to regions for staff
    - This adds a list of up to 10 regions (ordered by last_updated) in the quick access list next to the language selection.
    - This requires every user to have a user profile, so I added one to the test_data.json

-  Improve dashboard link in region list
    - Remove CMS-URL
    - Remove Webapp-URL
    - Add button to open dashboard

