### PR TITLE
added table_of_contents field to language model

### DIFF
--- a/src/cms/fixtures/test_data.json
+++ b/src/cms/fixtures/test_data.json
@@ -82,6 +82,7 @@
       "english_name": "German",
       "native_name": "Deutsch",
       "text_direction": "LEFT_TO_RIGHT",
+      "table_of_contents": "Inhaltsverzeichnis",
       "created_date": "2019-08-12T07:50:18.139Z",
       "last_updated": "2019-08-12T07:50:18.140Z"
     }
@@ -94,6 +95,7 @@
       "english_name": "English",
       "native_name": "English",
       "text_direction": "LEFT_TO_RIGHT",
+      "table_of_contents": "Table of Contents",
       "created_date": "2019-08-12T07:50:24.635Z",
       "last_updated": "2019-08-12T07:50:24.636Z"
     }
@@ -106,6 +108,7 @@
       "english_name": "Arabic",
       "native_name": "العربية",
       "text_direction": "RIGHT_TO_LEFT",
+      "table_of_contents": "محتويات",
       "created_date": "2019-08-12T07:51:29.233Z",
       "last_updated": "2019-08-12T07:51:29.233Z"
     }
@@ -118,6 +121,7 @@
       "english_name": "Farsi",
       "native_name": "فارسی",
       "text_direction": "RIGHT_TO_LEFT",
+      "table_of_contents": "محتویات",
       "created_date": "2019-08-12T07:52:21.399Z",
       "last_updated": "2019-08-12T07:52:21.400Z"
     }

--- a/src/cms/forms/languages/language_form.py
+++ b/src/cms/forms/languages/language_form.py
@@ -15,4 +15,5 @@ class LanguageForm(forms.ModelForm):
             "english_name",
             "native_name",
             "text_direction",
+            "table_of_contents",
         ]

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-25 00:16+0000\n"
+"POT-Creation-Date: 2020-10-29 10:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1294,6 +1294,14 @@ msgstr "Schreibrichtung"
 #: templates/languages/language_form.html:45
 msgid "Select text direction here"
 msgstr "Schreibrichtung auswählen"
+
+#: templates/languages/language_form.html:49
+msgid "PDF title"
+msgstr "PDF Titelüberschrift"
+
+#: templates/languages/language_form.html:50
+msgid "Select the native name for the PDF title here"
+msgstr "Native Bezeichnung für PDF Titelüberschrift hier eingeben"
 
 #: templates/languages/language_list.html:9
 msgid "Manage Languages"

--- a/src/cms/models/languages/language.py
+++ b/src/cms/models/languages/language.py
@@ -19,6 +19,7 @@ class Language(models.Model):
     :param text_direction: The text direction of the language (choices: :mod:`cms.constants.text_directions`)
     :param created_date: The date and time when the language was created
     :param last_updated: The date and time when the language was last updated
+    :param table_of_contents: The native name for 'Table of contents'
 
     Reverse relationships:
 
@@ -41,6 +42,7 @@ class Language(models.Model):
     )
     created_date = models.DateTimeField(default=timezone.now)
     last_updated = models.DateTimeField(auto_now=True)
+    table_of_contents = models.CharField(max_length=250, blank=False)
 
     @property
     def translated_name(self):

--- a/src/cms/templates/languages/language_form.html
+++ b/src/cms/templates/languages/language_form.html
@@ -44,6 +44,11 @@
 			    <label for="id_text_direction" class="font-bold block mb-2 cursor-pointer">{% trans 'Text direction' %}</label>
 			    {% trans 'Select text direction here' as text_direction_placeholder%}
 			    {% render_field form.text_direction placeholder=text_direction_placeholder class="appearance-none block w-full bg-gray-200 text-xl text-gray-800 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
+			</div>
+			<div class="w-full p-4 mb-4 rounded border border-solid border-gray-200 shadow bg-white">
+			    <label for="id_text_direction" class="font-bold block mb-2 cursor-pointer">{% trans 'PDF title' %}</label>
+			    {% trans 'Select the native name for the PDF title here' as table_of_contents_placeholder%}
+			    {% render_field form.table_of_contents placeholder=table_of_contents_placeholder class="appearance-none block w-full bg-gray-200 text-xl text-gray-800 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
 		    </div>
 	    </div>
     </div>

--- a/src/cms/templates/pages/page_pdf.html
+++ b/src/cms/templates/pages/page_pdf.html
@@ -17,7 +17,7 @@
 {% endif %}
 {% if amount_pages > 1 %}
     <!-- if the user selected several pages, additionally insert table of content -->
-    <h1 id="title_page">Table of Contents</h1>
+    <h1 id="title_page">{{ language.table_of_contents }}</h1>
     <!-- according to xhtml2pdf documentation all custom tags like <pdf:toc/>, <pdf:nextpage>, etc.
         should be wrapped inside block tags like <div> to avoid problems -->
     <div class="toc">


### PR DESCRIPTION

### Short description
<!-- Describe this PR in one or two sentences. -->
added table_of_contents field for language model/form

### Proposed changes
<!-- Describe this PR in more detail. -->

To print a uniform "Table of contents" header for each available
language, a new field is inserted for the language model/form and
applied to the PDF export feature.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #550
