### PR TITLE
Disable Heading 1 style in certain TinyMCE fields

### DIFF
--- a/src/cms/forms/events/event_translation_form.py
+++ b/src/cms/forms/events/event_translation_form.py
@@ -1,6 +1,8 @@
 import logging
 
 from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext_lazy as _
 
 from ...constants import status
 from ...models import EventTranslation
@@ -89,3 +91,14 @@ class EventTranslationForm(forms.ModelForm):
         self.data = self.data.copy()
         self.data["slug"] = unique_slug
         return unique_slug
+
+    def clean_description(self):
+        description = self.data["description"]
+
+        if "<h1>" in description:
+            raise ValidationError(
+                _("Use of Heading 1 style not allowed."),
+                code="no-heading-1",
+            )
+
+        return description

--- a/src/cms/forms/pages/page_translation_form.py
+++ b/src/cms/forms/pages/page_translation_form.py
@@ -1,6 +1,8 @@
 import logging
 
 from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext_lazy as _
 
 from ...constants import status
 from ...models import PageTranslation
@@ -85,3 +87,14 @@ class PageTranslationForm(forms.ModelForm):
 
     def clean_slug(self):
         return generate_unique_slug(self, "page")
+
+    def clean_text(self):
+        text = self.data["text"]
+
+        if "<h1>" in text:
+            raise ValidationError(
+                _("Use of Heading 1 style not allowed."),
+                code="no-heading-1",
+            )
+
+        return text

--- a/src/cms/forms/pois/poi_translation_form.py
+++ b/src/cms/forms/pois/poi_translation_form.py
@@ -1,6 +1,7 @@
 import logging
 
 from django import forms
+from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
 from ...constants import status
@@ -93,3 +94,14 @@ class POITranslationForm(forms.ModelForm):
         self.data = self.data.copy()
         self.data["slug"] = unique_slug
         return unique_slug
+
+    def clean_description(self):
+        description = self.data["description"]
+
+        if "<h1>" in description:
+            raise ValidationError(
+                _("Use of Heading 1 style not allowed."),
+                code="no-heading-1",
+            )
+
+        return description

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -279,6 +279,12 @@ msgstr ""
 msgid "The end of the event can't be before the start of the event"
 msgstr "Das Ende der Veranstaltung kann nicht vor seinem Beginn sein"
 
+#: forms/events/event_translation_form.py:100
+#: forms/pages/page_translation_form.py:96
+#: forms/pois/poi_translation_form.py:103
+msgid "Use of Heading 1 style not allowed."
+msgstr "Bitte benutzen Sie keine Überschrift 1 in diesem Feld."
+
 #: forms/events/recurrence_rule_form.py:67
 msgid "No recurrence frequency selected"
 msgstr "Keine Häufigkeit der Wiederholung angegeben"

--- a/src/cms/templates/events/event_form.html
+++ b/src/cms/templates/events/event_form.html
@@ -417,6 +417,7 @@
                 autosave_interval: '120s',
                 plugins: "code paste fullscreen autosave link preview media image lists directionality",
                 toolbar: 'bold italic underline forecolor | bullist numlist | styleselect | undo redo | ltr rtl notranslate removeformat | aligncenter indent outdent | link image',
+                block_formats: 'Paragraph=p; Heading 2=h2; Heading 3=h3; Heading 4=h4; Heading 5=h5; Heading 6=h6',
                 min_height: 400,
                 content_css : '{% static "css/tinymce_custom.css" %}',
                 language: '{{LANGUAGE_CODE|slice:"0:2"}}',

--- a/src/cms/templates/events/event_form.html
+++ b/src/cms/templates/events/event_form.html
@@ -417,7 +417,36 @@
                 autosave_interval: '120s',
                 plugins: "code paste fullscreen autosave link preview media image lists directionality",
                 toolbar: 'bold italic underline forecolor | bullist numlist | styleselect | undo redo | ltr rtl notranslate removeformat | aligncenter indent outdent | link image',
