### PR TITLE
Improve page revision slider

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-09 10:26+0000\n"
+"POT-Creation-Date: 2020-10-09 10:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -919,7 +919,7 @@ msgstr "Version"
 
 #: templates/events/event_form.html:148 templates/events/event_list.html:69
 #: templates/events/event_list_archived.html:52
-#: templates/pages/page_form.html:152 templates/pages/page_revisions.html:27
+#: templates/pages/page_form.html:152 templates/pages/page_revisions.html:44
 #: templates/pages/page_sbs.html:82 templates/pages/page_sbs.html:149
 #: templates/pages/page_sbs.html:154 templates/pages/page_tree.html:60
 #: templates/pages/page_tree_archived.html:32 templates/pois/poi_form.html:137
@@ -929,8 +929,8 @@ msgid "Status"
 msgstr "Status"
 
 #: templates/events/event_form.html:151 templates/pages/page_form.html:155
-#: templates/pages/page_revisions.html:45
-#: templates/pages/page_revisions.html:59 templates/pages/page_sbs.html:84
+#: templates/pages/page_revisions.html:62
+#: templates/pages/page_revisions.html:76 templates/pages/page_sbs.html:84
 #: templates/pages/page_sbs.html:157 templates/pois/poi_form.html:140
 #: templates/regions/region_form.html:53
 msgid "Permalink"
@@ -944,8 +944,8 @@ msgstr ""
 "generieren"
 
 #: templates/events/event_form.html:164 templates/pages/page_form.html:168
-#: templates/pages/page_revisions.html:47
-#: templates/pages/page_revisions.html:60 templates/pages/page_sbs.html:98
+#: templates/pages/page_revisions.html:64
+#: templates/pages/page_revisions.html:77 templates/pages/page_sbs.html:98
 #: templates/pages/page_sbs.html:170 templates/pages/page_xliff_confirm.html:43
 #: templates/pois/poi_form.html:150
 #: templates/push_notifications/push_notification_form.html:49
@@ -1594,8 +1594,8 @@ msgstr "Revision"
 msgid "Show revisions"
 msgstr "Revisionen anzeigen"
 
-#: templates/pages/page_form.html:171 templates/pages/page_revisions.html:49
-#: templates/pages/page_revisions.html:61 templates/pages/page_sbs.html:101
+#: templates/pages/page_form.html:171 templates/pages/page_revisions.html:66
+#: templates/pages/page_revisions.html:78 templates/pages/page_sbs.html:101
 #: templates/pages/page_sbs.html:173 templates/pages/page_xliff_confirm.html:45
 #: templates/push_notifications/push_notification_form.html:54
 msgid "Content"
@@ -1684,31 +1684,31 @@ msgstr "Diese Seite löschen"
 msgid "Page revisions of \"%(page_title)s\""
 msgstr "Revisionen der Seite \"%(page_title)s\""
 
-#: templates/pages/page_revisions.html:30
+#: templates/pages/page_revisions.html:47
 msgid "This is the revision shown in the apps."
 msgstr "Diese Revision wird in den Apps angezeigt."
 
-#: templates/pages/page_revisions.html:32
+#: templates/pages/page_revisions.html:49
 msgid "This is <b>not</b> the revision shown in the apps."
 msgstr "Diese Revision wird <b>nicht</b> in den Apps angezeigt."
 
-#: templates/pages/page_revisions.html:35
+#: templates/pages/page_revisions.html:52
 msgid "Editor"
 msgstr "Bearbeiter"
 
-#: templates/pages/page_revisions.html:68
+#: templates/pages/page_revisions.html:85
 msgid "Restore this revision as draft"
 msgstr "Diese Revision als Entwurf wiederherstellen"
 
-#: templates/pages/page_revisions.html:71
+#: templates/pages/page_revisions.html:88
 msgid "Restore and publish this revision"
 msgstr "Diese Revision wiederherstellen und veröffentlichen"
 
-#: templates/pages/page_revisions.html:73
+#: templates/pages/page_revisions.html:90
 msgid "Restore this revision and submit for review"
 msgstr "Diese Revision wiederherstellen und zum Review vorlegen"
 
-#: templates/pages/page_revisions.html:78 templates/pages/page_sbs.html:38
+#: templates/pages/page_revisions.html:95 templates/pages/page_sbs.html:38
 msgid "Go Back to Page Editor"
 msgstr "Zurück zum Seiten-Editor"
 

--- a/src/cms/static/css/style.less
+++ b/src/cms/static/css/style.less
@@ -391,6 +391,17 @@ input[type=file].image-field {
     z-index: 100;
 }
 
+datalist {
+    margin-top: -23px;
+}
+
+datalist option {
+    background-color: #e2e8f0;
+    border-radius: 50%;
+    padding: 3px 8px;
+    font-weight: bolder;
+}
+
 /* Page Revision Slider */
 #revision-slider {
     -webkit-appearance: none;
@@ -400,8 +411,6 @@ input[type=file].image-field {
     background: #e2e8f0;
     outline: none;
     opacity: 0.7;
-    -webkit-transition: .2s;
-    transition: opacity .2s;
 
     &::-webkit-slider-thumb {
         -webkit-appearance: none;

--- a/src/cms/templates/pages/page_revisions.html
+++ b/src/cms/templates/pages/page_revisions.html
@@ -18,8 +18,25 @@
 <form method="post" action="{% url 'page_revisions' page_id=page.id region_slug=region.slug language_code=language.code %}">
     {% csrf_token %}
     <div class="w-full mb-20 relative">
-        <input type="range" name="revision" min="1" max="{{ page_translations.count }}" value="{{ selected_revision.version }}" id="revision-slider">
+        <input type="range" name="revision" min="1" max="{{ page_translations.count }}" value="{{ selected_revision.version }}" id="revision-slider" list="steplist">
         <output id="revision-info"></output>
+        <datalist id ="steplist" class="w-full flex font-mono">
+            {% for page_translation in page_translations reversed %}
+                <option style="
+                    {% if page_translation.version > 1 %}
+                        margin-left: -webkit-calc(((100% - 25.6px) / ({{ page_translations.count }} - 1)) - 25.6px);
+                        margin-left: -moz-calc(((100% - 25.6px) / ({{ page_translations.count }} - 1)) - 25.6px);
+                        margin-left: calc(((100% - 25.6px) / ({{ page_translations.count }} - 1)) - 25.6px);
+                    {% endif %}
+                    {% if page_translation.version > 9 %}
+                        padding-left: 3.2px;
+                        padding-right: 3.2px;
+                    {% endif %}
+                    ">
+                        {{ page_translation.version }}
+                </option>
+            {% endfor %}
+        </datalist>
     </div>
 
     {% for page_translation in page_translations %}


### PR DESCRIPTION
This adds steps and labels to the revision slider:

![Screenshot_2020-09-24 Integreat CMS](https://user-images.githubusercontent.com/16021269/94179205-79cc3200-fe9c-11ea-871b-cd4c8b675503.png)

However, in my current Chromium version (85.0.4183.121), the `calc()`-statement doesn't work and the steps do not have the correct margins:

![revisions_chromium](https://user-images.githubusercontent.com/16021269/94179309-9c5e4b00-fe9c-11ea-8120-c00aa71e942d.png)

Does anybody have an idea how to resolve this (or do we just decide to not support this version of Chromium)?

Fixes #487