### PR TITLE
Add rel="noreferrer" to external links

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-03 12:28+0000\n"
+"POT-Creation-Date: 2020-09-03 12:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1520,7 +1520,7 @@ msgstr ""
 "beliebige Seiten zu ändern."
 
 #: templates/pages/page_form.html:274 templates/pages/page_form.html:275
-#: templates/pages/page_tree_archived_node.html:88
+#: templates/pages/page_tree_archived_node.html:87
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
@@ -1529,7 +1529,7 @@ msgid "Restore this page"
 msgstr "Diese Seite wiederherstellen"
 
 #: templates/pages/page_form.html:279 templates/pages/page_form.html:280
-#: templates/pages/page_tree_node.html:91
+#: templates/pages/page_tree_node.html:90
 msgid "Archive page"
 msgstr "Seite archivieren"
 
@@ -1538,14 +1538,14 @@ msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
 #: templates/pages/page_form.html:288 templates/pages/page_form.html:292
-#: templates/pages/page_tree_archived_node.html:97
-#: templates/pages/page_tree_node.html:100
+#: templates/pages/page_tree_archived_node.html:96
+#: templates/pages/page_tree_node.html:99
 msgid "Delete page"
 msgstr "Seite löschen"
 
 #: templates/pages/page_form.html:290
-#: templates/pages/page_tree_archived_node.html:93
-#: templates/pages/page_tree_node.html:96 views/pages/page_actions.py:85
+#: templates/pages/page_tree_archived_node.html:92
+#: templates/pages/page_tree_node.html:95 views/pages/page_actions.py:85
 msgid "You cannot delete a page which has children."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
@@ -1635,16 +1635,16 @@ msgstr "Archivierte Seiten"
 msgid "No pages archived yet."
 msgstr "Noch keine Seiten archiviert."
 
-#: templates/pages/page_tree_archived_node.html:85
-#: templates/pages/page_tree_node.html:84
+#: templates/pages/page_tree_archived_node.html:84
+#: templates/pages/page_tree_node.html:83
 msgid "View page"
 msgstr "Seite ansehen"
 
-#: templates/pages/page_tree_archived_node.html:103
+#: templates/pages/page_tree_archived_node.html:102
 msgid "Download page"
 msgstr "Seite herunterladen"
 
-#: templates/pages/page_tree_node.html:87
+#: templates/pages/page_tree_node.html:86
 msgid "Edit page"
 msgstr "Seite bearbeiten"
 

--- a/src/cms/templates/pages/page_tree_archived_node.html
+++ b/src/cms/templates/pages/page_tree_archived_node.html
@@ -81,8 +81,7 @@
     <td class="pl-2 pr-4 text-right">
         <!-- TODO: add link to view page in web app -->
         <a href="{% url 'view_page' page_id=page.id region_slug=region.slug language_code=language.code %}"
-           target="_blank"
-           title="{% trans 'View page' %}" class="py-3" style="padding-right:4px;">
+           target="_blank" rel="noopener noreferrer" title="{% trans 'View page' %}" class="py-3" style="padding-right:4px;">
             <i data-feather="eye" class="inline-block text-gray-800"></i>
         </a>
         <button title="{% trans 'Restore page' %}" class="confirmation-button py-3 pl-4" data-confirmation-title="{% if page_translation %}{{ page_translation.title }}{% endif %}" data-action="{% url 'restore_page' page_id=page.id region_slug=region.slug language_code=language.code %}" data-confirmation-popup="#confirm-restore-page">

--- a/src/cms/templates/pages/page_tree_node.html
+++ b/src/cms/templates/pages/page_tree_node.html
@@ -80,8 +80,7 @@
     <td class="pl-2 pr-4 text-right min">
         <!-- TODO: add link to view page in web app -->
         <a href="{% url 'view_page' page_id=page.id region_slug=region.slug language_code=language.code %}"
-           target="_blank"
-           title="{% trans 'View page' %}" class="py-3 px-2">
+           target="_blank" rel="noopener noreferrer" title="{% trans 'View page' %}" class="py-3 px-2">
             <i data-feather="eye" class="inline-block text-gray-800"></i>
         </a>
         <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_code=language.code %}" title="{% trans 'Edit page' %}" class="py-3 px-2">

--- a/src/cms/templates/regions/region_list_row.html
+++ b/src/cms/templates/regions/region_list_row.html
@@ -15,7 +15,7 @@
 		</a>
 	</td>
 	<td>
-		<a href="https://integreat.app{% url 'dashboard' region_slug=region.slug %}" target="_blank" class="block py-3 px-2 text-gray-800">
+		<a href="https://integreat.app{% url 'dashboard' region_slug=region.slug %}" target="_blank" rel="noopener noreferrer" class="block py-3 px-2 text-gray-800">
 			https://integreat.app{% url 'dashboard' region_slug=region.slug %}
 		</a>
 	</td>


### PR DESCRIPTION
This fixes code scanning alerts of CodeQL.
See https://help.semmle.com/wiki/display/JS/Potentially+unsafe+external+link for more information on this issue.