### PR TITLE
Improve Side by Side translation view

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-31 14:46+0000\n"
+"POT-Creation-Date: 2020-09-03 12:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -493,7 +493,8 @@ msgstr "Aktuelle Übersetzungen"
 #: templates/events/event_form.html:92 templates/events/event_form.html:121
 #: templates/events/event_list_archived_row.html:54
 #: templates/events/event_list_row.html:54 templates/pages/page_form.html:94
-#: templates/pages/page_form.html:123
+#: templates/pages/page_form.html:123 templates/pages/page_sbs.html:65
+#: templates/pages/page_sbs.html:124
 #: templates/pages/page_tree_archived_node.html:59
 #: templates/pages/page_tree_node.html:53 templates/pois/poi_form.html:83
 #: templates/pois/poi_form.html:112 templates/pois/poi_list_row.html:53
@@ -740,23 +741,25 @@ msgid "Create new event"
 msgstr "Veranstaltung erstellen"
 
 #: templates/events/event_form.html:67 templates/pages/page_form.html:67
-#: templates/pois/poi_form.html:64
+#: templates/pages/page_sbs.html:42 templates/pois/poi_form.html:64
 msgid "Save as draft"
 msgstr "Als Entwurf speichern"
 
 #: templates/events/event_form.html:70 templates/pages/page_form.html:71
-#: templates/pois/poi_form.html:65
+#: templates/pages/page_sbs.html:46 templates/pois/poi_form.html:65
 msgid "Publish"
 msgstr "Veröffentlichen"
 
 #: templates/events/event_form.html:72 templates/pages/page_form.html:73
+#: templates/pages/page_sbs.html:48
 msgid "Submit for review"
 msgstr "Zur Überprüfung vorlegen"
 
 #: templates/events/event_form.html:88 templates/events/event_form.html:117
 #: templates/events/event_list_archived_row.html:58
 #: templates/events/event_list_row.html:58 templates/pages/page_form.html:90
-#: templates/pages/page_form.html:119
+#: templates/pages/page_form.html:119 templates/pages/page_sbs.html:61
+#: templates/pages/page_sbs.html:120
 #: templates/pages/page_tree_archived_node.html:63
 #: templates/pages/page_tree_node.html:57 templates/pois/poi_form.html:79
 #: templates/pois/poi_form.html:108 templates/pois/poi_list_row.html:57
@@ -766,7 +769,8 @@ msgstr "Übersetzung ist veraltet"
 #: templates/events/event_form.html:96 templates/events/event_form.html:125
 #: templates/events/event_list_archived_row.html:62
 #: templates/events/event_list_row.html:62 templates/pages/page_form.html:98
-#: templates/pages/page_form.html:127
+#: templates/pages/page_form.html:127 templates/pages/page_sbs.html:69
+#: templates/pages/page_sbs.html:128
 #: templates/pages/page_tree_archived_node.html:67
 #: templates/pages/page_tree_node.html:61 templates/pois/poi_form.html:87
 #: templates/pois/poi_form.html:116 templates/pois/poi_list_row.html:61
@@ -784,13 +788,14 @@ msgid "Translation missing"
 msgstr "Übersetzung fehlt"
 
 #: templates/events/event_form.html:106 templates/pages/page_form.html:108
-#: templates/pois/poi_form.html:97
+#: templates/pages/page_sbs.html:133 templates/pois/poi_form.html:97
 msgid "Create Translation"
 msgstr "Übersetzung erstellen"
 
 #: templates/events/event_form.html:145 templates/events/event_list.html:47
 #: templates/events/event_list_archived.html:23
-#: templates/pages/page_form.html:147
+#: templates/pages/page_form.html:147 templates/pages/page_sbs.html:79
+#: templates/pages/page_sbs.html:146 templates/pages/page_sbs.html:151
 #: templates/pages/page_tree_archived.html:31 templates/pois/poi_form.html:136
 #: templates/pois/poi_list.html:48 templates/pois/poi_list_archived.html:31
 msgid "Version"
@@ -798,26 +803,30 @@ msgstr "Version"
 
 #: templates/events/event_form.html:147 templates/events/event_list.html:48
 #: templates/events/event_list_archived.html:24
-#: templates/pages/page_form.html:149 templates/pages/page_tree.html:59
-#: templates/pages/page_tree_archived.html:32 templates/pois/poi_form.html:138
-#: templates/pois/poi_list.html:49 templates/pois/poi_list_archived.html:32
+#: templates/pages/page_form.html:149 templates/pages/page_sbs.html:81
+#: templates/pages/page_sbs.html:148 templates/pages/page_sbs.html:153
+#: templates/pages/page_tree.html:59 templates/pages/page_tree_archived.html:32
+#: templates/pois/poi_form.html:138 templates/pois/poi_list.html:49
+#: templates/pois/poi_list_archived.html:32
 #: templates/regions/region_form.html:96 templates/regions/region_list.html:34
 msgid "Status"
 msgstr "Status"
 
 #: templates/events/event_form.html:150 templates/pages/page_form.html:152
+#: templates/pages/page_sbs.html:83 templates/pages/page_sbs.html:156
 #: templates/pois/poi_form.html:141 templates/regions/region_form.html:53
 msgid "Permalink"
 msgstr "Permalink"
 
 #: templates/events/event_form.html:152 templates/pages/page_form.html:154
-#: templates/regions/region_form.html:55
+#: templates/pages/page_sbs.html:158 templates/regions/region_form.html:55
 msgid " Leave blank to generate unique permalink from title"
 msgstr ""
 " Dieses Feld freilassen, um eine eindeutigen Permalink aus dem Titel zu "
 "generieren"
 
 #: templates/events/event_form.html:163 templates/pages/page_form.html:165
+#: templates/pages/page_sbs.html:97 templates/pages/page_sbs.html:169
 #: templates/pages/page_xliff_confirm.html:43 templates/pois/poi_form.html:151
 #: templates/push_notifications/push_notification_form.html:49
 #: templates/push_notifications/push_notification_list.html:24
@@ -825,7 +834,7 @@ msgid "Title"
 msgstr "Titel"
 
 #: templates/events/event_form.html:164 templates/pages/page_form.html:166
-#: templates/pages/page_sbs.html:30 templates/pois/poi_form.html:152
+#: templates/pages/page_sbs.html:170 templates/pois/poi_form.html:152
 msgid "Insert title here"
 msgstr "Titel hier eingeben"
 
@@ -838,16 +847,16 @@ msgid "Insert description here"
 msgstr "Beschreibung hier eingeben"
 
 #: templates/events/event_form.html:169 templates/pages/page_form.html:171
-#: templates/pois/poi_form.html:159
+#: templates/pages/page_sbs.html:175 templates/pois/poi_form.html:159
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
 
 #: templates/events/event_form.html:171 templates/pages/page_form.html:173
-#: templates/pois/poi_form.html:161
+#: templates/pages/page_sbs.html:177 templates/pois/poi_form.html:161
 msgid "This change does not require an update of the translations"
 msgstr "Diese Änderung erfordert keine angepasste Übersetzung"
 