-                block_formats: 'Paragraph=p; Heading 2=h2; Heading 3=h3; Heading 4=h4; Heading 5=h5; Heading 6=h6',
+                style_formats: [
+                    { title: 'Headings', items: [
+                        { title: 'Heading 2', format: 'h2' },
+                        { title: 'Heading 3', format: 'h3' },
+                        { title: 'Heading 4', format: 'h4' },
+                        { title: 'Heading 5', format: 'h5' },
+                        { title: 'Heading 6', format: 'h6' }
+                    ]},
+                    { title: 'Inline', items: [
+                        { title: 'Bold', format: 'bold' },
+                        { title: 'Italic', format: 'italic' },
+                        { title: 'Underline', format: 'underline' },
+                        { title: 'Strikethrough', format: 'strikethrough' },
+                        { title: 'Superscript', format: 'superscript' },
+                        { title: 'Subscript', format: 'subscript' },
+                        { title: 'Code', format: 'code' }
+                    ]},
+                    { title: 'Blocks', items: [
+                        { title: 'Paragraph', format: 'p' },
+                        { title: 'Blockquote', format: 'blockquote' },
+                        { title: 'Div', format: 'div' },
+                        { title: 'Pre', format: 'pre' }
+                    ]},
+                    { title: 'Align', items: [
+                        { title: 'Left', format: 'alignleft' },
+                        { title: 'Center', format: 'aligncenter' },
+                        { title: 'Right', format: 'alignright' },
+                        { title: 'Justify', format: 'alignjustify' }
+                    ]}
+                ],
                 min_height: 400,
                 content_css : '{% static "css/tinymce_custom.css" %}',
                 language: '{{LANGUAGE_CODE|slice:"0:2"}}',

