### PR TITLE
Add sphinx-last-updated-by-git

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ pylint-django = "*"
 pylint-runner = "*"
 sphinx = "*"
 sphinxcontrib-django = "*"
+sphinx-last-updated-by-git = "*"
 sphinx-rtd-theme = "*"
 
 [packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7f2b410d75f2b5983cc773585a3738d7a058acf8baf2417c7e5e76156c02d8e9"
+            "sha256": "f4294c69d8adfb109254979367353e64b3511216cf5bb13a51c7ad32143adebd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -851,6 +851,14 @@
             ],
             "index": "pypi",
             "version": "==3.1.2"
+        },
+        "sphinx-last-updated-by-git": {
+            "hashes": [
+                "sha256:7017ba80de387cddbdf403201e950b8667e37c5773796874a7750098edd33e70",
+                "sha256:f103776539bb19fdf16714a653b6ccb5a4e31483fed9b18717e1797859e73cab"
+            ],
+            "index": "pypi",
+            "version": "==0.2.2"
         },
         "sphinx-rtd-theme": {
             "hashes": [

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -56,6 +56,7 @@ extensions = [
     "sphinx.ext.linkcode",
     "sphinxcontrib_django",
     "sphinx_rtd_theme",
+    "sphinx_last_updated_by_git",
 ]
 
 # Enable cross-references to other documentations


### PR DESCRIPTION
The new dependency [sphinx-last-updated-by-git](https://pypi.org/project/sphinx-last-updated-by-git/) determines the last updated date in the documentation by the last change of the source file in git.
This package has only 1 contributor and is not used very often, but since it's just a dev dependency and won't run on our production server, I don't see a problem here.

Fixes #467