-#: templates/events/event_form.html:181 templates/pages/page_form.html:214
+#: templates/events/event_form.html:181 templates/pages/page_form.html:215
 #: templates/pois/poi_form.html:171
 msgid "Settings for all translations"
 msgstr "Einstellungen für alle Übersetzungen"
@@ -945,14 +954,14 @@ msgstr "Land"
 msgid "Map"
 msgstr "Karte"
 
-#: templates/events/event_form.html:287 templates/pages/page_form.html:262
+#: templates/events/event_form.html:287 templates/pages/page_form.html:263
 #: templates/pois/poi_form.html:203 templates/regions/region_form.html:80
 msgid "Icon"
 msgstr "Icon"
 
 #: templates/events/event_form.html:291
 #: templates/organizations/organization_form.html:65
-#: templates/pages/page_form.html:266 templates/pois/poi_form.html:207
+#: templates/pages/page_form.html:267 templates/pois/poi_form.html:207
 #: templates/regions/region_form.html:89
 msgid "Set icon"
 msgstr "Icon festlegen"
@@ -985,38 +994,38 @@ msgstr "Veranstaltung löschen"
 msgid "Delete this event"
 msgstr "Diese Veranstaltung löschen"
 
-#: templates/events/event_form.html:423 templates/pages/page_form.html:359
-#: templates/pois/poi_form.html:271
+#: templates/events/event_form.html:423 templates/pages/page_form.html:360
+#: templates/pages/page_sbs.html:215 templates/pois/poi_form.html:271
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
-#: templates/events/event_form.html:442 templates/pages/page_form.html:378
-#: templates/pois/poi_form.html:290
+#: templates/events/event_form.html:442 templates/pages/page_form.html:379
+#: templates/pages/page_sbs.html:234 templates/pois/poi_form.html:290
 msgid "Location"
 msgstr "Ort"
 
-#: templates/events/event_form.html:449 templates/pages/page_form.html:385
-#: templates/pois/poi_form.html:297
+#: templates/events/event_form.html:449 templates/pages/page_form.html:386
+#: templates/pages/page_sbs.html:241 templates/pois/poi_form.html:297
 msgid "Link"
 msgstr "Link"
 
-#: templates/events/event_form.html:456 templates/pages/page_form.html:392
-#: templates/pois/poi_form.html:304
+#: templates/events/event_form.html:456 templates/pages/page_form.html:393
+#: templates/pages/page_sbs.html:248 templates/pois/poi_form.html:304
 msgid "Phone"
 msgstr "Telefon"
 
-#: templates/events/event_form.html:463 templates/pages/page_form.html:399
-#: templates/pois/poi_form.html:311
+#: templates/events/event_form.html:463 templates/pages/page_form.html:400
+#: templates/pages/page_sbs.html:255 templates/pois/poi_form.html:311
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
-#: templates/events/event_form.html:470 templates/pages/page_form.html:406
-#: templates/pois/poi_form.html:318
+#: templates/events/event_form.html:470 templates/pages/page_form.html:407
+#: templates/pages/page_sbs.html:262 templates/pois/poi_form.html:318
 msgid "Email"
 msgstr "Email"
 
-#: templates/events/event_form.html:477 templates/pages/page_form.html:413
-#: templates/pois/poi_form.html:325
+#: templates/events/event_form.html:477 templates/pages/page_form.html:414
+#: templates/pages/page_sbs.html:269 templates/pois/poi_form.html:325
 msgid "Hint"
 msgstr "Tipp"
 
@@ -1109,7 +1118,6 @@ msgstr "Sprache hinzufügen"
 #: templates/languages/language_form.html:21
 #: templates/offer_templates/offer_template_form.html:22
 #: templates/organizations/organization_form.html:21
-#: templates/pages/page_sbs.html:38
 #: templates/push_notifications/push_notification_form.html:26
 #: templates/regions/region_form.html:21 templates/roles/role.html:21
 #: templates/users/admin/user.html:21 templates/users/region/user.html:21
@@ -1117,7 +1125,6 @@ msgid "Save"
 msgstr "Speichern"
 
 #: templates/language_tree/language_tree_node_form.html:37
-#: templates/pages/page_form.html:191
 msgid "Source Language"
 msgstr "Quell-Sprache"
 
@@ -1462,13 +1469,13 @@ msgstr "Neue Übersetzung erstellen"
 msgid "Create new page"
 msgstr "Neue Seite erstellen"
 
-#: templates/pages/page_form.html:168
-#: templates/pages/page_xliff_confirm.html:45
+#: templates/pages/page_form.html:168 templates/pages/page_sbs.html:100
+#: templates/pages/page_sbs.html:172 templates/pages/page_xliff_confirm.html:45
 #: templates/push_notifications/push_notification_form.html:54
 msgid "Content"
 msgstr "Inhalt"
 
-#: templates/pages/page_form.html:169 templates/pages/page_sbs.html:33
+#: templates/pages/page_form.html:169 templates/pages/page_sbs.html:173
 msgid "Insert content here"
 msgstr "Inhalt hier eingeben"
 
@@ -1476,31 +1483,35 @@ msgstr "Inhalt hier eingeben"
 msgid "Side-by-Side view"
 msgstr "Side-by-Side-Ansicht"
 
-#: templates/pages/page_form.html:204
+#: templates/pages/page_form.html:191
+msgid "Direction of translation"
+msgstr "Übersetzungsrichtung"
+
+#: templates/pages/page_form.html:205
 msgid "Show translations side by side"
 msgstr "Übersetzungen nebeneinander anzeigen"
 
-#: templates/pages/page_form.html:221
+#: templates/pages/page_form.html:222
 msgid "Positioning"
 msgstr "Anordnung"
 
-#: templates/pages/page_form.html:222
+#: templates/pages/page_form.html:223
 msgid "Relationship"
 msgstr "Verhältnis"
 
-#: templates/pages/page_form.html:226
+#: templates/pages/page_form.html:227
 msgid "Page"
 msgstr "Seite"
 
-#: templates/pages/page_form.html:234
+#: templates/pages/page_form.html:235
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: templates/pages/page_form.html:255
+#: templates/pages/page_form.html:256
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: templates/pages/page_form.html:256
+#: templates/pages/page_form.html:257
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -1508,50 +1519,69 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: templates/pages/page_form.html:273 templates/pages/page_form.html:274
+#: templates/pages/page_form.html:274 templates/pages/page_form.html:275
 #: templates/pages/page_tree_archived_node.html:88
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
-#: templates/pages/page_form.html:275
+#: templates/pages/page_form.html:276
 msgid "Restore this page"
 msgstr "Diese Seite wiederherstellen"
 
-#: templates/pages/page_form.html:278 templates/pages/page_form.html:279
+#: templates/pages/page_form.html:279 templates/pages/page_form.html:280
 #: templates/pages/page_tree_node.html:91
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: templates/pages/page_form.html:281
+#: templates/pages/page_form.html:282
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: templates/pages/page_form.html:287 templates/pages/page_form.html:291
+#: templates/pages/page_form.html:288 templates/pages/page_form.html:292
 #: templates/pages/page_tree_archived_node.html:97
 #: templates/pages/page_tree_node.html:100
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: templates/pages/page_form.html:289
+#: templates/pages/page_form.html:290
 #: templates/pages/page_tree_archived_node.html:93
 #: templates/pages/page_tree_node.html:96 views/pages/page_actions.py:85
 msgid "You cannot delete a page which has children."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: templates/pages/page_form.html:293
