### PR TITLE
Change messages for consistency, fixes #282

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-08 16:05+0000\n"
+"POT-Creation-Date: 2020-10-09 10:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1671,7 +1671,7 @@ msgstr "Seite löschen"
 
 #: templates/pages/page_form.html:295
 #: templates/pages/page_tree_archived_node.html:92
-#: templates/pages/page_tree_node.html:96 views/pages/page_actions.py:98
+#: templates/pages/page_tree_node.html:96
 msgid "You cannot delete a page which has children."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
@@ -2608,16 +2608,16 @@ msgid "An unexpected error has occurred."
 msgstr "Es ist ein unerwarteter Fehler aufgetreten."
 
 #: views/events/event_actions.py:30
-msgid "Event was successfully archived."
-msgstr "Veranstaltung wurde erfolgreich archiviert."
+msgid "Event was successfully archived"
+msgstr "Veranstaltung wurde erfolgreich archiviert"
 
 #: views/events/event_actions.py:53
-msgid "Event was successfully restored."
-msgstr "Veranstaltung wurde erfolgreich wiederhergestellt."
+msgid "Event was successfully restored"
+msgstr "Veranstaltung wurde erfolgreich wiederhergestellt"
 
 #: views/events/event_actions.py:73
-msgid "Event was successfully deleted."
-msgstr "Veranstaltung wurde erfolgreich gelöscht."
+msgid "Event was successfully deleted"
+msgstr "Veranstaltung wurde erfolgreich gelöscht"
 
 #: views/events/event_list_view.py:52
 msgid "Please create at least one language node before creating events."
@@ -2642,10 +2642,8 @@ msgid "You cannot edit this event because it is archived."
 msgstr ""
 "Sie können diese Veranstaltung nicht bearbeiten, weil sie archiviert ist."
 
-#: views/events/event_view.py:143
-#: views/language_tree/language_tree_node_view.py:66
-#: views/pages/page_sbs_view.py:156 views/pages/page_view.py:186
-#: views/pois/poi_view.py:109 views/regions/region_view.py:46
+#: views/events/event_view.py:143 views/pages/page_sbs_view.py:156
+#: views/pages/page_view.py:186 views/regions/region_view.py:46
 #: views/settings/user_settings_view.py:51
 #: views/settings/user_settings_view.py:68 views/users/region_user_view.py:92
 #: views/users/user_view.py:79
@@ -2653,29 +2651,29 @@ msgid "No changes detected."
 msgstr "Keine Änderungen vorgenommen."
 
 #: views/events/event_view.py:167
-msgid "Event was successfully created and published."
-msgstr "Veranstaltung wurde erfolgreich erstellt und veröffentlicht."
+msgid "Event was successfully created and published"
+msgstr "Veranstaltung wurde erfolgreich erstellt und veröffentlicht"
 
 #: views/events/event_view.py:170
-msgid "Event was successfully created."
-msgstr "Veranstaltung wurde erfolgreich erstellt."
+msgid "Event was successfully created"
+msgstr "Veranstaltung wurde erfolgreich erstellt"
 
 #: views/events/event_view.py:183
-msgid "Event translation was successfully created and published."
+msgid "Event translation was successfully created and published"
 msgstr ""
-"Veranstaltungsübersetzung wurde erfolgreich erstellt und veröffentlicht."
+"Veranstaltungsübersetzung wurde erfolgreich erstellt und veröffentlicht"
 
 #: views/events/event_view.py:187
-msgid "Event translation was successfully created."
-msgstr "Veranstaltungsübersetzung wurde erfolgreich erstellt."
+msgid "Event translation was successfully created"
+msgstr "Veranstaltungsübersetzung wurde erfolgreich erstellt"
 
 #: views/events/event_view.py:191
-msgid "Event was successfully published."
-msgstr "Veranstaltung wurde erfolgreich veröffentlicht."
+msgid "Event was successfully published"
+msgstr "Veranstaltung wurde erfolgreich veröffentlicht"
 
 #: views/events/event_view.py:193
-msgid "Event was successfully saved."
-msgstr "Veranstaltung wurde erfolgreich gespeichert."
+msgid "Event was successfully saved"
+msgstr "Veranstaltung wurde erfolgreich gespeichert"
 
 #: views/language_tree/language_tree_actions.py:54
 msgid "You can only move language tree nodes within one region."
@@ -2689,68 +2687,76 @@ msgstr "Eine Region kann nur eine Standard-Sprache besitzen."
 msgid "The language tree node \"{}\" was successfully moved."
 msgstr "Der Sprach-Knoten \"{}\" wurde erfolgreich verschoben."
 
+#: views/language_tree/language_tree_node_view.py:66 views/pois/poi_view.py:109
+msgid "No changes detected"
+msgstr "Keine Änderungen vorgenommen"
+
 #: views/language_tree/language_tree_node_view.py:72
