### PR TITLE
Add favicon.ico route

### DIFF
--- a/src/cms/urls.py
+++ b/src/cms/urls.py
@@ -8,6 +8,7 @@ from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.conf import settings as django_settings
 from django.contrib.auth import views as auth_views
+from django.views.generic import RedirectView
 
 from .forms.authentication import PasswordResetConfirmForm
 from .views import (
@@ -691,4 +692,5 @@ urlpatterns = [
             ]
         ),
     ),
+    url(r"^favicon\.ico$", RedirectView.as_view(url="/static/images/favicon.ico")),
 ] + static(django_settings.MEDIA_URL, document_root=django_settings.MEDIA_ROOT)


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Most browsers will request the `favicon.ico` file per default, even if it's not used in the templates.
This results in misleading log entries, e.g.:
```
Oct 02 14:16:40 INTEGREAT CMS - WARNING: Not Found: /favicon.ico
Oct 02 14:16:40 INTEGREAT CMS - WARNING: "GET /favicon.ico HTTP/1.1" 404 6960
```

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add `/favicon.ico` route and redirect to `/static/images/favicon.ico`