+#: templates/pages/page_form.html:294
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
-#: templates/pages/page_sbs.html:11
+#: templates/pages/page_sbs.html:31
 #, python-format
 msgid ""
-"Translate \"%(page_title)s\" from %(source_language)s to %(target_language)s"
+"Translate \"%(page_title)s\" from %(source_language)s to "
+"%(target_language_name)s"
 msgstr ""
-"Übersetze \"%(page_title)s\" von %(source_language)s nach %(target_language)s"
+"Übersetze \"%(page_title)s\" von %(source_language)s nach "
+"%(target_language_name)s"
 
-#: templates/pages/page_sbs.html:40
+#: templates/pages/page_sbs.html:37
 msgid "Go Back to Page Editor"
 msgstr "Zurück zum Seiten-Editor"
+
+#: templates/pages/page_sbs.html:104 templates/pages/page_sbs.html:105
+msgid "Copy content"
+msgstr "Inhalt kopieren"
+
+#: templates/pages/page_sbs.html:107
+#, python-format
+msgid "Copy content of %(source_language)s to %(target_language_name)s"
+msgstr "Inhalt von %(source_language)s nach %(target_language_name)s kopieren"
+
+#: templates/pages/page_sbs.html:152
+msgid "New"
+msgstr "Neu"
+
+#: templates/pages/page_sbs.html:154
+msgid "Not saved yet"
+msgstr "Noch nicht gespeichert"
 
 #: templates/pages/page_tree.html:22
 msgid "Archived pages"
@@ -2481,8 +2511,8 @@ msgid "You cannot edit this event because it is archived."
 msgstr ""
 "Sie können diese Veranstaltung nicht bearbeiten, weil sie archiviert ist."
 
-#: views/events/event_view.py:141 views/pages/page_sbs_view.py:122
-#: views/pages/page_view.py:136 views/pois/poi_view.py:104
+#: views/events/event_view.py:141 views/pages/page_sbs_view.py:150
+#: views/pages/page_view.py:146 views/pois/poi_view.py:104
 #: views/regions/region_view.py:46 views/settings/user_settings_view.py:51
 #: views/settings/user_settings_view.py:68 views/users/region_user_view.py:83
 #: views/users/user_view.py:74
@@ -2524,8 +2554,8 @@ msgstr "Sprach-Baum wurde erfolgreich erstellt."
 
 #: views/language_tree/language_tree_node_view.py:77
 #: views/offer_templates/offer_template_view.py:49
-#: views/organizations/organization_view.py:47 views/pages/page_sbs_view.py:124
-#: views/pages/page_view.py:120
+#: views/organizations/organization_view.py:47 views/pages/page_sbs_view.py:148
+#: views/pages/page_view.py:129
 #: views/push_notifications/push_notification_view.py:152
 #: views/regions/region_view.py:40 views/roles/role_view.py:46
 #: views/users/region_user_view.py:86 views/users/user_view.py:84
@@ -2633,11 +2663,37 @@ msgstr ""
 msgid "Success: The user {user} cannot publish this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr veröffentlichen"
 
-#: views/pages/page_sbs_view.py:117 views/pages/page_view.py:168
+#: views/pages/page_sbs_view.py:44 views/pages/page_sbs_view.py:110
+#, python-brace-format
+msgid ""
+"You cannot use the side-by-side-view for the region's default language (in "
+"this case {default_language})."
+msgstr ""
+"Sie können die Side-by-Side-Ansicht nicht für die Standard-Sprache (in "
+"diesem Fall {default_language}) verwenden."
+
+#: views/pages/page_sbs_view.py:63 views/pages/page_sbs_view.py:128
+#, python-brace-format
+msgid ""
+"You cannot use the side-by-side-view if the source translation (in this case "
+"{source_language}) does not exist."
+msgstr ""
+"Sie können die Side-by-Side-Ansicht nicht verwenden, wenn die Quell-"
+"Übersetzung (in diesem Fall {source_language}) nicht existiert."
+
+#: views/pages/page_sbs_view.py:158 views/pages/page_view.py:176
+msgid "Translation was successfully created and published."
+msgstr "Übersetzung wurde erfolgreich erstellt und veröffentlicht."
+
+#: views/pages/page_sbs_view.py:162 views/pages/page_view.py:179
 msgid "Translation was successfully created."
 msgstr "Übersetzung wurde erfolgreich erstellt."
 
-#: views/pages/page_sbs_view.py:120 views/pages/page_view.py:173
+#: views/pages/page_sbs_view.py:167 views/pages/page_view.py:182
+msgid "Translation was successfully published."
+msgstr "Übersetzung wurde erfolgreich veröffentlicht."
+
+#: views/pages/page_sbs_view.py:170 views/pages/page_view.py:184
 msgid "Translation was successfully saved."
 msgstr "Übersetzung wurde erfolgreich gespeichert."
 
@@ -2665,21 +2721,18 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um diese Seite zu bearbeiten, aber "
 "Sie können Änderungen vornehmen und diese zur Überprüfung vorlegen."
 
-#: views/pages/page_view.py:158
+#: views/pages/page_view.py:169
 msgid "Page was successfully created and published."
 msgstr "Seite wurde erfolgreich erstellt und veröffentlicht."
 
-#: views/pages/page_view.py:161
+#: views/pages/page_view.py:172
 msgid "Page was successfully created."
 msgstr "Seite wurde erfolgreich erstellt."
 
-#: views/pages/page_view.py:165
-msgid "Translation was successfully created and published."
-msgstr "Übersetzung wurde erfolgreich erstellt und veröffentlicht."
-
-#: views/pages/page_view.py:171
-msgid "Translation was successfully published."
-msgstr "Übersetzung wurde erfolgreich veröffentlicht."
+#: views/pages/page_view.py:221
+#, python-brace-format
+msgid "{source_language} to {target_language}"
+msgstr "{source_language} nach {target_language}"
 
 #: views/pois/poi_actions.py:27
 msgid "POI was successfully archived."

