### PR TITLE
Fix GVZ API URL

### DIFF
--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -227,7 +227,7 @@ COMPRESS_ENABLED = False
 COMPRESS_OFFLINE = True
 
 # GVZ (Gemeindeverzeichnis) API URL
-GVZ_API_URL = "https://gvz.integreat-app.de/api/"
+GVZ_API_URL = "https://gvz.integreat-app.de/api"
 GVZ_API_ENABLED = True
 
 # Allow access to all domains by setting the following variable to TRUE

--- a/src/gvz_api/apps.py
+++ b/src/gvz_api/apps.py
@@ -30,11 +30,13 @@ class GvzApiConfig(AppConfig):
                     response = requests.get(
                         f"{settings.GVZ_API_URL}/search/expect_empty_json", timeout=3
                     )
-                    json.loads(response.text)
+                    # Require the response to be empty, otherwise it's probably an error
+                    assert not json.loads(response.text)
                 except (
                     json.decoder.JSONDecodeError,
                     requests.exceptions.RequestException,
                     requests.exceptions.Timeout,
+                    AssertionError,
                 ):
                     logger.info(
                         "GVZ API is not available. You won't be able to "


### PR DESCRIPTION
- Remove the trailing slash from the api, because the slash is also appended whenever the api url is used
- Check if response from `expect_empty_json` is actually empty

Fixes #478