-msgid "Language tree node was saved successfully."
-msgstr "Sprach-Baum wurde erfolgreich gespeichert."
+msgid "Language tree node was successfully saved"
+msgstr "Sprach-Baum wurde erfolgreich gespeichert"
 
 #: views/language_tree/language_tree_node_view.py:76
-msgid "Language tree node was created successfully."
-msgstr "Sprach-Baum wurde erfolgreich erstellt."
+msgid "Language tree node was successfully created"
+msgstr "Sprach-Baum wurde erfolgreich erstellt"
 
 #: views/languages/language_view.py:36
-msgid "Language saved successfully."
-msgstr "Sprache wurde erfolgreich gespeichert."
+msgid "Language was successfully saved"
+msgstr "Sprache wurde erfolgreich gespeichert"
 
 #: views/languages/language_view.py:38
-msgid "Language created successfully"
-msgstr "Sprache wurde erfolgreich erstellt."
+msgid "Language was successfully created"
+msgstr "Sprache wurde erfolgreich erstellt"
 
 #: views/offer_templates/offer_template_view.py:37
-msgid "Offer template saved successfully"
-msgstr "Angebots-Vorlage wurde erfolgreich gespeichert."
+msgid "Offer template was successfully saved"
+msgstr "Angebots-Vorlage wurde erfolgreich gespeichert"
 
 #: views/offer_templates/offer_template_view.py:40
-msgid "Offer template created successfully"
-msgstr "Angebots-Vorlage wurde erfolgreich erstellt."
+msgid "Offer template was successfully created"
+msgstr "Angebots-Vorlage wurde erfolgreich erstellt"
 
 #: views/offer_templates/offer_template_view.py:49
 #: views/organizations/organization_view.py:47 views/pages/page_sbs_view.py:154
 #: views/pages/page_view.py:168
 #: views/push_notifications/push_notification_view.py:152
-#: views/regions/region_view.py:40 views/roles/role_view.py:46
-#: views/users/region_user_view.py:95 views/users/user_view.py:89
+#: views/regions/region_view.py:40 views/users/region_user_view.py:95
+#: views/users/user_view.py:89
 msgid "Errors have occurred."
 msgstr "Es sind Fehler aufgetreten."
 
 #: views/offers/offer_actions.py:19
 #, python-format
-msgid "Offer \"%(offer_name)s\" was successfully activated."
-msgstr "Angebot \"%(offer_name)s\" wurde erfolgreich aktiviert."
+msgid "Offer \"%(offer_name)s\" was successfully activated"
+msgstr "Angebot \"%(offer_name)s\" wurde erfolgreich aktiviert"
 
 #: views/offers/offer_actions.py:40
 #, python-format
-msgid "Offer \"%(offer_name)s\" was successfully deactivated."
-msgstr "Angebot \"%(offer_name)s\" wurde erfolgreich deaktiviert."
+msgid "Offer \"%(offer_name)s\" was successfully deactivated"
+msgstr "Angebot \"%(offer_name)s\" wurde erfolgreich deaktiviert"
 
 #: views/organizations/organization_view.py:37
-msgid "Organization created successfully"
-msgstr "Organisation wurde erfolgreich erstellt."
+msgid "Organization was successfully created"
+msgstr "Organisation wurde erfolgreich erstellt"
 
 #: views/organizations/organization_view.py:40
-msgid "Organization saved successfully"
-msgstr "Organisation wurde erfolgreich gespeichert."
+msgid "Organization was successfully saved"
+msgstr "Organisation wurde erfolgreich gespeichert"
 
 #: views/pages/page_actions.py:42
-msgid "Page was successfully archived."
-msgstr "Seite wurde erfolgreich archiviert."
+msgid "Page was successfully archived"
+msgstr "Seite wurde erfolgreich archiviert"
 
 #: views/pages/page_actions.py:65
-msgid "Page was successfully restored."
-msgstr "Seite wurde erfolgreich wiederhergestellt."
+msgid "Page was successfully restored"
+msgstr "Seite wurde erfolgreich wiederhergestellt"
+
+#: views/pages/page_actions.py:98
+msgid "You cannot delete a page which has children"
+msgstr "Sie können keine Seite löschen, die Unterseiten besitzt"
 
 #: views/pages/page_actions.py:101
-msgid "Page was successfully deleted."
-msgstr "Seite wurde erfolgreich gelöscht."
+msgid "Page was successfully deleted"
+msgstr "Seite wurde erfolgreich gelöscht"
 
 #: views/pages/page_actions.py:229
 #, python-brace-format
@@ -2828,8 +2834,8 @@ msgstr ""
 "Diese Revision ist identisch mit der aktuellen Version dieser Übersetzung."
 
 #: views/pages/page_revision_view.py:151
-msgid "The revision has been successfully restored."
-msgstr "Die Revision wurde erfolgreich wiederhergestellt."
+msgid "The revision was successfully restored"
+msgstr "Die Revision wurde erfolgreich wiederhergestellt"
 
 #: views/pages/page_sbs_view.py:44 views/pages/page_sbs_view.py:116
 #, python-brace-format
