### PR TITLE
Improve code style tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,13 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
       - id: black
-        language_version: python3.7
+  - repo: local
+    hooks:
+      - id: translations
+        name: translations
+        description: Check if the translation file is up-to-date
+        entry: dev-tools/check_translations.sh
+        language: script
+        pass_filenames: false

--- a/dev-tools/black.sh
+++ b/dev-tools/black.sh
@@ -6,3 +6,6 @@ cd $(dirname "$BASH_SOURCE")/..
 
 # Run black
 pipenv run black .
+
+# Update translations (because changed formatting affects line numbers)
+./translate.sh

--- a/dev-tools/check_translations.sh
+++ b/dev-tools/check_translations.sh
@@ -16,9 +16,18 @@ pipenv run integreat-cms-cli makemessages -l de > /dev/null
 
 # Check for missing entries
 if ! git diff --shortstat locale/de/LC_MESSAGES/django.po | grep -q "1 file changed, 1 insertion(+), 1 deletion(-)"; then
-    echo "Your translation file is not up to date. Please run ./dev-tools/translate.sh and check if any strings need manual translation." >&2
+    echo "Your translation file is not up to date." >&2
+    # Check if script is running in CircleCI context
+    if [[ -z "$CIRCLECI" ]]; then
+        echo "Please check if any strings need manual translation." >&2
+    else
+        echo "Please run ./dev-tools/translate.sh and check if any strings need manual translation." >&2
+    fi
     exit 1
 fi
+
+# Reset the translation file if only the POT-Creation-Date changed
+git checkout -- locale/de/LC_MESSAGES/django.po
 
 # Check for empty entries
 if pcregrep -Mq 'msgstr ""\n\n' locale/de/LC_MESSAGES/django.po; then


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This adds a few enhancements for our current code style tooling.
Since black also has side-effects on line-numbers in the translation file, we should update the translations after black formatting.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Pin black pre-commit hook to same version as in Pipfile
- Add translation check pre-commit hook
- Execute translate.sh in black.sh

### Resolved Issues

Fixes: #530