--- a/src/cms/static/js/page.js
+++ b/src/cms/static/js/page.js
@@ -146,26 +146,23 @@ async function update_page_permission(url, page_id, user_id, permission) {
 /* end page permissions */
 
 /* begin side by side view */
+function toggle_sbs_button(event) {
+    if (event.target.value !== '') {
+        u('#side-by-side-link').attr('href', event.target.value);
+        u('#side-by-side-link').removeClass('bg-gray-400');
+        u('#side-by-side-link').removeClass('pointer-events-none');
+        u('#side-by-side-link').addClass('bg-blue-500');
+        u('#side-by-side-link').addClass('hover:bg-blue-600');
+    } else {
+        u('#side-by-side-link').first().removeAttribute('href');
+        u('#side-by-side-link').removeClass('bg-blue-500');
+        u('#side-by-side-link').removeClass('hover:bg-blue-600');
+        u('#side-by-side-link').addClass('bg-gray-400');
+        u('#side-by-side-link').addClass('pointer-events-none');
+    }
+}
 u(document).handle('DOMContentLoaded', function() {
-    u('#side-by-side-select').handle('change', function (event) {
-        console.log(event);
-        let value = event.target.value;
-        console.log(event.target);
-        console.log(event.target.value);
-        if (value !== '') {
-            u('#side-by-side-link').attr('href', value);
-            u('#side-by-side-link').removeClass('bg-blue-400');
-            u('#side-by-side-link').removeClass('pointer-events-none');
-            u('#side-by-side-link').addClass('bg-blue-500');
-            u('#side-by-side-link').addClass('hover:bg-blue-600');
-        } else {
-            u('#side-by-side-link').first().removeAttribute('href');
-            u('#side-by-side-link').removeClass('bg-blue-500');
-            u('#side-by-side-link').removeClass('hover:bg-blue-600');
-            u('#side-by-side-link').addClass('bg-blue-400');
-            u('#side-by-side-link').addClass('pointer-events-none');
-        }
-    });
+    u('#side-by-side-select').handle('change', toggle_sbs_button);
+    u('#side-by-side-select').trigger('change')
 });
-
 /* end side by side view */

--- a/src/cms/static/js/pages/sbs_copy_content.js
+++ b/src/cms/static/js/pages/sbs_copy_content.js
@@ -1,0 +1,9 @@
+/**
+ * This file contains the functionality to copy content from the source to the target translation
+ * in the page side-by-side view.
+ */
+u('#copy-translation-content').handle('click', function (event) {
+    let source_translation_tinymce = tinymce.get('source_translation_tinymce');
+    let target_translation_tinymce = tinymce.get('target_translation_tinymce');
+    target_translation_tinymce.setContent(source_translation_tinymce.getContent());
+});

--- a/src/cms/templates/pages/page_form.html
+++ b/src/cms/templates/pages/page_form.html
@@ -188,18 +188,19 @@
                 </ul>
                 <div class="w-full mb-4 rounded border-2 border-solid border-blue-500 shadow bg-white">
                     <div class="w-full p-4">
-                        <span class="font-bold mb-2 mt-4 block">{% trans 'Source Language' %}</span>
-                        <select id="side-by-side-select" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400">
-                            <option value="">---------</option>
-                            {% for other_language in languages %}
-                                {% if other_language != language %}
-                                    {% with other_language.code|add:'__'|add:language.code as sbs_language_code %}
-                                        <option value="{% url 'sbs_edit_page' page_id=page.id region_slug=region.slug language_code=sbs_language_code %}">{{ other_language.translated_name }}</option>
-                                    {% endwith %}
-                                {% endif %}
-                            {% endfor %}
-                        </select>
-                        <a id="side-by-side-link" class="block pointer-events-none w-full bg-blue-400 text-white text-center font-bold py-2 px-4 mt-2 rounded">
+                        <span class="font-bold mb-2 mt-4 block">{% trans 'Direction of translation' %}</span>
+                        <div class="relative">
+                            <select id="side-by-side-select" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400">
+                                <option value="">---------</option>
+                                {% for side_by_side_language_option in side_by_side_language_options %}
+                                <option value="{% url 'sbs_edit_page' page_id=page.id region_slug=region.slug language_code=side_by_side_language_option.value %}"{% if side_by_side_language_option.disabled %}disabled="disabled"{% elif side_by_side_language_option.selected %}selected="selected"{% endif %}>{{ side_by_side_language_option.label }}</option>
+                                {% endfor %}
+                            </select>
+                            <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
+                                <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
+                            </div>
+                        </div>
+                        <a id="side-by-side-link" class="block pointer-events-none w-full bg-gray-400 text-white text-center font-bold py-2 px-4 mt-2 rounded">
                             <i data-feather="external-link" class="inline-block mr-2"></i>
                             {% trans 'Show translations side by side' %}
                         </a>

--- a/src/cms/templates/pages/page_sbs.html
+++ b/src/cms/templates/pages/page_sbs.html
@@ -1,46 +1,278 @@
 {% extends "_base.html" %}
+
 {% load i18n %}
-{% block content %}
 {% load static %}
 {% load widget_tweaks %}
+{% load rules %}
+
+{% block javascript_head %}
+<script src="{% static 'tinymce/tinymce.min.js' %}"></script>
+<script src="{% static 'tinymce/themes/silver/theme.js' %}"></script>
+<script src="{% static 'tinymce/plugins/paste/plugin.js' %}"></script>
+<script src="{% static 'tinymce/plugins/fullscreen/plugin.js' %}"></script>
+<script src="{% static 'tinymce/plugins/autosave/plugin.js' %}"></script>
+<script src="{% static 'tinymce/plugins/link/plugin.js' %}"></script>
+<script src="{% static 'tinymce/plugins/preview/plugin.js' %}"></script>
+<script src="{% static 'tinymce/plugins/media/plugin.js' %}"></script>
+<script src="{% static 'tinymce/plugins/image/plugin.js' %}"></script>
+<script src="{% static 'tinymce/plugins/code/plugin.js' %}"></script>
+<script src="{% static 'tinymce/plugins/lists/plugin.js' %}"></script>
+<script src="{% static 'tinymce/plugins/directionality/plugin.js' %}"></script>
+<script src="{% static 'tinymce-i18n/langs/de.js' %}"></script>
+{% endblock %}
+
+{% block content %}
+<form method="post">
 <div>
     <div class="flex flex-wrap mb-4">
-        <div class="w-full flex flex-wrap flex-col justify-center">
+        <div class="w-3/5 flex flex-wrap flex-col justify-center mb-6">
             <h2 class="heading font-normal">
-	            {% with source_page_translation.title as page_title %}
-	            {% blocktrans %}Translate "{{ page_title }}" from {{source_language}} to {{target_language}}{% endblocktrans %}
+	            {% with page_title=source_page_translation.title source_language=source_page_translation.language.translated_name target_language_name=target_language.translated_name %}
+	            {% blocktrans %}Translate "{{ page_title }}" from {{ source_language }} to {{ target_language_name }}{% endblocktrans %}
 	            {% endwith %}
             </h2>
+        </div>
+        <div class="w-2/5 flex justify-end mb-6">
+            <a href="{% url 'edit_page' page_id=source_page_translation.page.id region_slug=region.slug language_code=target_language.code %}" class="bg-gray-400 hover:bg-gray-500 cursor-pointer text-white font-bold py-3 px-4 rounded mr-2">
+                {% trans 'Go Back to Page Editor' %}
+            </a>
+            {% has_perm 'cms.edit_page' request.user source_page_translation.page as can_edit_page %}
+            {% if not source_page_translation.page.archived %}
+            {% if can_edit_page %}
+            <input type="submit" name="submit_draft" class="bg-gray-500 hover:bg-gray-600 cursor-pointer text-white font-bold py-3 px-4 rounded mr-2" value="{% trans 'Save as draft' %}" />
+            {% endif %}
+            {% has_perm 'cms.publish_page' request.user source_page_translation.page as can_publish_page %}
+            {% if can_publish_page %}
+            <input type="submit" name="submit_public" class="cursor-pointer bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded" value="{% trans 'Publish' %}" />
+            {% else %}
+            <input type="submit" name="submit_review" class="cursor-pointer bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded" value="{% trans 'Submit for review' %}" />
+            {% endif %}
+            {% endif %}
         </div>
     </div>
 
     <div class="flex flex-wrap">
         <div class="w-1/2 pr-2">
-            <div class="w-full p-4 mb-4 rounded border border-solid border-gray-200 shadow bg-white">
-                <input type="text" name="source_title" disabled value="{{source_page_translation.title}}" maxlength="250" class="appearance-none block w-full bg-gray-200 text-xl border border-gray-200 rounded py-3 px-4 leading-tight">
-	            <div class="mt-4">
-                    <textarea disabled name="text" cols="40" rows="10" class="bg-gray-200 w-full p-2">{{source_page_translation.text}}</textarea>
+            <ul class="flex pl-4">
+                <li class="z-10" style="margin-bottom: -2px">
+                    <div class="bg-white text-blue-500 border-l-2 border-t-2 border-r-2 border-blue-500 font-bold rounded-t-lg p-4">
+                        <div class="border-b-4 border-white">
+                            {% if source_page_translation.is_outdated %}
+                                <span title="{% trans 'Translation outdated' %}">
+                                    <i data-feather="alert-triangle" class="inline-block"></i>
+                                </span>
+                            {% elif source_page_translation.currently_in_translation %}
+                                <span title="{% trans 'Currently in translation' %}">
+                                    <i data-feather="clock" class="inline-block"></i>
+                                </span>
+                            {% else %}
+                                <span title="{% trans 'Translation up-to-date' %}">
+                                    <i data-feather="check" class="inline-block"></i>
+                                </span>
+                            {% endif %}
+                            {{ source_page_translation.language.translated_name }}
+                        </div>
+                    </div>
+                </li>
+            </ul>
+            <div class="w-full p-4 mb-4 rounded border-2 border-solid border-blue-500 shadow bg-white">
+                <label class="inline-block mt-4 mb-2 font-bold">{% trans 'Version' %}:</label>
+                {{ source_page_translation.version }}<br>
+                <label class="inline-block mb-2 font-bold">{% trans 'Status' %}:</label>
+                {{ source_page_translation.get_status_display }}
+                <label class="block mb-2 font-bold">{% trans 'Permalink' %}</label>
+                <div class="appearance-none block mb-2 w-full bg-gray-200 text-xl text-gray-800 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400">
+                    {% spaceless %}
+                    <div style="display: table; white-space: nowrap;">
+                        <span style="display: table-cell;">https://integreat.app/{{ region.slug }}/{{ source_page_translation.language.code }}/</span>
+                        {% if source_page_translation.ancestor_path %}
+                        <span style="display: table-cell;">{{ source_page_translation.ancestor_path }}/</span>
+                        {% endif %}
+                        <span style="display: table-cell; width: 100%;">
+                            <input type="text" value="{{source_page_translation.slug}}" class="w-full rounded" disabled>
+                        </span>
+                    </div>
+                    {% endspaceless %}
                 </div>
+                <label class="block mb-2 font-bold">{% trans 'Title' %}</label>
+                <input type="text" value="{{source_page_translation.title}}" class="appearance-none block w-full bg-gray-200 text-xl border border-gray-200 rounded py-3 px-4 leading-tight" disabled>
+	            <div class="mt-4">
+                    <label class="block mt-4 font-bold" style="margin-bottom: 86px;">{% trans 'Content' %}</label>
+                    <textarea id="source_translation_tinymce" cols="40" rows="10" class="bg-gray-200 w-full p-2" disabled>{{source_page_translation.text}}</textarea>
+                </div>
+
+                <span class="block font-bold mt-4 mb-4">{% trans 'Copy content' %}</span>
+                <button id="copy-translation-content" title="{% trans 'Copy content' %}" class="w-full bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded">
+                    {% with source_language=source_page_translation.language.translated_name target_language_name=target_language.translated_name %}
+                        {% blocktrans %}Copy content of {{ source_language }} to {{ target_language_name }}{% endblocktrans %}
+                    {% endwith %}
+                    <i data-feather="arrow-right-circle" class="inline-block mr-2"></i>
+                </button>
             </div>
         </div>
-        <form method="post" class="w-1/2 pr-2">
-            {% csrf_token %}
-            {{ page_translation_form.errors }}
-            <div class="w-full p-4 mb-4 rounded border border-solid border-gray-200 shadow bg-white">
-	            {% trans 'Insert title here' as title_placeholder%}
-                {% render_field page_translation_form.title placeholder=title_placeholder class="appearance-none block w-full bg-gray-200 text-xl text-gray-800 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
-	            <div class="mt-4">
-	                {% trans 'Insert content here' as text_placeholder%}
-                    {% render_field page_translation_form.text placeholder=text_placeholder class="bg-gray-200 w-full p-2 border border-gray-200 focus:outline-none focus:bg-white focus:border-gray-400 rounded" %}
+        <div class="w-1/2 pr-2">
+            <ul class="flex pl-4">
+                <li class="z-10" style="margin-bottom: -2px">
+                    <div class="bg-white text-blue-500 border-l-2 border-t-2 border-r-2 border-blue-500 font-bold rounded-t-lg p-4">
+                        <div class="border-b-4 border-white">
+                            {% if page_translation_form.instance.id %}
+                                {% if page_translation_form.instance.is_outdated %}
+                                    <span title="{% trans 'Translation outdated' %}">
+                                        <i data-feather="alert-triangle" class="inline-block"></i>
+                                    </span>
+                                {% elif page_translation_form.instance.currently_in_translation %}
+                                    <span title="{% trans 'Currently in translation' %}">
+                                        <i data-feather="clock" class="inline-block"></i>
+                                    </span>
+                                {% else %}
+                                    <span title="{% trans 'Translation up-to-date' %}">
+                                        <i data-feather="check" class="inline-block"></i>
+                                    </span>
+                                {% endif %}
+                            {% else %}
+                                <span title="{% trans 'Create Translation' %}">
+                                    <i data-feather="plus" class="inline-block"></i>
+                                </span>
+                            {% endif %}
+                            {{ target_language.translated_name }}
+                        </div>
+                    </div>
+                </li>
+            </ul>
+            <div class="w-full p-4 mb-4 rounded border-2 border-solid border-blue-500 shadow bg-white">
+                {% csrf_token %}
+                {{ page_translation_form.errors }}
+                {% if page_translation_form.instance.id %}
+                    <label class="inline-block mt-4 mb-2 font-bold">{% trans 'Version' %}:</label>
+                    {{ page_translation_form.instance.version }}<br>
+                    <label class="inline-block mb-2 font-bold">{% trans 'Status' %}:</label>
+                    {{ page_translation_form.instance.get_status_display }}
+                {% else %}
+                    <label class="inline-block mt-4 mb-2 font-bold">{% trans 'Version' %}:</label>
+                    {% trans 'New' %}<br>
+                    <label class="inline-block mb-2 font-bold">{% trans 'Status' %}:</label>
+                    {% trans 'Not saved yet' %}
+                {% endif %}
+                <label class="block mb-2 font-bold">{% trans 'Permalink' %}</label>
+                <div class="appearance-none block mb-2 w-full bg-gray-200 text-xl text-gray-800 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400">
+                    {% trans ' Leave blank to generate unique permalink from title' as slug_placeholder%}
+                    {% spaceless %}
+                    <div style="display: table; white-space: nowrap;">
+                        <span style="display: table-cell;">https://integreat.app/{{ region.slug }}/{{ target_language.code }}/</span>
+                        {% if page_translation_form.instance.ancestor_path %}
+                        <span style="display: table-cell;">{{ page_translation_form.instance.ancestor_path }}/</span>
+                        {% endif %}
+                        <span style="display: table-cell; width: 100%;">{% render_field page_translation_form.slug placeholder=slug_placeholder class="w-full rounded" %}</span>
+                    </div>
+                    {% endspaceless %}
                 </div>
+                <label class="block mb-2 font-bold">{% trans 'Title' %}</label>
+                {% trans 'Insert title here' as title_placeholder%}
+                {% render_field page_translation_form.title placeholder=title_placeholder class="appearance-none block w-full bg-gray-200 text-xl text-gray-800 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
+                <label class="block mb-2 mt-4 font-bold">{% trans 'Content' %}</label>
+                {% trans 'Insert content here' as text_placeholder%}
+                {% render_field page_translation_form.text id="target_translation_tinymce" placeholder=text_placeholder class="bg-gray-200 w-full p-2 border border-gray-200 focus:outline-none focus:bg-white focus:border-gray-400 rounded tinymce_textarea" %}
+                <span class="block mb-2 mt-4 font-bold">{% trans 'Implications on other translations' %}</span>
+                {% render_field page_translation_form.minor_edit id="minor_edit" %}
+                <label for="minor_edit" class="text-s">{% trans 'This change does not require an update of the translations' %}</label>
             </div>
-            <div class="w-full p-4 flex justify-end">
-                <input type="submit" name="submit_save" class="bg-blue-500 hover:bg-blue-600 cursor-pointer text-white font-bold py-3 px-4 rounded mr-2" value="{% trans 'Save' %}" />
-                 <a href="{% url 'edit_page' page_id=source_page_translation.page.id region_slug=region.slug language_code=source_language.code %}" class="bg-gray-400 hover:bg-gray-500 cursor-pointer text-white font-bold py-3 px-4 rounded">
-                    {% trans 'Go Back to Page Editor' %}
-                </a>
-            </div>
-        </form>
+        </div>
     </div>
 </div>
+</form>
+{% endblock %}
+
+{% block javascript %}
+<script src="{% static 'js/pages/sbs_copy_content.js' %}"></script>
+{% endblock %}
+
+{% block javascript_nocompress %}
+{% get_current_language as LANGUAGE_CODE %}
+<script>
+tinymce.init({
+    selector: '#source_translation_tinymce',
+    menubar: "",
+    toolbar: "",
+    min_height: 400,
+    content_css : '{% static "css/tinymce_custom.css" %}',
+    readonly : 1
+});
+tinymce.init({
+    selector: '#target_translation_tinymce',
+    menubar: "edit view insert format icon",
+    menu: {
+        icon: { title: "Icons", items: "pinicon wwwicon callicon clockicon aticon ideaicon"},
+        format: { title: 'Format', items: 'bold italic underline strikethrough superscript | formats | forecolor backcolor | removeformat' }
+    },
+    plugins: "code paste fullscreen autosave link preview media image lists directionality",
+    toolbar: 'bold italic underline forecolor | bullist numlist | styleselect | undo redo | ltr rtl notranslate removeformat | aligncenter indent outdent | link image',
+    min_height: 478,
+    content_css : '{% static "css/tinymce_custom.css" %}',
+    language: '{{LANGUAGE_CODE|slice:"0:2"}}',
+    setup: (editor) => {
+        editor.ui.registry.addButton('notranslate',
+        {
+            tooltip: '{% trans 'Do not translate the selected text.' %}',
+            icon: 'permanent-pen',
+                onAction: () => {
+                editor.focus();
+                val = tinymce.activeEditor.dom.getAttrib(tinyMCE.activeEditor.selection.getNode(), "translate", "yes");
+                if(val == "no") {
+                    tinymce.activeEditor.dom.setAttrib(tinyMCE.activeEditor.selection.getNode(), "translate", null);
+                } else if (editor.selection.getContent().length > 0) {
+                    editor.selection.setContent('<span class="notranslate" translate="no">' + editor.selection.getContent() + '</span>');
+                }
+            }
+        });
+        editor.ui.registry.addIcon('pin_icon', '<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">		<path d="M256,0C161.896,0,85.333,76.563,85.333,170.667c0,28.25,7.063,56.26,20.49,81.104L246.667,506.5			c1.875,3.396,5.448,5.5,9.333,5.5s7.458-2.104,9.333-5.5l140.896-254.813c13.375-24.76,20.438-52.771,20.438-81.021			C426.667,76.563,350.104,0,256,0z M256,256c-47.052,0-85.333-38.281-85.333-85.333c0-47.052,38.281-85.333,85.333-85.333			s85.333,38.281,85.333,85.333C341.333,217.719,303.052,256,256,256z"/></svg>');
+        editor.ui.registry.addIcon('www_icon','<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 viewBox="0 0 26 26" style="enable-background:new 0 0 26 26;" xml:space="preserve">	<path style="fill:#030104;" d="M8.083,11.222L6.419,15c-0.041,0.094-0.144,0.154-0.257,0.154H5.31		c-0.113,0-0.216-0.061-0.256-0.154l-0.79-1.803c-0.077-0.178-0.147-0.348-0.213-0.517c-0.073,0.186-0.148,0.359-0.223,0.525		l-0.833,1.8c-0.042,0.091-0.144,0.149-0.255,0.149H1.888c-0.117,0-0.219-0.063-0.259-0.158l-1.557-3.779		c-0.03-0.074-0.018-0.156,0.034-0.221s0.135-0.103,0.225-0.103H1.29c0.121,0,0.227,0.069,0.263,0.169l0.684,1.92		c0.057,0.162,0.11,0.315,0.159,0.461c0.06-0.146,0.125-0.3,0.194-0.463l0.842-1.932c0.041-0.093,0.143-0.155,0.256-0.155H4.48		c0.115,0,0.217,0.063,0.258,0.157l0.798,1.89c0.072,0.17,0.136,0.329,0.195,0.479c0.049-0.142,0.106-0.296,0.171-0.465l0.737-1.898		c0.038-0.098,0.143-0.164,0.26-0.164h0.926c0.091,0,0.175,0.039,0.227,0.104C8.105,11.064,8.115,11.147,8.083,11.222z		 M17.005,11.222L15.341,15c-0.041,0.094-0.144,0.154-0.256,0.154h-0.854c-0.113,0-0.215-0.061-0.256-0.154l-0.789-1.803		c-0.078-0.178-0.148-0.348-0.214-0.517c-0.073,0.186-0.148,0.359-0.223,0.525l-0.833,1.8c-0.042,0.091-0.143,0.149-0.255,0.149		h-0.853c-0.116,0-0.219-0.063-0.259-0.158l-1.557-3.779c-0.03-0.074-0.018-0.156,0.034-0.221c0.052-0.064,0.136-0.103,0.225-0.103		h0.959c0.121,0,0.227,0.069,0.263,0.169l0.683,1.92c0.057,0.162,0.11,0.315,0.161,0.461c0.059-0.146,0.123-0.3,0.192-0.463		l0.843-1.932c0.04-0.093,0.142-0.155,0.256-0.155H13.4c0.115,0,0.218,0.063,0.258,0.157l0.799,1.89		c0.071,0.17,0.135,0.329,0.193,0.479c0.051-0.142,0.106-0.296,0.172-0.465l0.737-1.898c0.038-0.098,0.144-0.164,0.261-0.164h0.926		c0.092,0,0.177,0.039,0.227,0.104C17.026,11.064,17.038,11.147,17.005,11.222z M25.926,11.222L24.263,15		c-0.042,0.094-0.144,0.154-0.257,0.154h-0.853c-0.113,0-0.216-0.061-0.256-0.154l-0.789-1.803		c-0.078-0.178-0.148-0.348-0.214-0.517c-0.073,0.186-0.149,0.359-0.224,0.525l-0.833,1.8c-0.042,0.091-0.144,0.149-0.255,0.149		H19.73c-0.117,0-0.22-0.063-0.26-0.158l-1.557-3.779c-0.029-0.074-0.019-0.156,0.033-0.221s0.136-0.103,0.226-0.103h0.96		c0.121,0,0.227,0.069,0.262,0.169l0.684,1.92c0.057,0.162,0.11,0.315,0.16,0.461c0.059-0.146,0.123-0.3,0.192-0.463l0.843-1.932		c0.041-0.093,0.143-0.155,0.257-0.155h0.791c0.115,0,0.218,0.063,0.258,0.157l0.798,1.89c0.072,0.17,0.137,0.329,0.196,0.479		c0.049-0.142,0.106-0.296,0.171-0.465l0.738-1.898c0.037-0.098,0.142-0.164,0.26-0.164h0.926c0.092,0,0.176,0.039,0.227,0.104		C25.946,11.064,25.958,11.147,25.926,11.222z"/>		<path style="fill:#030104;" d="M2.71,9c0.283-0.718,0.637-1.401,1.057-2.037C3.829,6.975,3.887,7,3.952,7h1.88			c-0.199,0.634-0.355,1.309-0.49,2h2.055c0.155-0.699,0.335-1.376,0.562-2h9.986c0.227,0.624,0.407,1.301,0.562,2h2.055			c-0.135-0.691-0.291-1.366-0.49-2h1.88c0.065,0,0.123-0.025,0.186-0.037C22.556,7.599,22.911,8.282,23.194,9h2.121			c-1.691-5.216-6.591-9-12.363-9S2.28,3.784,0.588,9H2.71z M20.478,5H19.29c-0.258-0.543-0.542-1.05-0.851-1.519			C19.179,3.909,19.861,4.419,20.478,5z M12.952,2c1.551,0,2.983,1.154,4.062,3H8.89C9.969,3.154,11.401,2,12.952,2z M7.463,3.481			C7.155,3.95,6.871,4.457,6.613,5H5.426C6.043,4.419,6.725,3.909,7.463,3.481z"/>		<path style="fill:#030104;" d="M23.194,17c-0.283,0.719-0.638,1.4-1.057,2.037C22.075,19.025,22.017,19,21.952,19h-1.881			c0.199-0.634,0.355-1.309,0.49-2h-2.055c-0.154,0.699-0.335,1.377-0.562,2H7.959c-0.227-0.623-0.407-1.301-0.562-2H5.343			c0.135,0.691,0.291,1.366,0.49,2H3.952c-0.065,0-0.123,0.025-0.185,0.037C3.348,18.4,2.993,17.719,2.71,17H0.588			c1.692,5.216,6.592,9,12.364,9s10.672-3.784,12.363-9H23.194z M5.426,21h1.188c0.258,0.543,0.542,1.051,0.85,1.519			C6.725,22.091,6.043,21.581,5.426,21z M12.952,24c-1.551,0-2.983-1.154-4.062-3h8.123C15.935,22.846,14.503,24,12.952,24z			 M18.44,22.519c0.309-0.468,0.593-0.976,0.851-1.519h1.188C19.861,21.581,19.179,22.091,18.44,22.519z"/></svg>');
+        editor.ui.registry.addIcon('call_icon', '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 width="16" height="16" viewBox="0 0 348.077 348.077" style="enable-background:new 0 0 348.077 348.077;"	 xml:space="preserve">			<path d="M340.273,275.083l-53.755-53.761c-10.707-10.664-28.438-10.34-39.518,0.744l-27.082,27.076				c-1.711-0.943-3.482-1.928-5.344-2.973c-17.102-9.476-40.509-22.464-65.14-47.113c-24.704-24.701-37.704-48.144-47.209-65.257				c-1.003-1.813-1.964-3.561-2.913-5.221l18.176-18.149l8.936-8.947c11.097-11.1,11.403-28.826,0.721-39.521L73.39,8.194				C62.708-2.486,44.969-2.162,33.872,8.938l-15.15,15.237l0.414,0.411c-5.08,6.482-9.325,13.958-12.484,22.02				C3.74,54.28,1.927,61.603,1.098,68.941C-6,127.785,20.89,181.564,93.866,254.541c100.875,100.868,182.167,93.248,185.674,92.876				c7.638-0.913,14.958-2.738,22.397-5.627c7.992-3.122,15.463-7.361,21.941-12.43l0.331,0.294l15.348-15.029				C350.631,303.527,350.95,285.795,340.273,275.083z"/></svg>');
+        editor.ui.registry.addIcon('clock_icon', '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 width="16" height="16" viewBox="0 0 468.067 468.067" style="enable-background:new 0 0 468.067 468.067;"	 xml:space="preserve">	<path d="M431.38,0.225H36.685C16.458,0.225,0,16.674,0,36.898v394.268c0,20.221,16.458,36.677,36.685,36.677H431.38		c20.232,0,36.688-16.456,36.688-36.677V36.898C468.062,16.668,451.606,0.225,431.38,0.225z M406.519,41.969		c8.678,0,15.711,7.04,15.711,15.72c0,8.683-7.033,15.717-15.711,15.717c-8.688,0-15.723-7.04-15.723-15.717		C390.796,49.009,397.83,41.969,406.519,41.969z M350.189,41.969c8.688,0,15.723,7.04,15.723,15.72		c0,8.683-7.034,15.717-15.723,15.717c-8.684,0-15.711-7.04-15.711-15.717C334.479,49.009,341.513,41.969,350.189,41.969z		 M426.143,425.924H41.919V112.429h384.224V425.924z M234.031,385.902c66.212,0,120.095-53.871,120.095-120.096		c0-66.221-53.883-120.095-120.095-120.095c-66.215,0-120.095,53.874-120.095,120.095		C113.936,332.031,167.815,385.902,234.031,385.902z M234.031,169.923c52.866,0,95.884,43.016,95.884,95.884		c0,52.866-43.019,95.885-95.884,95.885c-52.869,0-95.884-43.019-95.884-95.885C138.146,212.938,181.162,169.923,234.031,169.923z		 M221.926,265.807v-60.526c0-6.682,5.423-12.105,12.105-12.105s12.105,5.423,12.105,12.105v48.42h49.935		c6.679,0,12.105,5.427,12.105,12.105c0,6.68-5.427,12.105-12.105,12.105h-62.04C227.349,277.912,221.926,272.486,221.926,265.807z"		/></svg>');
+        editor.ui.registry.addIcon('email_icon', '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 viewBox="0 0 490.2 490.2" style="enable-background:new 0 0 490.2 490.2;" xml:space="preserve"><g>	<path d="M420.95,61.8C376.25,20.6,320.65,0,254.25,0c-69.8,0-129.3,23.4-178.4,70.3s-73.7,105.2-73.7,175		c0,66.9,23.4,124.4,70.1,172.6c46.9,48.2,109.9,72.3,189.2,72.3c47.8,0,94.7-9.8,140.7-29.5c15-6.4,22.3-23.6,16.2-38.7l0,0		c-6.3-15.6-24.1-22.8-39.6-16.2c-40,17.2-79.2,25.8-117.4,25.8c-60.8,0-107.9-18.5-141.3-55.6c-33.3-37-50-80.5-50-130.4		c0-54.2,17.9-99.4,53.6-135.7c35.6-36.2,79.5-54.4,131.5-54.4c47.9,0,88.4,14.9,121.4,44.7s49.5,67.3,49.5,112.5		c0,30.9-7.6,56.7-22.7,77.2c-15.1,20.6-30.8,30.8-47.1,30.8c-8.8,0-13.2-4.7-13.2-14.2c0-7.7,0.6-16.7,1.7-27.1l18.6-152.1h-64		l-4.1,14.9c-16.3-13.3-34.2-20-53.6-20c-30.8,0-57.2,12.3-79.1,36.8c-22,24.5-32.9,56.1-32.9,94.7c0,37.7,9.7,68.2,29.2,91.3		c19.5,23.2,42.9,34.7,70.3,34.7c24.5,0,45.4-10.3,62.8-30.8c13.1,19.7,32.4,29.5,57.9,29.5c37.5,0,69.9-16.3,97.2-49		c27.3-32.6,41-72,41-118.1C488.05,152.9,465.75,103,420.95,61.8z M273.55,291.9c-11.3,15.2-24.8,22.9-40.5,22.9		c-10.7,0-19.3-5.6-25.8-16.8c-6.6-11.2-9.9-25.1-9.9-41.8c0-20.6,4.6-37.2,13.8-49.8s20.6-19,34.2-19c11.8,0,22.3,4.7,31.5,14.2		s13.8,22.1,13.8,37.9C290.55,259.2,284.85,276.6,273.55,291.9z"/></g></svg>');
+        editor.ui.registry.addIcon('idea_icon', '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16"><path fill="#444444" d="M11.7 1.9c-1-1.2-2.6-1.9-4.2-1.9s-3.2 0.7-4.2 1.9c-1 1.1-1.4 2.6-1.2 4 0.2 1.5 0.8 2.6 2.1 3.7 0.5 0.4 0.7 0.8 0.9 1.2 0 0.1 0.1 0.2 0.1 0.3-0.1 0.1-0.2 0.2-0.2 0.4 0 0.3 0.2 0.5 0.5 0.5-0.3 0-0.5 0.2-0.5 0.5s0.2 0.5 0.5 0.5c-0.3 0-0.5 0.2-0.5 0.5s0.2 0.5 0.5 0.5c-0.3 0-0.5 0.2-0.5 0.5s0.2 0.5 0.5 0.5h0.5c0 0.5 0.7 1 1.5 1s1.5-0.5 1.5-1h0.5c0.3 0 0.5-0.2 0.5-0.5s-0.2-0.5-0.5-0.5c0.3 0 0.5-0.2 0.5-0.5s-0.2-0.5-0.5-0.5c0.3 0 0.5-0.2 0.5-0.5s-0.2-0.5-0.5-0.5c0.3 0 0.5-0.2 0.5-0.5 0-0.2-0.1-0.3-0.2-0.4 0-0.1 0.1-0.1 0.1-0.2 0.2-0.4 0.4-0.8 0.9-1.2 1.3-1.1 1.9-2.2 2.1-3.8 0.2-1.4-0.2-2.8-1.2-4zM12 5.8c-0.2 1.3-0.7 2.2-1.8 3.2-0.6 0.5-0.9 1-1.2 1.4-0.2 0.5-0.3 0.6-0.5 0.6h-2c-0.2 0-0.3-0.1-0.5-0.6-0.2-0.4-0.5-1-1.1-1.6-1.3-1.1-1.6-2-1.8-3-0.2-1.1 0.2-2.3 0.9-3.2 0.9-1 2.2-1.6 3.5-1.6s2.6 0.6 3.5 1.6c0.7 0.9 1.1 2.1 1 3.2z"></path><path fill="#444444" d="M11 5h-1c0-0.7-0.8-2-2-2v-1c1.8 0 3 1.8 3 3z"></path></svg>');
+        editor.ui.registry.addMenuItem('pinicon', {
+            text: '{% trans 'Location' %}',
+            icon: 'pin_icon',
+            onAction: function () {
+                editor.insertContent('<img src="{% static "svg/pin.svg" %}" style="width:1.5em">');
+            }
+        });
+        editor.ui.registry.addMenuItem('wwwicon', {
+            text: '{% trans 'Link' %}',
+            icon: 'www_icon',
+            onAction: function () {
+                editor.insertContent('<img src="{% static "svg/world-wide-web.svg" %}" style="width:1.5em">');
+            }
+        });
+        editor.ui.registry.addMenuItem('callicon', {
+            text: '{% trans 'Phone' %}',
+            icon: 'call_icon',
+            onAction: function () {
+                editor.insertContent('<img src="{% static "svg/call.svg" %}" style="width:1.5em">');
+            }
+        });
+        editor.ui.registry.addMenuItem('clockicon', {
+            text: '{% trans 'Opening Hours' %}',
+            icon: 'clock_icon',
+            onAction: function () {
+                editor.insertContent('<img src="{% static "svg/clock.svg" %}" style="width:1.5em">');
+            }
+        });
+        editor.ui.registry.addMenuItem('aticon', {
+            text: '{% trans 'Email' %}',
+            icon: 'email_icon',
+            onAction: function () {
+                editor.insertContent('<img src="{% static "svg/at.svg" %}" style="width:1.5em">');
+            }
+        });
+        editor.ui.registry.addMenuItem('ideaicon', {
+            text: '{% trans 'Hint' %}',
+            icon: 'idea_icon',
+            onAction: function () {
+                editor.insertContent('<img src="{% static "svg/idea.svg" %}" style="width:1.5em">');
+            }
+        });
+    }
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
Improvements in page form:
- Dropdown for translation direction
- Derive source language automatically from language tree
- Automatically preselect currently selected language as target language

Improvements in side-by-side view:
- Include only target language in url
- Derive source language automatically from language tree
- Adapt layout to normal page form
- Add permalink input field
- Add minor_edit checkbox
- Add draft/publish buttons
- TinyMCE editor for textarea fields
- "Copy content from source to target language"-button

Fixes #235