@@ -2854,20 +2860,20 @@ msgid "You don't have the permission to edit this page."
 msgstr "Sie haben nicht die nötige Berechtigung, um diese Seite zu bearbeiten."
 
 #: views/pages/page_sbs_view.py:164 views/pages/page_view.py:220
-msgid "Translation was successfully created and published."
-msgstr "Übersetzung wurde erfolgreich erstellt und veröffentlicht."
+msgid "Translation was successfully created and published"
+msgstr "Übersetzung wurde erfolgreich erstellt und veröffentlicht"
 
-#: views/pages/page_sbs_view.py:168 views/pages/page_view.py:223
-msgid "Translation was successfully created."
-msgstr "Übersetzung wurde erfolgreich erstellt."
+#: views/pages/page_sbs_view.py:167 views/pages/page_view.py:223
+msgid "Translation was successfully created"
+msgstr "Übersetzung wurde erfolgreich erstellt"
 
-#: views/pages/page_sbs_view.py:173 views/pages/page_view.py:226
-msgid "Translation was successfully published."
-msgstr "Übersetzung wurde erfolgreich veröffentlicht."
+#: views/pages/page_sbs_view.py:171 views/pages/page_view.py:226
+msgid "Translation was successfully published"
+msgstr "Übersetzung wurde erfolgreich veröffentlicht"
 
-#: views/pages/page_sbs_view.py:176 views/pages/page_view.py:228
-msgid "Translation was successfully saved."
-msgstr "Übersetzung wurde erfolgreich gespeichert."
+#: views/pages/page_sbs_view.py:174 views/pages/page_view.py:228
+msgid "Translation was successfully saved"
+msgstr "Übersetzung wurde erfolgreich gespeichert"
 
 #: views/pages/page_tree_view.py:47
 msgid "Please create at least one language node before creating pages."
@@ -2905,12 +2911,12 @@ msgstr ""
 "underline'>Revision %(revision)s</a> in den Apps angezeigt."
 
 #: views/pages/page_view.py:213
-msgid "Page was successfully created and published."
-msgstr "Seite wurde erfolgreich erstellt und veröffentlicht."
+msgid "Page was successfully created and published"
+msgstr "Seite wurde erfolgreich erstellt und veröffentlicht"
 
 #: views/pages/page_view.py:216
-msgid "Page was successfully created."
-msgstr "Seite wurde erfolgreich erstellt."
+msgid "Page was successfully created"
+msgstr "Seite wurde erfolgreich erstellt"
 
 #: views/pages/page_view.py:266
 #, python-brace-format
@@ -2918,16 +2924,16 @@ msgid "{source_language} to {target_language}"
 msgstr "{source_language} nach {target_language}"
 
 #: views/pois/poi_actions.py:27
-msgid "Location was successfully archived."
-msgstr "Ort wurde erfolgreich archiviert."
+msgid "Location was successfully archived"
+msgstr "Ort wurde erfolgreich archiviert"
 
 #: views/pois/poi_actions.py:47
-msgid "Location was successfully restored."
-msgstr "Ort wurde erfolgreich wiederhergestellt."
+msgid "Location was successfully restored"
+msgstr "Ort wurde erfolgreich wiederhergestellt"
 
 #: views/pois/poi_actions.py:64
-msgid "Location was successfully deleted."
-msgstr "Ort wurde erfolgreich gelöscht."
+msgid "Location was successfully deleted"
+msgstr "Ort wurde erfolgreich gelöscht"
 
 #: views/pois/poi_list_view.py:48
 msgid "Please create at least one language node before creating locations."
@@ -2944,20 +2950,20 @@ msgid "You cannot edit this location because it is archived."
 msgstr "Sie können diesen Ort nicht bearbeiten, da er archiviert ist."
 
 #: views/pois/poi_view.py:120
-msgid "Location was successfully created and published."
-msgstr "Der Ort wurde erfolgreich erstellt und veröffentlicht."
+msgid "Location was successfully created and published"
+msgstr "Ort wurde erfolgreich erstellt und veröffentlicht"
 
 #: views/pois/poi_view.py:123
-msgid "Location was successfully created."
-msgstr "Der Ort wurde erfolgreich erstellt."
+msgid "Location was successfully created"
+msgstr "Ort wurde erfolgreich erstellt"
 
 #: views/pois/poi_view.py:133
-msgid "Location was successfully published."
-msgstr "Der Ort wurde erfolgreich veröffentlicht."
+msgid "Location was successfully published"
+msgstr "Ort wurde erfolgreich veröffentlicht"
 
 #: views/pois/poi_view.py:135
-msgid "Location was successfully saved."
-msgstr "Der Ort wurde erfolgreich gespeichert."
+msgid "Location was successfully saved"
+msgstr "Ort wurde erfolgreich gespeichert"
 
 #: views/push_notifications/push_notification_list_view.py:42
 msgid ""
