### PR TITLE
Add timeout to GVZ API test

### DIFF
--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -197,7 +197,9 @@ LOGGING = {
     "loggers": {
         "django": {"handlers": ["console"], "level": "WARN", "propagate": True,},
         "api": {"handlers": ["console"], "level": "INFO", "propagate": True,},
+        "backend": {"handlers": ["console"], "level": "INFO", "propagate": True,},
         "cms": {"handlers": ["console"], "level": "INFO", "propagate": True,},
+        "gvz_api": {"handlers": ["console"], "level": "INFO", "propagate": True,},
         "rules": {"handlers": ["console"], "level": "DEBUG", "propagate": True,},
         "auth": {"handlers": ["console", "authlog", "syslog"], "level": "INFO",},
     },
@@ -225,7 +227,7 @@ COMPRESS_ENABLED = False
 COMPRESS_OFFLINE = True
 
 # GVZ (Gemeindeverzeichnis) API URL
-GVZ_API_URL = "http://gvz.integreat-app.de/api/"
+GVZ_API_URL = "https://gvz.integreat-app.de/api/"
 GVZ_API_ENABLED = True
 
 # Allow access to all domains by setting the following variable to TRUE


### PR DESCRIPTION
- Add logging for `backend` and `gvz_api` apps
- Change GVZ API to https
- Only check availability on "runserver" command
- Add timeout of 3 seconds to request

Fixes #472