### PR TITLE
Fix translation file

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -3087,7 +3087,6 @@ msgstr ""
 #~ msgid "Create POI"
 #~ msgstr "POI erstellen"
 
-#, python-format
 #~ msgid "Create POI with title \"%(poi_query)s\""
 #~ msgstr "POI mit Titel \"%(poi_query)s\" erstellen"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
It seems that the GNU gettext tools behave slightly different on the CircleCI server compared to my local machine...
Even though I double-checked the translations locally before merging #510 via the command line into develop, the build is now failing.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Fix the failing circleci build by fixing the translation file