@@ -2967,68 +2973,72 @@ msgstr ""
 "Benachrichtigungen verwalten."
 
 #: views/push_notifications/push_notification_view.py:84
-msgid "Push notification saved successfully."
-msgstr "Push-Benachrichtigung wurde erfolgreich gespeichert."
+msgid "Push notification was successfully saved"
+msgstr "Push-Benachrichtigung wurde erfolgreich gespeichert"
 
 #: views/push_notifications/push_notification_view.py:87
-msgid "Push notification created successfully."
-msgstr "Push-Benachrichtigung wurde erfolgreich erstellt."
+msgid "Push notification was successfully created"
+msgstr "Push-Benachrichtigung wurde erfolgreich erstellt"
 
 #: views/push_notifications/push_notification_view.py:144
-msgid "Push notification was successfully sent."
-msgstr "Push-Benachrichtigung wurde erfolgreich gespeichert."
+msgid "Push notification was successfully sent"
+msgstr "Push-Benachrichtigung wurde erfolgreich gesendet"
 
 #: views/push_notifications/push_notification_view.py:148
 msgid "Error occurred sending the push notification"
-msgstr "Push-Benachrichtigung konnte nicht gesendet werden"
+msgstr "Fehler während des Sendens der Push-Benachrichtigung"
 
 #: views/regions/region_actions.py:22
-msgid "Region was successfully deleted."
-msgstr "Region wurde erfolgreich gelöscht."
+msgid "Region was successfully deleted"
+msgstr "Region wurde erfolgreich gelöscht"
 
 #: views/regions/region_view.py:54
-msgid "Region saved successfully."
-msgstr "Region wurde erfolgreich gespeichert."
+msgid "Region was saved successfully"
+msgstr "Region wurde erfolgreich gespeichert"
 
 #: views/regions/region_view.py:56
-msgid "Region created successfully"
-msgstr "Region wurde erfolgreich erstellt."
+msgid "Region was created successfully"
+msgstr "Region wurde erfolgreich erstellt"
 
 #: views/roles/role_view.py:37
-msgid "Role saved successfully"
-msgstr "Rolle wurde erfolgreich gespeichert."
+msgid "Role was successfully saved"
+msgstr "Rolle wurde erfolgreich gespeichert"
 
 #: views/roles/role_view.py:40
-msgid "Role created successfully"
-msgstr "Rolle wurde erfolgreich erstellt."
+msgid "Role was successfully created"
+msgstr "Rolle wurde erfolgreich erstellt"
+
+#: views/roles/role_view.py:46
+msgid "Errors have occurred"
+msgstr "Es sind Fehler aufgetreten"
 
 #: views/settings/mfa/mfa.py:50
 msgid "The provided password is not correct"
-msgstr "Das angegebene Passwort ist falsch."
+msgstr "Das angegebene Passwort ist falsch"
 
 #: views/settings/mfa/mfa.py:109
 msgid "This nickname has already been used"
-msgstr "Dieser Name wurde bereits genutzt."
+msgstr "Dieser Name wurde bereits genutzt"
 
 #: views/settings/mfa/mfa.py:117
 msgid "You already registered this key"
 msgstr "Sie haben diesen Schlüssel bereits registriert"
 
 #: views/settings/user_settings_view.py:54
-msgid "E-mail-address was successfully saved."
-msgstr "E-Mail-Adresse wurde erfolgreich geändert."
+msgid "E-mail-address was successfully saved"
+msgstr "E-Mail-Adresse wurde erfolgreich geändert"
 
 #: views/settings/user_settings_view.py:73
-msgid "Password was successfully saved."
-msgstr "Passwort wurde erfolgreich geändert."
+msgid "Password was successfully saved"
+msgstr "Passwort wurde erfolgreich geändert"
 
 #: views/statistics/analytics_view.py:59
 msgid "Please enter a correct start and enddate"
-msgstr "Bitte fügen sie ein valides Start- und Enddatum für die Ansicht ein."
+msgstr "Bitte fügen sie ein gültiges Start- und Enddatum ein"
 
 #: views/statistics/analytics_view.py:86
 msgid "Connection to Matomo could not be established"
-msgstr "Es konnte keine Verbindung zum Matomo hergestellt werden."
+msgstr "Es konnte keine Verbindung zum Matomo hergestellt werden"
 
 #: views/statistics/analytics_view.py:93
 msgid ""
@@ -3056,16 +3066,16 @@ msgid "User {user} was successfully removed from this region."
 msgstr "Benutzer {user} wurde erfolgreich gelöscht."
 
 #: views/users/region_user_view.py:81 views/users/user_view.py:69
-msgid "User was successfully saved."
-msgstr "Benutzer wurde erfolgreich gespeichert."
+msgid "User was successfully saved"
+msgstr "Benutzer wurde erfolgreich gespeichert"
 
 #: views/users/region_user_view.py:83 views/users/user_view.py:71
-msgid "User was successfully created."
-msgstr "Benutzer wurde erfolgreich erstellt."
+msgid "User was successfully created"
+msgstr "Benutzer wurde erfolgreich erstellt"
 
 #: views/users/user_actions.py:17
