### PR TITLE
Make text direction values consistent

### DIFF
--- a/src/cms/constants/text_directions.py
+++ b/src/cms/constants/text_directions.py
@@ -9,11 +9,11 @@ This module contains all constants representing the text directions of a :class:
 from django.utils.translation import ugettext_lazy as _
 
 
-LTR = "LTR"
-RTL = "RTL"
+LEFT_TO_RIGHT = "LEFT_TO_RIGHT"
+RIGHT_TO_LEFT = "RIGHT_TO_LEFT"
 
 
 CHOICES = (
-    (LTR, _("Left to right")),
-    (RTL, _("Right to left")),
+    (LEFT_TO_RIGHT, _("Left to right")),
+    (RIGHT_TO_LEFT, _("Right to left")),
 )

--- a/src/cms/fixtures/test_data.json
+++ b/src/cms/fixtures/test_data.json
@@ -81,7 +81,7 @@
       "code": "de-de",
       "english_name": "German",
       "native_name": "Deutsch",
-      "text_direction": "ltr",
+      "text_direction": "LEFT_TO_RIGHT",
       "created_date": "2019-08-12T07:50:18.139Z",
       "last_updated": "2019-08-12T07:50:18.140Z"
     }
@@ -93,7 +93,7 @@
       "code": "en-us",
       "english_name": "English",
       "native_name": "English",
-      "text_direction": "ltr",
+      "text_direction": "LEFT_TO_RIGHT",
       "created_date": "2019-08-12T07:50:24.635Z",
       "last_updated": "2019-08-12T07:50:24.636Z"
     }
@@ -105,7 +105,7 @@
       "code": "ar-ma",
       "english_name": "Arabic",
       "native_name": "العربية",
-      "text_direction": "rtl",
+      "text_direction": "RIGHT_TO_LEFT",
       "created_date": "2019-08-12T07:51:29.233Z",
       "last_updated": "2019-08-12T07:51:29.233Z"
     }
@@ -117,7 +117,7 @@
       "code": "fa-ir",
       "english_name": "Farsi",
       "native_name": "فارسی",
-      "text_direction": "rtl",
+      "text_direction": "RIGHT_TO_LEFT",
       "created_date": "2019-08-12T07:52:21.399Z",
       "last_updated": "2019-08-12T07:52:21.400Z"
     }

--- a/src/cms/models/languages/language.py
+++ b/src/cms/models/languages/language.py
@@ -35,7 +35,9 @@ class Language(models.Model):
     native_name = models.CharField(max_length=250, blank=False)
     english_name = models.CharField(max_length=250, blank=False)
     text_direction = models.CharField(
-        default=text_directions.LTR, choices=text_directions.CHOICES, max_length=3
+        default=text_directions.LEFT_TO_RIGHT,
+        choices=text_directions.CHOICES,
+        max_length=13,
     )
     created_date = models.DateTimeField(default=timezone.now)
     last_updated = models.DateTimeField(auto_now=True)

--- a/src/cms/views/pages/page_actions.py
+++ b/src/cms/views/pages/page_actions.py
@@ -203,7 +203,7 @@ def export_pdf(request, region_slug, language_code):
     template_path = "pages/page_pdf.html"
     context = {
         "html2pdf": True,
-        "right_to_left": language.text_direction == text_directions.RTL,
+        "right_to_left": language.text_direction == text_directions.RIGHT_TO_LEFT,
         "region": region,
         "pages": pages,
         "language": language,


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This makes the text direction values consistent.

### Proposed changes
<!-- Describe this PR in more detail. -->
- used the more verbose constants `LEFT_TO_RIGHT` and `RIGHT_TO_LEFT`
- changed the values in the test data

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #559