--- a/src/cms/templates/pages/page_form.html
+++ b/src/cms/templates/pages/page_form.html
@@ -362,11 +362,12 @@ document.addEventListener('DOMContentLoaded', function(){
         contextmenu: "paste link",
         autosave_interval: '120s',
         toolbar: 'bold italic underline forecolor | bullist numlist | styleselect | undo redo | ltr rtl notranslate removeformat | aligncenter indent outdent | link image',
+        block_formats: 'Paragraph=p; Heading 2=h2; Heading 3=h3; Heading 4=h4; Heading 5=h5; Heading 6=h6',
         min_height: 400,
         content_css : '{% static "css/tinymce_custom.css" %}',
         language: '{{LANGUAGE_CODE|slice:"0:2"}}',
         setup: (editor) => {
-            editor.ui.registry.addButton('notranslate', 
+            editor.ui.registry.addButton('notranslate',
             {
                 tooltip: '{% trans 'Do not translate the selected text.' %}',
                 icon: 'permanent-pen',

--- a/src/cms/templates/pages/page_form.html
+++ b/src/cms/templates/pages/page_form.html
@@ -362,7 +362,36 @@ document.addEventListener('DOMContentLoaded', function(){
         contextmenu: "paste link",
         autosave_interval: '120s',
         toolbar: 'bold italic underline forecolor | bullist numlist | styleselect | undo redo | ltr rtl notranslate removeformat | aligncenter indent outdent | link image',
-        block_formats: 'Paragraph=p; Heading 2=h2; Heading 3=h3; Heading 4=h4; Heading 5=h5; Heading 6=h6',
+        style_formats: [
+            { title: 'Headings', items: [
+                { title: 'Heading 2', format: 'h2' },
+                { title: 'Heading 3', format: 'h3' },
+                { title: 'Heading 4', format: 'h4' },
+                { title: 'Heading 5', format: 'h5' },
+                { title: 'Heading 6', format: 'h6' }
+            ]},
+            { title: 'Inline', items: [
+                { title: 'Bold', format: 'bold' },
+                { title: 'Italic', format: 'italic' },
+                { title: 'Underline', format: 'underline' },
+                { title: 'Strikethrough', format: 'strikethrough' },
+                { title: 'Superscript', format: 'superscript' },
+                { title: 'Subscript', format: 'subscript' },
+                { title: 'Code', format: 'code' }
+            ]},
+            { title: 'Blocks', items: [
+                { title: 'Paragraph', format: 'p' },
+                { title: 'Blockquote', format: 'blockquote' },
+                { title: 'Div', format: 'div' },
+                { title: 'Pre', format: 'pre' }
+            ]},
+            { title: 'Align', items: [
+                { title: 'Left', format: 'alignleft' },
+                { title: 'Center', format: 'aligncenter' },
+                { title: 'Right', format: 'alignright' },
+                { title: 'Justify', format: 'alignjustify' }
+            ]}
+        ],
         min_height: 400,
         content_css : '{% static "css/tinymce_custom.css" %}',
         language: '{{LANGUAGE_CODE|slice:"0:2"}}',

--- a/src/cms/templates/pages/page_sbs.html
+++ b/src/cms/templates/pages/page_sbs.html
@@ -207,6 +207,7 @@ tinymce.init({
     },
     plugins: "code paste fullscreen autosave link preview media image lists directionality",
     toolbar: 'bold italic underline forecolor | bullist numlist | styleselect | undo redo | ltr rtl notranslate removeformat | aligncenter indent outdent | link image',
+    block_formats: 'Paragraph=p; Heading 2=h2; Heading 3=h3; Heading 4=h4; Heading 5=h5; Heading 6=h6',
     min_height: 478,
     contextmenu: "paste link",
     autosave_interval: '120s',

--- a/src/cms/templates/pages/page_sbs.html
+++ b/src/cms/templates/pages/page_sbs.html
@@ -207,7 +207,36 @@ tinymce.init({
     },
     plugins: "code paste fullscreen autosave link preview media image lists directionality",
     toolbar: 'bold italic underline forecolor | bullist numlist | styleselect | undo redo | ltr rtl notranslate removeformat | aligncenter indent outdent | link image',
-    block_formats: 'Paragraph=p; Heading 2=h2; Heading 3=h3; Heading 4=h4; Heading 5=h5; Heading 6=h6',
+    style_formats: [
+        { title: 'Headings', items: [
+            { title: 'Heading 2', format: 'h2' },
+            { title: 'Heading 3', format: 'h3' },
+            { title: 'Heading 4', format: 'h4' },
+            { title: 'Heading 5', format: 'h5' },
+            { title: 'Heading 6', format: 'h6' }
+        ]},
+        { title: 'Inline', items: [
+            { title: 'Bold', format: 'bold' },
+            { title: 'Italic', format: 'italic' },
+            { title: 'Underline', format: 'underline' },
+            { title: 'Strikethrough', format: 'strikethrough' },
+            { title: 'Superscript', format: 'superscript' },
+            { title: 'Subscript', format: 'subscript' },
+            { title: 'Code', format: 'code' }
+        ]},
+        { title: 'Blocks', items: [
+            { title: 'Paragraph', format: 'p' },
+            { title: 'Blockquote', format: 'blockquote' },
+            { title: 'Div', format: 'div' },
+            { title: 'Pre', format: 'pre' }
+        ]},
+        { title: 'Align', items: [
+            { title: 'Left', format: 'alignleft' },
+            { title: 'Center', format: 'aligncenter' },
+            { title: 'Right', format: 'alignright' },
+            { title: 'Justify', format: 'alignjustify' }
+        ]}
+    ],
     min_height: 478,
     contextmenu: "paste link",
     autosave_interval: '120s',

--- a/src/cms/templates/pois/poi_form.html
+++ b/src/cms/templates/pois/poi_form.html
@@ -263,7 +263,36 @@ document.addEventListener('DOMContentLoaded', function(){
         },
         plugins: "code paste fullscreen autosave link preview media image lists directionality",
         toolbar: 'bold italic underline forecolor | bullist numlist | styleselect | undo redo | ltr rtl notranslate removeformat | aligncenter indent outdent | link image',
-        block_formats: 'Paragraph=p; Heading 2=h2; Heading 3=h3; Heading 4=h4; Heading 5=h5; Heading 6=h6',
+        style_formats: [
+            { title: 'Headings', items: [
+                { title: 'Heading 2', format: 'h2' },
+                { title: 'Heading 3', format: 'h3' },
+                { title: 'Heading 4', format: 'h4' },
+                { title: 'Heading 5', format: 'h5' },
+                { title: 'Heading 6', format: 'h6' }
+            ]},
+            { title: 'Inline', items: [
+                { title: 'Bold', format: 'bold' },
+                { title: 'Italic', format: 'italic' },
+                { title: 'Underline', format: 'underline' },
+                { title: 'Strikethrough', format: 'strikethrough' },
+                { title: 'Superscript', format: 'superscript' },
+                { title: 'Subscript', format: 'subscript' },
+                { title: 'Code', format: 'code' }
+            ]},
+            { title: 'Blocks', items: [
+                { title: 'Paragraph', format: 'p' },
+                { title: 'Blockquote', format: 'blockquote' },
+                { title: 'Div', format: 'div' },
+                { title: 'Pre', format: 'pre' }
+            ]},
+            { title: 'Align', items: [
+                { title: 'Left', format: 'alignleft' },
+                { title: 'Center', format: 'aligncenter' },
+                { title: 'Right', format: 'alignright' },
+                { title: 'Justify', format: 'alignjustify' }
+            ]}
+        ],
         min_height: 400,
         contextmenu: "paste link",
         autosave_interval: '120s',

--- a/src/cms/templates/pois/poi_form.html
+++ b/src/cms/templates/pois/poi_form.html
@@ -263,13 +263,14 @@ document.addEventListener('DOMContentLoaded', function(){
         },
         plugins: "code paste fullscreen autosave link preview media image lists directionality",
         toolbar: 'bold italic underline forecolor | bullist numlist | styleselect | undo redo | ltr rtl notranslate removeformat | aligncenter indent outdent | link image',
+        block_formats: 'Paragraph=p; Heading 2=h2; Heading 3=h3; Heading 4=h4; Heading 5=h5; Heading 6=h6',
         min_height: 400,
         contextmenu: "paste link",
         autosave_interval: '120s',
         content_css : '{% static "css/tinymce_custom.css" %}',
         language: '{{LANGUAGE_CODE|slice:"0:2"}}',
         setup: (editor) => {
-            editor.ui.registry.addButton('notranslate', 
+            editor.ui.registry.addButton('notranslate',
             {
                 tooltip: '{% trans 'Do not translate the selected text.' %}',
                 icon: 'permanent-pen',


### PR DESCRIPTION
### Short description
This PR disables the possibility of using the Heading 1 style in TinyMCE fields for text and descriptions, throwing a validation error if the `<h1>` tags are (manually) inserted into the field's content.

### Proposed changes
First, the PR removes the possibility of selecting "Heading 1" as a style in certain TinyMCE fields by manually overriding which styles are visible in the TinyMCE styles list. The affected tinyMCE instances are in the following templates:

- `cms/templates/events/event_form.html`
- `cms/templates/pages/page_form.html`
- `cms/templates/pages/page_sbs.html`
- `cms/templates/pois/poi_form.html`

Second, the PR adds a specific `clean_<field>` method to the Django Forms being used in the aforementioned templates, that checks for the presence of `<h1>` tags in their fields and, if found, raises a validation error with an appropriate message.

The forms changed are:

- EventTranslationForm (field: description)
- PageTranslationForm (field: text)
- POITranslationForm (field: description)

These three forms are used in the templates above. This way, we prevent the use of "Heading 1" styles both in front-end and in back-end.

### Misc notes

I am not sure about the validation error message I used, which is: "Use of Heading 1 style not allowed."

Any suggestions would be accepted and changed into the Pull Request.

Also, ich spreche nicht Deutsch :-P so I wasn't able to add a properly translated string to the DE locale files. That would be a pending thing to do. If you can provide an equivalent message in Deutsch, I can add it to the proper locale file.

### Resolved issues

Fixes: #516 