-msgid "User was successfully deleted."
-msgstr "Benutzer wurde erfolgreich gelöscht."
+msgid "User was successfully deleted"
+msgstr "Benutzer wurde erfolgreich gelöscht"
 
 #: views/users/user_view.py:84
 msgid ""
@@ -3074,6 +3084,9 @@ msgid ""
 msgstr ""
 "Ein Benutzer muss entweder Mitarbeiter/Super-Administrator sein, oder "
 "mindestens einer Region zugewiesen sein."
+
+#~ msgid "Offer was successfully deactivated."
+#~ msgstr "Angebot wurde erfolgreich deaktiviert."
 
 #~ msgid "Create new location translation"
 #~ msgstr "Neue Orts-Übersetzung erstellen"
@@ -3087,7 +3100,6 @@ msgstr ""
 #~ msgid "Create POI"
 #~ msgstr "POI erstellen"
 
-#, python-format
 #~ msgid "Create POI with title \"%(poi_query)s\""
 #~ msgstr "POI mit Titel \"%(poi_query)s\" erstellen"
 
@@ -3189,6 +3201,36 @@ msgstr ""
 #~ msgstr ""
 #~ "Diese Quell-Sprache gehört zu einer anderen Region. Bitte geben Sie eine "
 #~ "Quell-Sprache dieser Region ein."
+
+#~ msgid "Language tree node was created successfully."
+#~ msgstr "Sprach-Baum wurde erfolgreich erstellt."
+
+#~ msgid "Language saved successfully."
+#~ msgstr "Sprache wurde erfolgreich gespeichert."
+
+#~ msgid "Language created successfully"
+#~ msgstr "Sprache wurde erfolgreich erstellt."
+
+#~ msgid "Offer template created successfully"
+#~ msgstr "Angebots-Vorlage wurde erfolgreich erstellt."
+
+#~ msgid "Organization created successfully"
+#~ msgstr "Organisation wurde erfolgreich erstellt."
+
+#~ msgid "Organization saved successfully"
+#~ msgstr "Organisation wurde erfolgreich gespeichert."
+
+#~ msgid "Push notification saved successfully."
+#~ msgstr "Push-Benachrichtigung wurde erfolgreich gespeichert."
+
+#~ msgid "Push notification created successfully."
+#~ msgstr "Push-Benachrichtigung wurde erfolgreich erstellt."
+
+#~ msgid "Role saved successfully"
+#~ msgstr "Rolle wurde erfolgreich gespeichert."
+
+#~ msgid "Role created successfully"
+#~ msgstr "Rolle wurde erfolgreich erstellt."
 
 #~ msgid "Relationship"
 #~ msgstr "Verhältnis"

--- a/src/cms/views/events/event_actions.py
+++ b/src/cms/views/events/event_actions.py
@@ -27,7 +27,7 @@ def archive(request, event_id, region_slug, language_code):
     event.archived = True
     event.save()
 
-    messages.success(request, _("Event was successfully archived."))
+    messages.success(request, _("Event was successfully archived"))
 
     return redirect(
         "events",
@@ -50,7 +50,7 @@ def restore(request, event_id, region_slug, language_code):
     event.archived = False
     event.save()
 
-    messages.success(request, _("Event was successfully restored."))
+    messages.success(request, _("Event was successfully restored"))
 
     return redirect(
         "events",
@@ -70,7 +70,7 @@ def delete(request, event_id, region_slug, language_code):
     if event.recurrence_rule:
         event.recurrence_rule.delete()
     event.delete()
-    messages.success(request, _("Event was successfully deleted."))
+    messages.success(request, _("Event was successfully deleted"))
 
     return redirect(
         "events",

--- a/src/cms/views/events/event_view.py
+++ b/src/cms/views/events/event_view.py
@@ -164,10 +164,10 @@ class EventView(PermissionRequiredMixin, TemplateView):
             if not event_instance:
                 if published:
                     messages.success(
-                        request, _("Event was successfully created and published.")
+                        request, _("Event was successfully created and published")
                     )
                 else:
-                    messages.success(request, _("Event was successfully created."))
+                    messages.success(request, _("Event was successfully created"))
                 return redirect(
                     "edit_event",
                     **{
@@ -180,17 +180,17 @@ class EventView(PermissionRequiredMixin, TemplateView):
                 if published:
                     messages.success(
                         request,
-                        _("Event translation was successfully created and published."),
+                        _("Event translation was successfully created and published"),
                     )
                 else:
                     messages.success(
-                        request, _("Event translation was successfully created.")
+                        request, _("Event translation was successfully created")
                     )
             else:
                 if published:
-                    messages.success(request, _("Event was successfully published."))
+                    messages.success(request, _("Event was successfully published"))
                 else:
-                    messages.success(request, _("Event was successfully saved."))
+                    messages.success(request, _("Event was successfully saved"))
 
         return render(
             request,

--- a/src/cms/views/language_tree/language_tree_node_view.py
+++ b/src/cms/views/language_tree/language_tree_node_view.py
@@ -63,17 +63,17 @@ class LanguageTreeNodeView(PermissionRequiredMixin, TemplateView):
                 messages.error(request, _(error))
 
         elif not language_tree_node_form.has_changed():
-            messages.info(request, _("No changes detected."))
+            messages.info(request, _("No changes detected"))
 
         else:
             language_tree_node = language_tree_node_form.save()
             if language_tree_node_instance:
                 messages.success(
-                    request, _("Language tree node was saved successfully.")
+                    request, _("Language tree node was successfully saved")
                 )
             else:
                 messages.success(
-                    request, _("Language tree node was created successfully.")
+                    request, _("Language tree node was successfully created")
                 )
             return redirect(
                 "edit_language_tree_node",

--- a/src/cms/views/languages/language_view.py
+++ b/src/cms/views/languages/language_view.py
@@ -33,9 +33,9 @@ class LanguageView(PermissionRequiredMixin, TemplateView):
         if form.is_valid():
             form.save()
             if language_code:
-                messages.success(request, _("Language saved successfully."))
+                messages.success(request, _("Language was successfully saved"))
             else:
-                messages.success(request, _("Language created successfully"))
+                messages.success(request, _("Language was successfully created"))
         else:
             # TODO: error handling
             # TODO: improve messages

--- a/src/cms/views/offer_templates/offer_template_view.py
+++ b/src/cms/views/offer_templates/offer_template_view.py
@@ -34,10 +34,10 @@ class OfferTemplateView(PermissionRequiredMixin, TemplateView):
         if offer_template_id:
             offer_template = OfferTemplate.objects.get(id=offer_template_id)
             form = OfferTemplateForm(request.POST, instance=offer_template)
-            success_message = _("Offer template saved successfully")
+            success_message = _("Offer template was successfully saved")
         else:
             form = OfferTemplateForm(request.POST)
-            success_message = _("Offer template created successfully")
+            success_message = _("Offer template was successfully created")
 
         if form.is_valid():
             messages.success(request, success_message)

--- a/src/cms/views/offers/offer_actions.py
+++ b/src/cms/views/offers/offer_actions.py
@@ -16,7 +16,7 @@ def activate(request, region_slug, offer_template_slug):
     Offer.objects.create(region=region, template=template)
     messages.success(
         request,
-        _('Offer "%(offer_name)s" was successfully activated.')
+        _('Offer "%(offer_name)s" was successfully activated')
         % {"offer_name": template.name},
     )
     return redirect(
@@ -37,7 +37,7 @@ def deactivate(request, region_slug, offer_template_slug):
     offer.delete()
     messages.success(
         request,
-        _('Offer "%(offer_name)s" was successfully deactivated.')
+        _('Offer "%(offer_name)s" was successfully deactivated')
         % {"offer_name": template.name},
     )
     return redirect(

--- a/src/cms/views/organizations/organization_view.py
+++ b/src/cms/views/organizations/organization_view.py
@@ -34,10 +34,10 @@ class OrganizationView(PermissionRequiredMixin, TemplateView):
         if organization_id:
             organization = Organization.objects.get(id=organization_id)
             form = OrganizationForm(request.POST, instance=organization)
-            success_message = _("Organization created successfully")
+            success_message = _("Organization was successfully created")
         else:
             form = OrganizationForm(request.POST)
-            success_message = _("Organization saved successfully")
+            success_message = _("Organization was successfully saved")
 
         if form.is_valid():
             form.save()

--- a/src/cms/views/pages/page_actions.py
+++ b/src/cms/views/pages/page_actions.py
@@ -39,7 +39,7 @@ def archive_page(request, page_id, region_slug, language_code):
     page.archived = True
     page.save()
 
-    messages.success(request, _("Page was successfully archived."))
+    messages.success(request, _("Page was successfully archived"))
 
     return redirect(
         "pages",
@@ -62,7 +62,7 @@ def restore_page(request, page_id, region_slug, language_code):
     page.archived = False
     page.save()
 
-    messages.success(request, _("Page was successfully restored."))
+    messages.success(request, _("Page was successfully restored"))
 
     return redirect(
         "pages",
@@ -95,10 +95,10 @@ def delete_page(request, page_id, region_slug, language_code):
     page = get_object_or_404(region.pages, id=page_id)
 
     if page.children.exists():
-        messages.error(request, _("You cannot delete a page which has children."))
+        messages.error(request, _("You cannot delete a page which has children"))
     else:
         page.delete()
-        messages.success(request, _("Page was successfully deleted."))
+        messages.success(request, _("Page was successfully deleted"))
 
     return redirect(
         "pages",

--- a/src/cms/views/pages/page_revision_view.py
+++ b/src/cms/views/pages/page_revision_view.py
@@ -148,7 +148,7 @@ class PageRevisionView(PermissionRequiredMixin, TemplateView):
 
         revision.save()
 
-        messages.success(request, _("The revision has been successfully restored."))
+        messages.success(request, _("The revision was successfully restored"))
 
         page_translations = page.translations.filter(language=language)
 

--- a/src/cms/views/pages/page_sbs_view.py
+++ b/src/cms/views/pages/page_sbs_view.py
@@ -161,19 +161,17 @@ class PageSideBySideView(PermissionRequiredMixin, TemplateView):
                 if published:
                     messages.success(
                         request,
-                        _("Translation was successfully created and published."),
+                        _("Translation was successfully created and published"),
                     )
                 else:
-                    messages.success(
-                        request, _("Translation was successfully created.")
-                    )
+                    messages.success(request, _("Translation was successfully created"))
             else:
                 if published:
                     messages.success(
-                        request, _("Translation was successfully published.")
+                        request, _("Translation was successfully published")
                     )
                 else:
-                    messages.success(request, _("Translation was successfully saved."))
+                    messages.success(request, _("Translation was successfully saved"))
 
         return render(
             request,

--- a/src/cms/views/pages/page_view.py
+++ b/src/cms/views/pages/page_view.py
@@ -210,22 +210,22 @@ class PageView(PermissionRequiredMixin, TemplateView):
         if not page_instance:
             if published:
                 messages.success(
-                    request, _("Page was successfully created and published.")
+                    request, _("Page was successfully created and published")
                 )
             else:
-                messages.success(request, _("Page was successfully created."))
+                messages.success(request, _("Page was successfully created"))
         elif not page_translation_instance:
             if published:
                 messages.success(
-                    request, _("Translation was successfully created and published.")
+                    request, _("Translation was successfully created and published")
                 )
             else:
-                messages.success(request, _("Translation was successfully created."))
+                messages.success(request, _("Translation was successfully created"))
         else:
             if published:
-                messages.success(request, _("Translation was successfully published."))
+                messages.success(request, _("Translation was successfully published"))
             else:
-                messages.success(request, _("Translation was successfully saved."))
+                messages.success(request, _("Translation was successfully saved"))
 
         return redirect(
             "edit_page",

--- a/src/cms/views/pois/poi_actions.py
+++ b/src/cms/views/pois/poi_actions.py
@@ -24,7 +24,7 @@ def archive_poi(request, poi_id, region_slug, language_code):
     poi.archived = True
     poi.save()
 
-    messages.success(request, _("Location was successfully archived."))
+    messages.success(request, _("Location was successfully archived"))
 
     return redirect(
         "pois",
@@ -44,7 +44,7 @@ def restore_poi(request, poi_id, region_slug, language_code):
     poi.archived = False
     poi.save()
 
-    messages.success(request, _("Location was successfully restored."))
+    messages.success(request, _("Location was successfully restored"))
 
     return redirect(
         "pois",
@@ -61,7 +61,7 @@ def delete_poi(request, poi_id, region_slug, language_code):
 
     poi = POI.objects.get(id=poi_id)
     poi.delete()
-    messages.success(request, _("Location was successfully deleted."))
+    messages.success(request, _("Location was successfully deleted"))
 
     return redirect(
         "pois",

--- a/src/cms/views/pois/poi_view.py
+++ b/src/cms/views/pois/poi_view.py
@@ -106,7 +106,7 @@ class POIView(PermissionRequiredMixin, TemplateView):
 
         elif not poi_form.has_changed() and not poi_translation_form.has_changed():
 
-            messages.info(request, _("No changes detected."))
+            messages.info(request, _("No changes detected"))
 
         else:
 
@@ -117,10 +117,10 @@ class POIView(PermissionRequiredMixin, TemplateView):
             if not poi_instance:
                 if published:
                     messages.success(
-                        request, _("Location was successfully created and published.")
+                        request, _("Location was successfully created and published")
                     )
                 else:
-                    messages.success(request, _("Location was successfully created."))
+                    messages.success(request, _("Location was successfully created"))
                 return redirect(
                     "edit_poi",
                     **{
@@ -130,9 +130,9 @@ class POIView(PermissionRequiredMixin, TemplateView):
                     }
                 )
             if published:
-                messages.success(request, _("Location was successfully published."))
+                messages.success(request, _("Location was successfully published"))
             else:
-                messages.success(request, _("Location was successfully saved."))
+                messages.success(request, _("Location was successfully saved"))
 
         return render(
             request,

--- a/src/cms/views/push_notifications/push_notification_view.py
+++ b/src/cms/views/push_notifications/push_notification_view.py
@@ -81,10 +81,10 @@ class PushNotificationView(PermissionRequiredMixin, TemplateView):
             push_notification_form = PushNotificationForm(
                 request.POST, instance=push_notification
             )
-            success_message = _("Push notification saved successfully.")
+            success_message = _("Push notification was successfully saved")
         else:
             push_notification_form = PushNotificationForm(request.POST)
-            success_message = _("Push notification created successfully.")
+            success_message = _("Push notification was successfully created")
 
         # Then check if translation in current language already exists
         push_notification_translation = PushNotificationTranslation.objects.filter(
@@ -141,7 +141,7 @@ class PushNotificationView(PermissionRequiredMixin, TemplateView):
                     push_notification.sent_date = timezone.now()
                     push_notification.save()
                     messages.success(
-                        request, _("Push notification was successfully sent.")
+                        request, _("Push notification was successfully sent")
                     )
                 else:
                     messages.error(

--- a/src/cms/views/regions/region_actions.py
+++ b/src/cms/views/regions/region_actions.py
@@ -19,6 +19,6 @@ def delete_region(request, *args, **kwargs):
     region = Region.get_current_region(request)
     region.delete()
 
-    messages.success(request, _("Region was successfully deleted."))
+    messages.success(request, _("Region was successfully deleted"))
 
     return redirect("regions")

--- a/src/cms/views/regions/region_view.py
+++ b/src/cms/views/regions/region_view.py
@@ -51,9 +51,9 @@ class RegionView(PermissionRequiredMixin, TemplateView):
         region = form.save()
 
         if region_instance:
-            messages.success(request, _("Region saved successfully."))
+            messages.success(request, _("Region was saved successfully"))
         else:
-            messages.success(request, _("Region created successfully"))
+            messages.success(request, _("Region was created successfully"))
 
         return redirect(
             "edit_region",

--- a/src/cms/views/roles/role_view.py
+++ b/src/cms/views/roles/role_view.py
@@ -34,15 +34,15 @@ class RoleView(PermissionRequiredMixin, TemplateView):
         if role_id:
             role = Role.objects.get(id=role_id)
             form = RoleForm(request.POST, instance=role)
-            success_message = _("Role saved successfully")
+            success_message = _("Role was successfully saved")
         else:
             form = RoleForm(request.POST)
-            success_message = _("Role created successfully")
+            success_message = _("Role was successfully created")
         if form.is_valid():
             form.save()
             messages.success(request, success_message)
         else:
             # TODO: improve messages
-            messages.error(request, _("Errors have occurred."))
+            messages.error(request, _("Errors have occurred"))
 
         return render(request, self.template_name, {"form": form, **self.base_context})

--- a/src/cms/views/settings/user_settings_view.py
+++ b/src/cms/views/settings/user_settings_view.py
@@ -51,7 +51,7 @@ class UserSettingsView(TemplateView):
                 messages.info(request, _("No changes detected."))
             else:
                 user_email_form.save()
-                messages.success(request, _("E-mail-address was successfully saved."))
+                messages.success(request, _("E-mail-address was successfully saved"))
 
         elif request.POST.get("submit_form") == "password_form":
             user_password_form = UserPasswordForm(request.POST, instance=user)
@@ -70,6 +70,6 @@ class UserSettingsView(TemplateView):
                 user = user_password_form.save()
                 # Prevent user from being logged out after password has changed
                 update_session_auth_hash(request, user)
-                messages.success(request, _("Password was successfully saved."))
+                messages.success(request, _("Password was successfully saved"))
 
         return redirect("user_settings")

--- a/src/cms/views/users/region_user_view.py
+++ b/src/cms/views/users/region_user_view.py
@@ -78,9 +78,9 @@ class RegionUserView(PermissionRequiredMixin, TemplateView):
 
             if region_user_form.has_changed() or user_profile_form.has_changed():
                 if user_instance:
-                    messages.success(request, _("User was successfully saved."))
+                    messages.success(request, _("User was successfully saved"))
                 else:
-                    messages.success(request, _("User was successfully created."))
+                    messages.success(request, _("User was successfully created"))
                     return redirect(
                         "edit_region_user",
                         **{

--- a/src/cms/views/users/user_actions.py
+++ b/src/cms/views/users/user_actions.py
@@ -14,6 +14,6 @@ def delete_user(request, user_id):
 
     get_user_model().objects.get(id=user_id).delete()
 
-    messages.success(request, _("User was successfully deleted."))
+    messages.success(request, _("User was successfully deleted"))
 
     return redirect("users")

--- a/src/cms/views/users/user_view.py
+++ b/src/cms/views/users/user_view.py
@@ -66,9 +66,9 @@ class UserView(PermissionRequiredMixin, TemplateView):
 
                 if user_form.has_changed() or user_profile_form.has_changed():
                     if user_instance:
-                        messages.success(request, _("User was successfully saved."))
+                        messages.success(request, _("User was successfully saved"))
                     else:
-                        messages.success(request, _("User was successfully created."))
+                        messages.success(request, _("User was successfully created"))
                         return redirect(
                             "edit_user",
                             **{


### PR DESCRIPTION
* Order of words was changed for many messages to be consistent.
* Stops at the end of messages was removed, as they're not really sentences and the stop just makes them unnecessarily longer.

Fixes #282

Co-authored-by: Amin Al-Ait <aminalait@outlook>